### PR TITLE
chore(ci): 扩展 CI 到 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
           pip install -e ".[test,dev,browser]"
 
       - name: Run pyright
+        # pyright 的跨平台类型分析依赖 sys.platform narrowing，对 Windows 侧测试文件
+        # （如 tests/application/test_wechat_service_manager.py）仍会报 POSIX 符号缺失；
+        # WeChat service 本身也只支持 macOS/Linux。Windows 端类型覆盖收益有限，只在 Ubuntu 跑。
+        if: runner.os == 'Linux'
         run: pyright
 
       - name: Run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,12 @@ concurrency:
 
 jobs:
   test:
-    name: test (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12"]
 
     steps:

--- a/dayu/contracts/agent_execution.py
+++ b/dayu/contracts/agent_execution.py
@@ -581,7 +581,7 @@ def _normalize_snapshot_value(value: object) -> ExecutionContractSnapshotValue:
     if value is None or isinstance(value, str | int | float | bool):
         return value
     if isinstance(value, Path):
-        return str(value)
+        return value.as_posix()
     if isinstance(value, dict):
         return {
             str(key): _normalize_snapshot_value(item)

--- a/dayu/contracts/toolset_config.py
+++ b/dayu/contracts/toolset_config.py
@@ -163,7 +163,7 @@ def serialize_toolset_config_payload_value(value: ToolsetConfigValue) -> Toolset
     if value is None or isinstance(value, str | int | float | bool):
         return value
     if isinstance(value, Path):
-        return str(value)
+        return value.as_posix()
     if isinstance(value, list):
         return [serialize_toolset_config_payload_value(item) for item in value]
     if isinstance(value, tuple):

--- a/dayu/engine/tools/utils_tools.py
+++ b/dayu/engine/tools/utils_tools.py
@@ -79,7 +79,7 @@ def create_get_current_time_tool(registry=None) -> Tuple[str, Any, Any]:
         }
         
         return {
-            "time": now.strftime("%Y年%m月%d日 %H:%M:%S"),
+            "time": f"{now:%Y}年{now:%m}月{now:%d}日 {now:%H:%M:%S}",
             "timezone": timezone,
             "weekday": weekday_names[now.weekday()],
             "iso": now.isoformat()

--- a/dayu/file_lock.py
+++ b/dayu/file_lock.py
@@ -2,24 +2,19 @@
 
 统一封装 POSIX `fcntl.flock()` 与 Windows `msvcrt.locking()`，
 供需要跨进程互斥的模块复用。
+
+模块级 `_FCNTL` / `_MSVCRT` 作为平台后端的唯一入口，允许测试在非宿主平台
+通过 `monkeypatch.setattr` 注入 fake 后端以验证跨平台分支行为；生产运行时
+这两个变量由 `sys.platform` narrowing 初始化，保持 pyright 类型分析的精确性。
 """
 
 from __future__ import annotations
 
 import errno
 import os
+import sys
 import time
 from typing import Protocol, TextIO, cast
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - Windows 不提供 fcntl
-    fcntl = None
-
-try:
-    import msvcrt
-except ImportError:  # pragma: no cover - POSIX 不提供 msvcrt
-    msvcrt = None
 
 _WINDOWS_LOCK_RETRY_INTERVAL_SEC = 0.1
 
@@ -36,6 +31,31 @@ class _MsvcrtLockingModule(Protocol):
         ...
 
 
+class _FcntlLockingModule(Protocol):
+    """POSIX `fcntl` 锁接口的最小协议。"""
+
+    LOCK_EX: int
+    LOCK_NB: int
+    LOCK_UN: int
+
+    def flock(self, fd: int, operation: int) -> None:
+        """对文件描述符执行 flock 操作。"""
+
+        ...
+
+
+if sys.platform == "win32":
+    import msvcrt as _msvcrt_native
+
+    _FCNTL: _FcntlLockingModule | None = None
+    _MSVCRT: _MsvcrtLockingModule | None = cast(_MsvcrtLockingModule, _msvcrt_native)
+else:
+    import fcntl as _fcntl_native
+
+    _FCNTL: _FcntlLockingModule | None = cast(_FcntlLockingModule, _fcntl_native)
+    _MSVCRT: _MsvcrtLockingModule | None = None
+
+
 def ensure_lock_region(stream: TextIO, *, region_bytes: int) -> None:
     """确保锁文件存在可锁定的固定字节区间。
 
@@ -48,6 +68,7 @@ def ensure_lock_region(stream: TextIO, *, region_bytes: int) -> None:
 
     Raises:
         OSError: 当写入或同步失败时抛出。
+        ValueError: `region_bytes` 非正数时抛出。
     """
 
     if region_bytes <= 0:
@@ -101,19 +122,20 @@ def acquire_text_file_lock(
         ValueError: `region_bytes` 非法时抛出。
     """
 
-    if fcntl is not None:
-        lock_flags = fcntl.LOCK_EX
+    fcntl_backend = _FCNTL
+    if fcntl_backend is not None:
+        lock_flags = fcntl_backend.LOCK_EX
         if not blocking:
-            lock_flags |= fcntl.LOCK_NB
-        fcntl.flock(stream.fileno(), lock_flags)
+            lock_flags |= fcntl_backend.LOCK_NB
+        fcntl_backend.flock(stream.fileno(), lock_flags)
         return
-    if msvcrt is not None:
-        msvcrt_module = cast(_MsvcrtLockingModule, msvcrt)
+    msvcrt_backend = _MSVCRT
+    if msvcrt_backend is not None:
         ensure_lock_region(stream, region_bytes=region_bytes)
         while True:
             stream.seek(0)
             try:
-                msvcrt_module.locking(stream.fileno(), msvcrt_module.LK_NBLCK, region_bytes)
+                msvcrt_backend.locking(stream.fileno(), msvcrt_backend.LK_NBLCK, region_bytes)
                 return
             except OSError as exc:
                 if not blocking or not is_lock_contention_error(exc):
@@ -121,7 +143,6 @@ def acquire_text_file_lock(
                 # Windows 的 LK_LOCK 最多重试 10 次，不符合 blocking=True 的语义；
                 # 这里改为显式轮询 LK_NBLCK，直到真正拿到锁。
                 time.sleep(_WINDOWS_LOCK_RETRY_INTERVAL_SEC)
-        return
     raise OSError(f"当前平台不支持 {lock_name}")
 
 
@@ -146,12 +167,13 @@ def release_text_file_lock(
         ValueError: `region_bytes` 非法时抛出。
     """
 
-    if fcntl is not None:
-        fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+    fcntl_backend = _FCNTL
+    if fcntl_backend is not None:
+        fcntl_backend.flock(stream.fileno(), fcntl_backend.LOCK_UN)
         return
-    if msvcrt is not None:
-        msvcrt_module = cast(_MsvcrtLockingModule, msvcrt)
+    msvcrt_backend = _MSVCRT
+    if msvcrt_backend is not None:
         stream.seek(0)
-        msvcrt_module.locking(stream.fileno(), msvcrt_module.LK_UNLCK, region_bytes)
+        msvcrt_backend.locking(stream.fileno(), msvcrt_backend.LK_UNLCK, region_bytes)
         return
     raise OSError(f"当前平台不支持 {lock_name}")

--- a/dayu/fins/downloaders/sec_downloader.py
+++ b/dayu/fins/downloaders/sec_downloader.py
@@ -25,6 +25,7 @@ import json
 import os
 import posixpath
 import re
+import sys
 import time
 from dataclasses import dataclass
 from html.parser import HTMLParser
@@ -37,10 +38,8 @@ from xml.etree import ElementTree as ET
 import httpx
 from dayu.workspace_paths import build_sec_throttle_dir
 
-try:
+if sys.platform != "win32":
     import fcntl
-except ImportError:  # pragma: no cover - 当前运行环境为 Unix，此分支仅作兼容兜底
-    fcntl = None
 
 from dayu.log import Log
 from dayu.fins.domain.document_models import FileObjectMeta
@@ -601,12 +600,12 @@ def _sec_throttle_lock(lock_path: Path) -> Any:
 
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+", encoding="utf-8") as stream:
-        if fcntl is not None:
+        if sys.platform != "win32":
             fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
         try:
             yield stream
         finally:
-            if fcntl is not None:
+            if sys.platform != "win32":
                 fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
 
 

--- a/dayu/fins/storage/local_file_store.py
+++ b/dayu/fins/storage/local_file_store.py
@@ -183,7 +183,7 @@ class LocalFileStore(FileStore):
         for path in root.rglob("*"):
             if not path.is_file():
                 continue
-            key = str(path.relative_to(self._root))
+            key = path.relative_to(self._root).as_posix()
             items.append(self.stat_object(key))
         return items
 

--- a/dayu/host/concurrency.py
+++ b/dayu/host/concurrency.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from dayu.host.host_store import HostStore
 from dayu.host.protocols import ConcurrencyGovernorProtocol, ConcurrencyPermit, LaneStatus
+from dayu.process_liveness import is_pid_alive
 
 # 默认 lane 配置
 DEFAULT_LANE_CONFIG: dict[str, int] = {
@@ -28,25 +29,6 @@ def _now_utc() -> datetime:
     """返回当前 UTC 时间。"""
 
     return datetime.now(timezone.utc)
-
-
-def _is_pid_alive(pid: int) -> bool:
-    """检查 PID 对应的进程是否存活。
-
-    Args:
-        pid: 目标进程 ID。
-
-    Returns:
-        True 如果进程存活。
-    """
-
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
 
 
 class SQLiteConcurrencyGovernor(ConcurrencyGovernorProtocol):
@@ -170,7 +152,7 @@ class SQLiteConcurrencyGovernor(ConcurrencyGovernorProtocol):
 
         stale_ids: list[str] = []
         for row in rows:
-            if not _is_pid_alive(row["owner_pid"]):
+            if not is_pid_alive(row["owner_pid"]):
                 stale_ids.append(row["permit_id"])
 
         if stale_ids:

--- a/dayu/host/prepared_turn.py
+++ b/dayu/host/prepared_turn.py
@@ -215,7 +215,7 @@ def _normalize_snapshot_value(value: object) -> PendingTurnSnapshotValue:
     if value is None or isinstance(value, str | int | float | bool):
         return value
     if isinstance(value, Path):
-        return str(value)
+        return value.as_posix()
     if isinstance(value, dict):
         return {
             str(key): _normalize_snapshot_value(item)

--- a/dayu/host/run_registry.py
+++ b/dayu/host/run_registry.py
@@ -15,6 +15,7 @@ from dayu.host.host_store import HostStore
 from dayu.host.protocols import RunRegistryProtocol
 from dayu.contracts.run import ACTIVE_STATES, RunCancelReason, RunRecord, RunState, is_valid_transition
 from dayu.log import Log
+from dayu.process_liveness import is_pid_alive
 
 MODULE = "HOST.RUN_REGISTRY"
 
@@ -71,26 +72,6 @@ def _row_to_record(row: dict[str, Any]) -> RunRecord:
         owner_pid=row["owner_pid"],
         metadata=metadata,
     )
-
-
-def _is_pid_alive(pid: int) -> bool:
-    """检查 PID 对应的进程是否存活。
-
-    Args:
-        pid: 目标进程 ID。
-
-    Returns:
-        True 如果进程存活。
-    """
-
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        # 进程存在但无权限发信号
-        return True
-    return True
 
 
 class SQLiteRunRegistry(RunRegistryProtocol):
@@ -300,7 +281,7 @@ class SQLiteRunRegistry(RunRegistryProtocol):
         active_runs = self.list_active_runs()
         orphan_ids: list[str] = []
         for run in active_runs:
-            if not _is_pid_alive(run.owner_pid):
+            if not is_pid_alive(run.owner_pid):
                 orphan_ids.append(run.run_id)
 
         if orphan_ids:

--- a/dayu/process_liveness.py
+++ b/dayu/process_liveness.py
@@ -1,0 +1,112 @@
+"""跨平台进程判活辅助。
+
+`os.kill(pid, 0)` 仅在 POSIX 上是一个「发送 0 号信号」的存在性探测；
+在 Windows 上 CPython 将 signal=0 路由到 `TerminateProcess`，无法用于判活，
+对不存在的 PID 也不会稳定抛出 `ProcessLookupError`，可能阻塞或误判。
+
+本模块把两类平台都收敛到 `is_pid_alive` 一个入口：
+
+- POSIX：沿用 `os.kill(pid, 0)` 的 `ProcessLookupError` / `PermissionError` 语义。
+- Windows：通过 `ctypes` 调用 `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)`
+  + `GetExitCodeProcess`，根据 `STILL_ACTIVE` 判定存活；`ACCESS_DENIED` 视为存在。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Windows Win32 API 常量
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_STILL_ACTIVE = 259
+_ERROR_ACCESS_DENIED = 5
+_ERROR_INVALID_PARAMETER = 87
+
+
+def _is_pid_alive_posix(pid: int) -> bool:
+    """POSIX 平台下基于 `os.kill(pid, 0)` 的存在性探测。
+
+    Args:
+        pid: 目标进程 ID。
+
+    Returns:
+        `True` 表示进程存活；`False` 表示进程已退出。
+
+    Raises:
+        OSError: 底层非预期错误原样抛出。
+    """
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # 进程存在但无权限发信号。
+        return True
+    return True
+
+
+if sys.platform == "win32":
+    import ctypes
+    from ctypes import wintypes
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    _kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+    def _is_pid_alive_windows(pid: int) -> bool:
+        """Windows 平台下基于 Win32 `OpenProcess` + `GetExitCodeProcess` 的存活判定。
+
+        Args:
+            pid: 目标进程 ID。
+
+        Returns:
+            `True` 表示进程仍在运行；`False` 表示 PID 不存在或进程已退出。
+
+        Raises:
+            OSError: 底层 Win32 调用发生非预期错误时抛出。
+        """
+
+        handle = _kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            last_error = ctypes.get_last_error()
+            if last_error == _ERROR_INVALID_PARAMETER:
+                # 对应不存在或已回收的 PID。
+                return False
+            if last_error == _ERROR_ACCESS_DENIED:
+                # 进程存在但当前令牌无权限查询。
+                return True
+            raise OSError(last_error, f"OpenProcess 失败：winerror={last_error}")
+        try:
+            exit_code = wintypes.DWORD()
+            if not _kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                last_error = ctypes.get_last_error()
+                raise OSError(last_error, f"GetExitCodeProcess 失败：winerror={last_error}")
+            return exit_code.value == _STILL_ACTIVE
+        finally:
+            _kernel32.CloseHandle(handle)
+
+
+def is_pid_alive(pid: int) -> bool:
+    """跨平台判断指定 PID 对应的进程是否存活。
+
+    Args:
+        pid: 目标进程 ID。
+
+    Returns:
+        `True` 表示进程仍在运行；`False` 表示进程已退出或 PID 不存在。
+
+    Raises:
+        OSError: 底层系统调用发生非预期错误时抛出。
+    """
+
+    if sys.platform == "win32":
+        return _is_pid_alive_windows(pid)
+    return _is_pid_alive_posix(pid)
+
+
+__all__ = ["is_pid_alive"]

--- a/dayu/services/internal/write_pipeline/artifact_store.py
+++ b/dayu/services/internal/write_pipeline/artifact_store.py
@@ -189,6 +189,50 @@ def _manifest_file_lock(output_dir: Path) -> Iterator[TextIO]:
             _release_manifest_stream_lock(stream)
 
 
+# 章节 write 阶段产物文件名形如 `{idx}_{slug}.{stage}_write.md`；
+# 这里给每个 stage 指定单调递增的优先级，后面补上阶段重试序号作为次序键，
+# 保证排序语义只依赖文件名本身，不被跨平台 mtime 粒度（Windows NTFS 可能 ~15ms）干扰。
+_CHAPTER_WRITE_STAGE_ORDER: dict[str, int] = {
+    "initial": 0,
+    "initial_fix_placeholders": 1,
+    "repair": 2,
+    "regenerate": 3,
+}
+_CHAPTER_WRITE_STAGE_PATTERN = re.compile(
+    r"^(?P<stage>initial_fix_placeholders|initial|repair|regenerate)(?:_(?P<retry>\d+))?_write$"
+)
+
+
+def _chapter_write_artifact_sort_key(path: Path) -> tuple[int, int, int, str]:
+    """按轮次 → 阶段优先级为 write 中间稿排序。
+
+    轮次（retry）是时间主轴，阶段（stage）仅在同一轮次内决定先后。
+    这样跨轮次切换策略（如先 regenerate 再 repair）时，较新轮次的产物
+    始终排在较旧轮次之后，避免回退到更旧中间稿。
+
+    Args:
+        path: 形如 ``{idx}_{slug}.{stage}[_{retry}]_write.md`` 的 write 产物路径。
+
+    Returns:
+        `(retry, stage_order, 0, full_stem)` 四元组；未知格式退化到
+        `(-1, -1, 0, stem)` 排到最前。
+
+    Raises:
+        无。
+    """
+
+    stem_parts = path.stem.split(".", 1)
+    if len(stem_parts) != 2:
+        return (-1, -1, 0, path.stem)
+    stage_token = stem_parts[1]
+    match = _CHAPTER_WRITE_STAGE_PATTERN.match(stage_token)
+    if match is None:
+        return (-1, -1, 0, path.stem)
+    stage = match.group("stage")
+    retry = int(match.group("retry") or 0)
+    return (retry, _CHAPTER_WRITE_STAGE_ORDER[stage], 0, path.stem)
+
+
 def _slugify_title(title: str) -> str:
     """将章节标题转为文件名 slug。
 
@@ -683,7 +727,7 @@ class ArtifactStore:
         slug = _slugify_title(task.title)
         candidates = sorted(
             chapter_dir.glob(f"{display_index:02d}_{slug}.*_write.md"),
-            key=lambda path: path.stat().st_mtime,
+            key=_chapter_write_artifact_sort_key,
             reverse=True,
         )
         for candidate in candidates:

--- a/dayu/services/prompt_contributions.py
+++ b/dayu/services/prompt_contributions.py
@@ -53,7 +53,7 @@ def build_base_user_contribution(*, now: datetime | None = None) -> str:
     return "\n".join(
         [
             "# 用户与运行时上下文",
-            f"当前时间：{current.strftime('%Y年%m月%d日')}。",
+            f"当前时间：{current:%Y}年{current:%m}月{current:%d}日。",
         ]
     )
 

--- a/dayu/wechat/service_manager.py
+++ b/dayu/wechat/service_manager.py
@@ -17,6 +17,7 @@ import plistlib
 import re
 import shlex
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -1250,9 +1251,11 @@ def _build_launchctl_domain_target() -> str:
         launchctl domain target。
 
     Raises:
-        无。
+        RuntimeError: 在不支持 launchctl 的平台上调用时抛出。
     """
 
+    if sys.platform == "win32":
+        raise RuntimeError("launchctl 仅在 macOS 上可用")
     return f"gui/{os.getuid()}"
 
 

--- a/tests/application/test_wechat_daemon.py
+++ b/tests/application/test_wechat_daemon.py
@@ -1166,7 +1166,10 @@ def test_process_once_sends_typing_best_effort(tmp_path: Path) -> None:
         scripted_turns=[
             _ScriptedTurn(
                 events=(AppEvent(type=AppEventType.FINAL_ANSWER, payload={"content": "答复"}, meta={}),),
-                delay_sec=0.02,
+                # Windows ProactorEventLoop 的 timer 粒度约 15ms；
+                # 这里把 scripted turn 的 delay 拉高到 0.2s，保证 typing task 有机会至少跑一次，
+                # 不再依赖 macOS/Linux 上更细的 scheduling 粒度。
+                delay_sec=0.2,
             )
         ]
     )

--- a/tests/application/test_wechat_daemon.py
+++ b/tests/application/test_wechat_daemon.py
@@ -1130,8 +1130,8 @@ def test_single_instance_lock_uses_msvcrt_when_fcntl_unavailable(
             self.calls.append((mode, size))
 
     fake_msvcrt = _FakeMsvcrt()
-    monkeypatch.setattr(state_dir_lock_module.file_lock_module, "fcntl", None)
-    monkeypatch.setattr(state_dir_lock_module.file_lock_module, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(state_dir_lock_module.file_lock_module, "_FCNTL", None)
+    monkeypatch.setattr(state_dir_lock_module.file_lock_module, "_MSVCRT", fake_msvcrt)
 
     lock_path = tmp_path / ".wechat" / ".daemon.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/application/test_wechat_service_manager.py
+++ b/tests/application/test_wechat_service_manager.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import plistlib
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
 from dayu.wechat import service_manager
+
+# WeChat service 仅支持 macOS (launchd) 与 Linux (systemd)；Windows 上 service_manager
+# 依赖 os.getuid() 等 POSIX 专属 API，不参与运行或测试。
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="WeChat service 不支持 Windows")
 
 
 @pytest.mark.unit

--- a/tests/engine/test_write_pipeline.py
+++ b/tests/engine/test_write_pipeline.py
@@ -4640,8 +4640,8 @@ def test_manifest_file_lock_uses_msvcrt_when_fcntl_unavailable(
             self.calls.append((mode, size))
 
     fake_msvcrt = _FakeMsvcrt()
-    monkeypatch.setattr(artifact_store_module.file_lock_module, "fcntl", None)
-    monkeypatch.setattr(artifact_store_module.file_lock_module, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(artifact_store_module.file_lock_module, "_FCNTL", None)
+    monkeypatch.setattr(artifact_store_module.file_lock_module, "_MSVCRT", fake_msvcrt)
 
     output_dir = tmp_path / "out"
     with artifact_store_module._manifest_file_lock(output_dir):
@@ -4689,8 +4689,8 @@ def test_manifest_file_lock_retries_until_windows_lock_is_available(
 
     fake_msvcrt = _RetryingMsvcrt()
     sleep_calls: list[float] = []
-    monkeypatch.setattr(artifact_store_module.file_lock_module, "fcntl", None)
-    monkeypatch.setattr(artifact_store_module.file_lock_module, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(artifact_store_module.file_lock_module, "_FCNTL", None)
+    monkeypatch.setattr(artifact_store_module.file_lock_module, "_MSVCRT", fake_msvcrt)
     monkeypatch.setattr(artifact_store_module.file_lock_module.time, "sleep", sleep_calls.append)
 
     with artifact_store_module._manifest_file_lock(tmp_path / "out"):
@@ -4715,8 +4715,8 @@ def test_manifest_file_lock_raises_when_no_platform_lock_backend(
 ) -> None:
     """验证没有任何平台锁实现时会显式失败，而不是静默放过。"""
 
-    monkeypatch.setattr(artifact_store_module.file_lock_module, "fcntl", None)
-    monkeypatch.setattr(artifact_store_module.file_lock_module, "msvcrt", None)
+    monkeypatch.setattr(artifact_store_module.file_lock_module, "_FCNTL", None)
+    monkeypatch.setattr(artifact_store_module.file_lock_module, "_MSVCRT", None)
 
     with pytest.raises(OSError, match="当前平台不支持 manifest 文件锁"):
         with artifact_store_module._manifest_file_lock(tmp_path / "out"):

--- a/tests/fins/test_storage_batch_recovery.py
+++ b/tests/fins/test_storage_batch_recovery.py
@@ -611,8 +611,8 @@ def test_fins_batch_lock_uses_msvcrt_when_fcntl_unavailable(
 
     core = build_fs_storage_test_context(tmp_path).core
     fake_msvcrt = _FakeMsvcrt()
-    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "fcntl", None)
-    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "_FCNTL", None)
+    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "_MSVCRT", fake_msvcrt)
     fake_msvcrt.calls.clear()
     stream = core._open_and_lock_stream(tmp_path / ".dayu" / "batch_locks" / "AAPL.lock", blocking=False)
     try:
@@ -656,8 +656,8 @@ def test_recovery_lock_retries_until_windows_lock_is_available(
     core = build_fs_storage_test_context(tmp_path).core
     fake_msvcrt = _RetryingMsvcrt()
     sleep_calls: list[float] = []
-    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "fcntl", None)
-    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "_FCNTL", None)
+    monkeypatch.setattr(fs_storage_infra_module.file_lock_module, "_MSVCRT", fake_msvcrt)
     monkeypatch.setattr(fs_storage_infra_module.file_lock_module.time, "sleep", sleep_calls.append)
 
     stream = core._acquire_recovery_lock()

--- a/tests/test_process_liveness.py
+++ b/tests/test_process_liveness.py
@@ -1,0 +1,130 @@
+"""测试跨平台进程判活 `dayu.process_liveness.is_pid_alive`。
+
+设计原则：
+- 唯一的「真实进程」用例是当前进程判活，因为 `os.getpid()` 必然对应当前运行的 Python 进程，
+  任何 OS/CI 环境都能给出确定结果。
+- 其余分支（PID 不存在、权限被拒、Win32 错误码等）全部通过 monkeypatch 直接桩住
+  `os.kill` 或 Win32 `OpenProcess` 返回值，不依赖任何「某个 PID 当前空闲」或
+  「子进程 PID 不会被立刻回收」这类与 OS 调度相关的不确定性。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from dayu import process_liveness as liveness_module
+from dayu.process_liveness import is_pid_alive
+
+_POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX 分支专用")
+_WINDOWS_ONLY = pytest.mark.skipif(sys.platform != "win32", reason="Windows 分支专用")
+
+
+@pytest.mark.unit
+def test_is_pid_alive_returns_true_for_current_process() -> None:
+    """当前进程的 PID 一定被判为存活。"""
+
+    assert is_pid_alive(os.getpid()) is True
+
+
+@pytest.mark.unit
+@_POSIX_ONLY
+def test_posix_branch_returns_false_on_process_lookup_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POSIX 下 `os.kill` 抛 `ProcessLookupError` 时判定为已退出。"""
+
+    def _raise_lookup(pid: int, sig: int) -> None:
+        del pid, sig
+        raise ProcessLookupError
+
+    monkeypatch.setattr(liveness_module.os, "kill", _raise_lookup)
+    assert liveness_module._is_pid_alive_posix(12345) is False
+
+
+@pytest.mark.unit
+@_POSIX_ONLY
+def test_posix_branch_returns_true_on_permission_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POSIX 下 `os.kill` 抛 `PermissionError` 表示目标存在、仅无权限发信号。"""
+
+    def _raise_permission(pid: int, sig: int) -> None:
+        del pid, sig
+        raise PermissionError
+
+    monkeypatch.setattr(liveness_module.os, "kill", _raise_permission)
+    assert liveness_module._is_pid_alive_posix(12345) is True
+
+
+@pytest.mark.unit
+@_POSIX_ONLY
+def test_posix_branch_returns_true_when_kill_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POSIX 下 `os.kill(pid, 0)` 正常返回即表示目标进程存活。"""
+
+    def _noop(pid: int, sig: int) -> None:
+        del pid, sig
+
+    monkeypatch.setattr(liveness_module.os, "kill", _noop)
+    assert liveness_module._is_pid_alive_posix(12345) is True
+
+
+@pytest.mark.unit
+@_WINDOWS_ONLY
+def test_windows_branch_returns_false_for_invalid_pid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows 下 `OpenProcess` 失败且 last error 为 INVALID_PARAMETER 时判定为不存在。"""
+
+    import ctypes
+
+    set_last_error = getattr(ctypes, "set_last_error")
+    kernel32 = getattr(liveness_module, "_kernel32")
+    is_alive_windows = getattr(liveness_module, "_is_pid_alive_windows")
+
+    def _fake_open_process(access: int, inherit: bool, pid: int) -> int:
+        del access, inherit, pid
+        set_last_error(liveness_module._ERROR_INVALID_PARAMETER)
+        return 0
+
+    monkeypatch.setattr(kernel32, "OpenProcess", _fake_open_process)
+    assert is_alive_windows(999999) is False
+
+
+@pytest.mark.unit
+@_WINDOWS_ONLY
+def test_windows_branch_returns_true_for_access_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows 下 `OpenProcess` 失败且 last error 为 ACCESS_DENIED 时表示目标存在。"""
+
+    import ctypes
+
+    set_last_error = getattr(ctypes, "set_last_error")
+    kernel32 = getattr(liveness_module, "_kernel32")
+    is_alive_windows = getattr(liveness_module, "_is_pid_alive_windows")
+
+    def _fake_open_process(access: int, inherit: bool, pid: int) -> int:
+        del access, inherit, pid
+        set_last_error(liveness_module._ERROR_ACCESS_DENIED)
+        return 0
+
+    monkeypatch.setattr(kernel32, "OpenProcess", _fake_open_process)
+    assert is_alive_windows(12345) is True
+
+
+@pytest.mark.unit
+@_WINDOWS_ONLY
+def test_windows_branch_raises_on_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows 下 `OpenProcess` 出现未预期的 winerror 时必须外抛 OSError。"""
+
+    import ctypes
+
+    set_last_error = getattr(ctypes, "set_last_error")
+    kernel32 = getattr(liveness_module, "_kernel32")
+    is_alive_windows = getattr(liveness_module, "_is_pid_alive_windows")
+
+    _UNEXPECTED_WINERROR = 1234
+
+    def _fake_open_process(access: int, inherit: bool, pid: int) -> int:
+        del access, inherit, pid
+        set_last_error(_UNEXPECTED_WINERROR)
+        return 0
+
+    monkeypatch.setattr(kernel32, "OpenProcess", _fake_open_process)
+    with pytest.raises(OSError):
+        is_alive_windows(12345)


### PR DESCRIPTION
## Summary

Matrix 扩展为 `[ubuntu-latest, windows-latest] × [3.11, 3.12]`，共 4 个 job。

## 目的

- 证明 \`pip install -e \".[test,dev,browser]\"\` 在 Windows 上可走通。
- 为 Windows 用户使用 dayu-agent 提供最低持续保障。
- 当前除 macOS（开发者日常环境）、Linux（v0.1.0 时 CI 已覆盖）外，Windows 是最后一块未覆盖的平台。

## Test plan

- [ ] 4 个 job 全部绿：ubuntu × py3.11 / ubuntu × py3.12 / windows × py3.11 / windows × py3.12
- [ ] 若 Windows job 失败，根据日志决定：在 README 声明 Windows 未验证，还是单独修 Windows 兼容问题