### PR TITLE
feat: 支持自定义OpenAI兼容来源API（如OpenRouter）

### DIFF
--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -56,6 +56,10 @@ _PROVIDER_OPTION_OPENAI = "openai"
 _PROVIDER_OPTION_ANTHROPIC = "anthropic"
 _PROVIDER_OPTION_GEMINI = "gemini"
 _PROVIDER_OPTION_QWEN = "qwen"
+_PROVIDER_OPTION_CUSTOM_OPENAI = "custom_openai"
+
+# 自定义 OpenAI 兼容 API（OpenRouter 等）统一使用的目录键
+_CUSTOM_CATALOG_KEY = "custom-openai"
 
 _PROVIDER_OPTIONS: tuple[_ProviderOption, ...] = (
     _ProviderOption(
@@ -120,6 +124,13 @@ _PROVIDER_OPTIONS: tuple[_ProviderOption, ...] = (
         api_key_name="QWEN_API_KEY",
         non_thinking_model="qwen3",
         thinking_model="qwen3-thinking",
+    ),
+    _ProviderOption(
+        option_key=_PROVIDER_OPTION_CUSTOM_OPENAI,
+        display_name="自定义 OpenAI 兼容 API（OpenRouter 等）",
+        api_key_name="CUSTOM_OPENAI_API_KEY",
+        non_thinking_model=_CUSTOM_CATALOG_KEY,
+        thinking_model=_CUSTOM_CATALOG_KEY,
     ),
 )
 
@@ -546,6 +557,12 @@ def _update_manifest_default_models(
         new_name = role_to_model[role]
         changed = new_name != current or stored_role != role
 
+        allowed = model_section.get("allowed_names")
+        if isinstance(allowed, list) and new_name not in allowed:
+            allowed.append(new_name)
+            model_section["allowed_names"] = allowed
+            changed = True
+
         if changed:
             model_section["default_name"] = new_name
             model_section[_INIT_ROLE_KEY] = role
@@ -636,6 +653,145 @@ def _prompt_api_key(api_key_name: str) -> str:
         sys.exit(1)
 
     return value
+
+
+@dataclass(frozen=True)
+class _CustomOpenAIConfig:
+    """用户自定义 OpenAI 兼容 API 的参数。"""
+
+    base_url: str
+    api_key_env: str
+    api_key_value: str
+    model_id: str
+
+
+def _prompt_custom_openai_config() -> _CustomOpenAIConfig:
+    """交互式收集自定义 OpenAI 兼容 API 参数。
+
+    收集 base URL、API Key 值，以及单个模型 ID；thinking / 非 thinking
+    两个角色共享该模型。
+
+    Returns:
+        已收集完毕的 `_CustomOpenAIConfig`。
+
+    Raises:
+        SystemExit: 用户中断或必填项为空。
+    """
+
+    print("\n— 自定义 OpenAI 兼容 API 配置 —")
+    print("  示例: OpenRouter 的 base URL 为 https://openrouter.ai/api/v1")
+    try:
+        base_url = input("  Base URL（如 https://openrouter.ai/api/v1）: ").strip()
+        if not base_url:
+            print("错误: Base URL 不能为空")
+            sys.exit(1)
+        base_url = base_url.rstrip("/")
+
+        api_key_env = "CUSTOM_OPENAI_API_KEY"
+        existing_value = os.environ.get(api_key_env, "")
+        if existing_value:
+            masked = existing_value[:4] + "***" + existing_value[-4:] if len(existing_value) > 8 else "***"
+            print(f"  {api_key_env} 已在环境变量中配置（{masked}），将复用该值。")
+            api_key_value = existing_value
+        else:
+            api_key_value = input(f"  请输入 {api_key_env}: ").strip()
+            if not api_key_value:
+                print(f"错误: {api_key_env} 不能为空")
+                sys.exit(1)
+
+        print("  请填写模型 ID（OpenRouter 示例：openai/gpt-4o、anthropic/claude-sonnet-4）")
+        model_id = input("  模型 ID: ").strip()
+        if not model_id:
+            print("错误: 模型 ID 不能为空")
+            sys.exit(1)
+    except (EOFError, KeyboardInterrupt):
+        print()
+        sys.exit(1)
+
+    return _CustomOpenAIConfig(
+        base_url=base_url,
+        api_key_env=api_key_env,
+        api_key_value=api_key_value,
+        model_id=model_id,
+    )
+
+
+def _write_custom_openai_catalog_entries(
+    config_dir: Path, custom: _CustomOpenAIConfig
+) -> None:
+    """将自定义 API 的两个条目写入工作区 ``llm_models.json``。
+
+    使用固定的目录键 `_CUSTOM_CATALOG_NON_THINKING` / `_CUSTOM_CATALOG_THINKING`，
+    覆盖式写入以保证 init 可重复执行。
+
+    Args:
+        config_dir: 工作区配置目录。
+        custom: 用户填写的自定义 API 参数。
+
+    Raises:
+        OSError: 文件读写失败时抛出。
+    """
+
+    catalog_path = config_dir / "llm_models.json"
+    data: dict[str, object] = {}
+    if catalog_path.exists():
+        text = catalog_path.read_text(encoding="utf-8")
+        if text.strip():
+            data = json.loads(text)
+
+    endpoint_url = f"{custom.base_url}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {{{{{custom.api_key_env}}}}}",
+        "Content-Type": "application/json",
+    }
+
+    runtime_hints = {
+        "temperature_profiles": {
+            "write": {"temperature": 1.0},
+            "overview": {"temperature": 1.0},
+            "audit": {"temperature": 0.8},
+            "decision": {"temperature": 1.0},
+            "interactive": {"temperature": 1.0},
+            "prompt": {"temperature": 1.0},
+            "infer": {"temperature": 0.5},
+            "conversation_compaction": {"temperature": 0.4},
+        },
+        "conversation_memory": {
+            "episodic_memory_token_budget_floor": 4000,
+            "episodic_memory_token_budget_cap": 4000,
+        },
+    }
+
+    def _entry(catalog_key: str, model_id: str, description: str) -> dict[str, object]:
+        return {
+            "runner_type": "openai_compatible",
+            "name": catalog_key,
+            "endpoint_url": endpoint_url,
+            "model": model_id,
+            "headers": headers,
+            "timeout": 3600,
+            "stream_idle_timeout": 120.0,
+            "stream_idle_heartbeat_sec": 10.0,
+            "supports_stream": True,
+            "supports_tool_calling": True,
+            "supports_usage": True,
+            "supports_stream_usage": True,
+            "max_context_tokens": 131072,
+            "max_output_tokens": 8192,
+            "extra_payloads": {},
+            "description": description,
+            "runtime_hints": runtime_hints,
+        }
+
+    data[_CUSTOM_CATALOG_KEY] = _entry(
+        _CUSTOM_CATALOG_KEY,
+        custom.model_id,
+        f"自定义 OpenAI 兼容 API（{custom.base_url}）",
+    )
+
+    catalog_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
 
 
 def _prompt_optional_search_keys() -> list[tuple[str, str]]:
@@ -833,26 +989,44 @@ def run_init_command(args: Namespace) -> int:
     env_vars_written = False
     main_key_persist_failed = False
 
-    existing_value = os.environ.get(chosen_option.api_key_name)
-    if existing_value:
-        masked = existing_value[:4] + "***" + existing_value[-4:] if len(existing_value) > 8 else "***"
-        print(f"\n✓ {chosen_option.api_key_name} 已在环境变量中配置（{masked}），跳过写入。")
+    if chosen_option_key == _PROVIDER_OPTION_CUSTOM_OPENAI:
+        custom = _prompt_custom_openai_config()
+        effective_api_key_name = custom.api_key_env
+        _write_custom_openai_catalog_entries(config_dir, custom)
+        print(f"✓ 已写入自定义模型条目到 {config_dir / 'llm_models.json'}")
+        if os.environ.get(custom.api_key_env) == custom.api_key_value:
+            print(f"\n✓ {custom.api_key_env} 已在环境变量中配置，跳过写入。")
+        else:
+            _target, ok = _persist_env_var(custom.api_key_env, custom.api_key_value)
+            env_vars_written = True
+            if not ok:
+                main_key_persist_failed = True
+                print(f"\n❌ {custom.api_key_env} 无法持久化到系统环境变量。")
+                print(f"   已为当前进程设置，但重开终端后会丢失。")
+                print(f"   为避免切换模型后下次启动找不到 API Key，跳过 manifest 更新。")
+                print(f"   请手动配置环境变量后重新运行 dayu-cli init。")
     else:
-        api_key_value = _prompt_api_key(chosen_option.api_key_name)
-        _target, ok = _persist_env_var(chosen_option.api_key_name, api_key_value)
-        env_vars_written = True
-        if not ok:
-            main_key_persist_failed = True
-            print(f"\n❌ {chosen_option.api_key_name} 无法持久化到系统环境变量。")
-            print(f"   已为当前进程设置，但重开终端后会丢失。")
-            print(f"   为避免切换模型后下次启动找不到 API Key，跳过 manifest 更新。")
-            print(f"   请手动配置环境变量后重新运行 dayu-cli init。")
+        effective_api_key_name = chosen_option.api_key_name
+        existing_value = os.environ.get(chosen_option.api_key_name)
+        if existing_value:
+            masked = existing_value[:4] + "***" + existing_value[-4:] if len(existing_value) > 8 else "***"
+            print(f"\n✓ {chosen_option.api_key_name} 已在环境变量中配置（{masked}），跳过写入。")
+        else:
+            api_key_value = _prompt_api_key(chosen_option.api_key_name)
+            _target, ok = _persist_env_var(chosen_option.api_key_name, api_key_value)
+            env_vars_written = True
+            if not ok:
+                main_key_persist_failed = True
+                print(f"\n❌ {chosen_option.api_key_name} 无法持久化到系统环境变量。")
+                print(f"   已为当前进程设置，但重开终端后会丢失。")
+                print(f"   为避免切换模型后下次启动找不到 API Key，跳过 manifest 更新。")
+                print(f"   请手动配置环境变量后重新运行 dayu-cli init。")
 
     # 3. 更新 manifest 默认模型（仅在主 key 持久化成功或已存在时执行）
     non_thinking = chosen_option.non_thinking_model
     thinking = chosen_option.thinking_model
     if main_key_persist_failed:
-        print(f"\n⚠️  跳过 manifest 更新（{chosen_option.api_key_name} 未持久化）")
+        print(f"\n⚠️  跳过 manifest 更新（{effective_api_key_name} 未持久化）")
     else:
         updated_count = _update_manifest_default_models(config_dir, non_thinking, thinking)
         print(f"✓ 默认模型已设置为: {non_thinking} / {thinking}（更新了 {updated_count} 个 manifest）")


### PR DESCRIPTION
## feat: 支持自定义OpenAI兼容来源API（如OpenRouter）

### 动机

目前 `dayu-cli init` 只支持预定义的模型供应商（Mimo/DeepSeek/OpenAI/Anthropic/Gemini/Qwen）。用户如果使用 OpenRouter、Together AI、Groq 等 OpenAI 兼容的第三方 API 聚合服务，无法通过 init 流程完成配置，需要手动编辑 `llm_models.json` 和 manifest 文件，门槛较高。

### 改动内容

**`dayu/cli/commands/init.py`**

1. **新增 Provider 选项** `_PROVIDER_OPTION_CUSTOM_OPENAI`（显示名「自定义 OpenAI 兼容 API（OpenRouter 等）」），使用固定目录键 `custom-openai`。thinking / 非 thinking 两个角色共享同一模型。

2. **新增 `_CustomOpenAIConfig` 数据类 + `_prompt_custom_openai_config()`**：交互式收集三项必填信息：
   - Base URL（如 `https://openrouter.ai/api/v1`）
   - API Key（环境变量名固定为 `CUSTOM_OPENAI_API_KEY`，与其他选项行为一致）
   - 模型 ID（如 `openai/gpt-4o`、`anthropic/claude-sonnet-4`）

3. **新增 `_write_custom_openai_catalog_entries()`**：将 `custom-openai` 条目覆盖式写入工作区 `config/llm_models.json`，包含：
   - `endpoint_url`：`{base_url}/chat/completions`
   - `headers`：`Authorization: Bearer {{CUSTOM_OPENAI_API_KEY}}`
   - 完整 `runtime_hints`（覆盖所有 scene 的 temperature_profiles + conversation_memory 默认配置）

4. **`_update_manifest_default_models()` 增强**：设置 `default_name` 时自动将其追加到 `allowed_names` 列表，避免 manifest 校验报错。

5. **`run_init_command()` 分支处理**：选中自定义选项时走专用流程（收集配置 → 写 catalog → 持久化环境变量 → 复用现有 manifest 替换逻辑）。

### 使用方式

```bash
dayu-cli init --base ./workspace
# 选择最后一项「自定义 OpenAI 兼容 API（OpenRouter 等）」
# 输入 Base URL、API Key、模型 ID
```

### 验证

- `ast.parse` 语法校验通过
- 实测 `init --overwrite` → `prompt` 流程可正常解析 manifest 和 catalog 条目