### PR TITLE
feat: streamlit 实现web服务的基础框架，包含自选股管理，及页面导航

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ playwright install chromium
 
 ```bash
 dayu-cli --help
+dayu-web --help
 dayu-wechat --help
 dayu-render --help
 ```
@@ -269,7 +270,27 @@ dayu-cli <subcommand> [参数]
 - 宿主管理命令同样支持 `--base` / `--config` / 日志参数；例如 `dayu-cli host --base ./workspace status`、`dayu-cli sessions --base ./workspace --source cli --scene interactive`、`dayu-cli conv --base ./workspace list`。
 - `interactive` 默认会续接本地绑定的同一个多轮会话；如果上一次回答还没完整回显到终端，重启 CLI 会先把那次回答补完，再进入新的输入循环。
 
-### 2.2 WeChat 入口
+### 2.2 Web 入口（Streamlit）
+
+基于 Streamlit 的 Web UI：
+
+```bash
+dayu-web
+```
+
+也可以用模块入口启动（等价）：
+
+```bash
+python -m dayu.web
+```
+
+默认使用 `./workspace` 作为工作区
+
+启动后，默认打开 Local URL: http://localhost:8501 （如果 8501 端口被占用将按尝试其他端口）
+
+功能说明：详见[dayu/web/README.md](dayu/web/README.md)
+
+### 2.3 WeChat 入口
 
 统一入口：
 

--- a/dayu/web/README.md
+++ b/dayu/web/README.md
@@ -1,0 +1,34 @@
+## `dayu.web` 开发说明
+
+本文档说明 `dayu.web` 下 Web 适配层的当前实现边界，重点说明 Streamlit 模块。
+
+## 1. 模块定位
+
+- `dayu.web` 是 UI 适配层，负责把宿主入口请求转成 `Service` 调用，并把结果渲染给用户。
+- 当前 Web 有两条并行入口：
+  - Streamlit UI：`dayu/web/streamlit_app.py`（用户交互主入口），为用户提供本地访问的 Web 页面
+  - FastAPI：`dayu/web/fastapi_app.py`（HTTP API 入口）,为独立的 Web 服务提供 API 接口。
+- 设计基线保持稳定分层：`UI -> Service -> Host -> Agent`。
+
+细分职责如下：
+
+| 入口文件 | 目标对象 | 主要职责 | 不负责 |
+| --- | --- | --- | --- |
+| `dayu/web/streamlit_app.py` | 人工交互用户（浏览器页面） | 页面级 UI 交互、会话状态管理（`st.session_state`）、页面路由与本地文件预览入口装配 | 对外 HTTP API 契约、路由 schema 设计 |
+| `dayu/web/fastapi_app.py` | 程序化调用方（HTTP 客户端/Worker） | API 装配、路由注册、请求/响应契约与后台任务受理边界 | 页面渲染、前端会话态维护、Streamlit 组件状态 |
+
+统一约束：
+
+- 两条入口都遵循 `UI -> Service -> Host -> Agent`，不允许 UI 直接绕过 `Service` 调 `Host` 内部细节。
+- `streamlit_app.py` 可以维护 UI 会话状态，但不扩展成通用 API 网关。
+- `fastapi_app.py` 负责稳定 API 契约，但不承载 Streamlit 页面行为或页面状态。
+- 同一业务能力优先复用同一组 `ServiceProtocol`，保证 CLI / Streamlit / FastAPI 语义一致。
+
+## 2. Streamlit Web 核心功能
+
+- 初始化配置，并配置各个场景的模型
+- 配置自选股
+- 下载个股财报，目前支持从SEC下载财报
+- 交互式分析，目前未保存会话历史，刷新页面将开启新的会话
+- 分析报告，支持生成完整的分析报告，查看报告详情(Service未暴露分析过程的详细信息，暂时通过跟踪draft输出的文件跟踪任务状态)，并导出为Markdown、PDF、Html等格式的完成报告
+

--- a/dayu/web/__main__.py
+++ b/dayu/web/__main__.py
@@ -1,0 +1,25 @@
+"""`python -m dayu.web` 入口。"""
+
+from __future__ import annotations
+
+from dayu.web.streamlit_app import run_streamlit
+
+
+def main() -> int:
+    """运行 Streamlit Web 模块入口。
+
+    Args:
+        无。
+
+    Returns:
+        Streamlit 子进程退出码。
+
+    Raises:
+        无。异常由下层 ``run_streamlit()`` 透传。
+    """
+
+    return run_streamlit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dayu/web/__main__.py
+++ b/dayu/web/__main__.py
@@ -8,14 +8,14 @@ from dayu.web.streamlit_app import run_streamlit
 def main() -> int:
     """运行 Streamlit Web 模块入口。
 
-    Args:
+    参数:
         无。
 
-    Returns:
+    返回值:
         Streamlit 子进程退出码。
 
-    Raises:
-        无。异常由下层 ``run_streamlit()`` 透传。
+    异常:
+        无。异常由下层 `run_streamlit()` 透传。
     """
 
     return run_streamlit()

--- a/dayu/web/streamlit/bootstrap.py
+++ b/dayu/web/streamlit/bootstrap.py
@@ -1,0 +1,184 @@
+"""Streamlit 入口依赖装配模块。
+
+负责工作区路径解析、Service 依赖初始化，以及本地文件服务安全启动。
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import streamlit as st
+
+from dayu.log import Log
+
+if TYPE_CHECKING:
+    from dayu.services.startup_preparation import PreparedHostRuntimeDependencies
+    from dayu.services.protocols import ChatServiceProtocol, FinsServiceProtocol, WriteServiceProtocol
+    from dayu.web.streamlit.pages.chat_tab import ChatServiceClient
+
+MODULE = "WEB.STREAMLIT.BOOTSTRAP"
+
+def initialize_services() -> tuple[Path, FinsServiceProtocol | None, WriteServiceProtocol | None, ChatServiceClient | None]:
+    """初始化 Streamlit 页面所需 Service 依赖。
+
+    参数:
+        无。
+
+    返回值:
+        四元组：`(workspace_root, fins_service, write_service, chat_service_client)`。
+
+    异常:
+        无。内部异常会转换为 UI warning 并降级返回空服务。
+    """
+
+    workspace_root = resolve_workspace_root()
+    Log.info(f"工作区根目录: {workspace_root}", module=MODULE)
+
+    prepared_runtime_dependencies: PreparedHostRuntimeDependencies | None = None
+    try:
+        prepared_runtime_dependencies = _prepare_host_runtime_dependencies(workspace_root)
+    except Exception as exception:  # noqa: BLE001
+        st.warning(f"Host 运行时依赖初始化失败（功能不可用）: {exception}")
+
+    fins_service = None
+    host_admin_service = None
+    if prepared_runtime_dependencies is not None:
+        try:
+            fins_service = _create_fins_service(prepared_runtime_dependencies)
+        except Exception as exception:  # noqa: BLE001
+            st.warning(f"财报服务初始化失败（部分功能不可用）: {exception}")
+
+        from dayu.services.host_admin_service import HostAdminService
+
+        host_admin_service = HostAdminService(host=prepared_runtime_dependencies.host)
+
+    write_service = None
+    chat_service_client = None
+    if prepared_runtime_dependencies is not None:
+        try:
+            write_service, chat_service = _create_write_service_and_chat_service(prepared_runtime_dependencies)
+            from dayu.services.reply_delivery_service import ReplyDeliveryService
+
+            if host_admin_service is None:
+                raise RuntimeError("Host 管理服务未初始化")
+            reply_delivery_service = ReplyDeliveryService(host=prepared_runtime_dependencies.host)
+
+            from dayu.web.streamlit.pages.chat_tab import create_chat_service_client
+            chat_service_client = create_chat_service_client(
+                chat_service=chat_service,
+                host_admin_service=host_admin_service,
+                reply_delivery_service=reply_delivery_service,
+            )
+        except Exception as exception:  # noqa: BLE001
+            st.warning(f"分析报告和交互式分析功能不可用: {exception}")
+
+    st.session_state["host_admin_service"] = host_admin_service
+    return workspace_root, fins_service, write_service, chat_service_client
+
+
+def resolve_workspace_root() -> Path:
+    """解析 Streamlit 运行工作区目录。
+
+    优先级：
+    1. 命令行参数 `--workspace` / `-w`
+    2. 当前目录下的 `workspace`
+
+    参数:
+        无。
+
+    返回值:
+        解析后的绝对路径。
+
+    异常:
+        无。
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", "-w", type=str, help="工作区目录路径")
+    parsed_args, _ = parser.parse_known_args()
+    if parsed_args.workspace:
+        return Path(parsed_args.workspace).resolve()
+
+    return (Path.cwd() / "workspace").resolve()
+
+
+def _prepare_host_runtime_dependencies(workspace_root: Path) -> PreparedHostRuntimeDependencies:
+    """准备 Streamlit 共享 Host 运行时依赖。
+
+    参数:
+        workspace_root: 工作区根目录。
+
+    返回值:
+        Streamlit 各 Service 共享的 Host 运行时依赖。
+
+    异常:
+        Exception: 启动依赖准备失败时抛出。
+    """
+
+    from dayu.services import prepare_host_runtime_dependencies
+
+    return prepare_host_runtime_dependencies(
+        workspace_root=workspace_root,
+        config_root=None,
+        execution_options=None,
+        runtime_label="Streamlit Host runtime",
+        log_module=MODULE,
+    )
+
+
+def _create_fins_service(prepared_runtime_dependencies: PreparedHostRuntimeDependencies) -> FinsServiceProtocol:
+    """创建财报服务实例。
+
+    参数:
+        prepared_runtime_dependencies: 共享 Host 运行时依赖。
+
+    返回值:
+        财报服务实例。
+
+    异常:
+        Exception: 初始化依赖失败时抛出。
+    """
+
+    from dayu.services import FinsService
+
+    return FinsService(
+        host=prepared_runtime_dependencies.host,
+        fins_runtime=prepared_runtime_dependencies.fins_runtime,
+    )
+
+
+def _create_write_service_and_chat_service(
+    prepared_runtime_dependencies: PreparedHostRuntimeDependencies,
+) -> tuple[WriteServiceProtocol, ChatServiceProtocol]:
+    """创建写作服务与聊天服务。
+
+    参数:
+        prepared_runtime_dependencies: 共享 Host 运行时依赖。
+
+    返回值:
+        二元组：`(write_service, chat_service)`。
+
+    异常:
+        Exception: 依赖准备或实例化失败时抛出。
+    """
+
+    from dayu.contracts.session import SessionSource
+    from dayu.services import ChatService, WriteService
+
+    write_service = WriteService(
+        host=prepared_runtime_dependencies.host,
+        host_governance=prepared_runtime_dependencies.host,
+        workspace=prepared_runtime_dependencies.workspace,
+        scene_execution_acceptance_preparer=prepared_runtime_dependencies.scene_execution_acceptance_preparer,
+        company_name_resolver=prepared_runtime_dependencies.fins_runtime.get_company_name,
+        company_meta_summary_resolver=prepared_runtime_dependencies.fins_runtime.get_company_meta_summary,
+    )
+    chat_service = ChatService(
+        host=prepared_runtime_dependencies.host,
+        scene_execution_acceptance_preparer=prepared_runtime_dependencies.scene_execution_acceptance_preparer,
+        company_name_resolver=prepared_runtime_dependencies.fins_runtime.get_company_name,
+        session_source=SessionSource.WEB,
+    )
+    return write_service, chat_service

--- a/dayu/web/streamlit/components/sidebar.py
+++ b/dayu/web/streamlit/components/sidebar.py
@@ -1,0 +1,126 @@
+"""Streamlit 侧边栏组件。
+
+提供自选股列表展示和选择功能，并展示当前工作区目录。
+使用本地JSON文件存储（workspace/.dayu/streamlit/watchlist.json），刷新不丢失。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import streamlit as st
+
+from dayu.web.streamlit.components.watchlist import WatchlistItem, load_watchlist_items, render_watchlist_manager
+
+_INIT_ROLE_KEY = "_init_model_role"
+_ROLE_NON_THINKING = "non_thinking"
+_ROLE_THINKING = "thinking"
+_CONFIG_NEEDS_REFRESH_KEY = "config_needs_refresh"
+
+def render_sidebar(
+    workspace_root: Path,
+    on_select_callback: Callable[[WatchlistItem], None] | None = None,
+) -> WatchlistItem | None:
+    """渲染侧边栏，展示自选股列表并处理选择。
+
+    参数:
+        workspace_root: 工作区根目录，用于读取自选股存储文件。
+        on_select_callback: 选中自选股后的回调函数，接收 WatchlistItem 参数。
+
+    返回值:
+        当前选中的自选股条目，未选中时返回 None。
+    """
+
+    st.sidebar.title("大禹 Agent")
+
+    # 工作区信息展示（优化样式）
+    workspace_resolved = workspace_root.resolve()
+
+    # 使用 caption 样式展示工作区路径
+    st.sidebar.markdown(f"**📁 工作区**  \n`{workspace_resolved}`")
+
+    st.sidebar.markdown("---")
+
+    # 选中按钮使用 primary 类型，通过 CSS 改为仅边框高亮
+    st.sidebar.markdown(
+        """
+        <style>
+        section[data-testid="stSidebar"] div[data-testid="stButton"] > button[kind="primary"] {
+            background-color: transparent;
+            color: inherit;
+            border: 1px solid #ff4b4b;
+            box-shadow: 0 0 0 1px rgba(255, 75, 75, 0.25);
+        }
+        section[data-testid="stSidebar"] div[data-testid="stButton"] > button[kind="primary"]:hover {
+            background-color: rgba(255, 75, 75, 0.06);
+            color: inherit;
+            border: 1px solid #ff4b4b;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    # 检查是否需要刷新数据（对话框保存后设置）
+    refresh_key = "watchlist_needs_refresh"
+    needs_refresh = st.session_state.pop(refresh_key, False)
+
+    # 获取自选股列表（从文件读取）
+    try:
+        watchlist = load_watchlist_items(workspace_root)
+    except Exception as e:
+        st.sidebar.error(f"加载自选股失败: {e}")
+        watchlist = []
+
+    # 初始化选中状态
+    if "selected_ticker" not in st.session_state:
+        st.session_state["selected_ticker"] = None
+
+    # 如果刷新了数据，检查当前选中的股票是否还在列表中，不在则清除选中状态
+    selected_ticker = st.session_state.get("selected_ticker")
+    if needs_refresh:
+        if selected_ticker is not None and not any(item.ticker == selected_ticker for item in watchlist):
+            st.session_state["selected_ticker"] = None
+
+    # 自选股标题行：左侧标题，右侧管理按钮（icon 按钮，更小）
+    col1, col2 = st.sidebar.columns([5, 1], vertical_alignment="center")
+    with col1:
+        st.markdown("**❤️ 自选股**")
+   
+    with col2:
+        if st.button("", key="manage_watchlist_btn", icon=":material/list_alt_add:", type="tertiary", help="管理自选股"):
+            # 调用对话框函数（装饰器会自动处理）
+            render_watchlist_manager(workspace_root)
+
+    # 展示自选股列表
+    selected_item = None
+    for item in watchlist:
+        display_name = f"{item.company_name} ({item.ticker})"
+        current_selected_ticker = st.session_state.get("selected_ticker")
+        is_selected = isinstance(current_selected_ticker, str) and current_selected_ticker == item.ticker
+
+        # 使用按钮展示每个自选股
+        button_type = "primary" if is_selected else "secondary"
+        if st.sidebar.button(display_name, key=f"stock_{item.ticker}", type=button_type, width="stretch"):
+            st.session_state["selected_ticker"] = item.ticker
+            selected_item = item
+            if on_select_callback:
+                on_select_callback(item)
+            st.rerun()
+
+    if not watchlist:
+        st.sidebar.info("暂无自选股，请点击管理按钮添加")
+
+    st.sidebar.markdown("---")
+
+    # 返回当前选中的条目
+    current_selected_ticker = st.session_state.get("selected_ticker")
+    if isinstance(current_selected_ticker, str) and current_selected_ticker and not selected_item:
+        # 从列表中找到选中的条目
+        for item in watchlist:
+            if item.ticker == current_selected_ticker:
+                selected_item = item
+                break
+
+    return selected_item

--- a/dayu/web/streamlit/components/watchlist.py
+++ b/dayu/web/streamlit/components/watchlist.py
@@ -210,7 +210,7 @@ def _build_final_dataframe(
         # 从大到小排序，确保删除时索引不偏移
         for idx in sorted(deleted_indices, reverse=True):
             if idx < len(df):
-                df = df.drop(df.index[idx])
+                df = df.drop(df.index[idx], axis=0)
         df = df.reset_index(drop=True)
 
     # 处理编辑：更新指定行的数据

--- a/dayu/web/streamlit/components/watchlist.py
+++ b/dayu/web/streamlit/components/watchlist.py
@@ -207,11 +207,12 @@ def _build_final_dataframe(
     # 处理删除：按索引删除行（从大到小删除避免索引变化）
     deleted_indices = editor_state.get("deleted_rows", [])
     if deleted_indices:
-        # 从大到小排序，确保删除时索引不偏移
-        for idx in sorted(deleted_indices, reverse=True):
-            if idx < len(df):
-                df = df.drop(df.index[idx], axis=0)
-        df = df.reset_index(drop=True)
+        valid_deleted = {
+            int(raw_idx) for raw_idx in deleted_indices if 0 <= int(raw_idx) < len(df)
+        }
+        if valid_deleted:
+            keep_positions = [pos for pos in range(len(df)) if pos not in valid_deleted]
+            df = df.iloc[keep_positions]
 
     # 处理编辑：更新指定行的数据
     edited_rows = editor_state.get("edited_rows", {})

--- a/dayu/web/streamlit/components/watchlist.py
+++ b/dayu/web/streamlit/components/watchlist.py
@@ -1,0 +1,383 @@
+"""Streamlit 自选股管理对话框组件。
+
+在表格内完成自选股的添加、删除、编辑，保存后写入本地 JSON。
+存储路径：workspace/.dayu/streamlit/watchlist.json。
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+import pandas as pd
+import streamlit as st
+from dataclasses import dataclass
+
+
+
+@dataclass(frozen=True)
+class WatchlistItem:
+    """自选股条目（Streamlit内部使用）。
+
+    属性:
+        ticker: 股票代码，如 AAPL。
+        company_name: 公司名称，如 苹果。
+        created_at: 创建时间 ISO8601 格式。
+        updated_at: 更新时间 ISO8601 格式。
+    """
+
+    ticker: str
+    company_name: str
+    created_at: str
+    updated_at: str
+
+
+def _watchlist_storage_path(workspace_root: Path) -> Path:
+    """返回自选股持久化文件路径。
+
+    参数:
+        workspace_root: 工作区根目录。
+
+    返回值:
+        自选股 JSON 文件绝对路径。
+
+    异常:
+        无。
+    """
+
+    return workspace_root / ".dayu" / "streamlit" / "watchlist.json"
+
+
+def load_watchlist_items(workspace_root: Path) -> list[WatchlistItem]:
+    """从本地 JSON 文件加载自选股列表。
+
+    参数:
+        workspace_root: 工作区根目录。
+
+    返回值:
+        自选股条目列表；文件不存在或解析失败时返回空列表。
+
+    异常:
+        无：解析失败时返回空列表，不向调用方抛出。
+    """
+
+    storage_path = _watchlist_storage_path(workspace_root)
+    if not storage_path.exists():
+        return []
+
+    try:
+        with open(storage_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        items: list[WatchlistItem] = []
+        for item_data in data.get("items", []):
+            items.append(
+                WatchlistItem(
+                    ticker=str(item_data["ticker"]),
+                    company_name=str(item_data["company_name"]),
+                    created_at=str(item_data["created_at"]),
+                    updated_at=str(item_data["updated_at"]),
+                )
+            )
+        return items
+    except Exception:
+        return []
+
+
+def save_watchlist_items(workspace_root: Path, items: list[WatchlistItem]) -> None:
+    """将自选股列表写入本地 JSON 文件。
+
+    参数:
+        workspace_root: 工作区根目录。
+        items: 要持久化的条目列表。
+
+    异常:
+        OSError: 无法创建目录或写入文件时抛出。
+    """
+
+    storage_path = _watchlist_storage_path(workspace_root)
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "items": [
+            {
+                "ticker": item.ticker,
+                "company_name": item.company_name,
+                "created_at": item.created_at,
+                "updated_at": item.updated_at,
+            }
+            for item in items
+        ],
+        "version": "1.0",
+    }
+    with open(storage_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+
+
+def _is_cell_empty(val: object) -> bool:
+    """判断表格单元格是否为空（含 NaN、pd.NA）。
+
+    参数:
+        val: 单元格原始值。
+
+    返回值:
+        视为空则为 True。
+
+    异常:
+        无。
+    """
+
+    if val is None:
+        return True
+    try:
+        if val is pd.NA:
+            return True
+    except (TypeError, AttributeError):
+        pass
+    if isinstance(val, float) and math.isnan(val):
+        return True
+    return False
+
+
+def _series_cell_str(series_row: pd.Series, key: str) -> str:
+    """从 DataFrame 行读取单元格为去空白字符串；空或缺失视为空串。
+
+    参数:
+        series_row: 一行数据。
+        key: 列名。
+
+    返回值:
+        去首尾空白后的字符串，空单元格返回空串。
+
+    异常:
+        无。
+    """
+
+    if key not in series_row.index:
+        return ""
+    val: object = series_row[key]
+    if _is_cell_empty(val):
+        return ""
+    if isinstance(val, str):
+        return val.strip()
+    return str(val).strip()
+
+
+def _items_to_dataframe(items: list[WatchlistItem]) -> pd.DataFrame:
+    """将自选股列表转为可编辑表格 DataFrame。
+
+    参数:
+        items: 自选股条目列表。
+
+    返回值:
+        列为「股票代码」「公司名称」的 DataFrame。
+
+    异常:
+        无。
+    """
+
+    if not items:
+        return pd.DataFrame(columns=["股票代码", "公司名称"])
+    rows = [{"股票代码": i.ticker, "公司名称": i.company_name} for i in items]
+    return pd.DataFrame(rows)
+
+
+def _build_final_dataframe(
+    original: pd.DataFrame,
+    editor_state: dict,
+) -> pd.DataFrame:
+    """根据 data_editor 的 session state 构建最终的 DataFrame。
+
+    处理删除、编辑、新增三种操作，返回反映用户所有修改后的 DataFrame。
+
+    参数:
+        original: 原始 DataFrame（即传给 data_editor 的数据）。
+        editor_state: st.session_state[editor_key]，包含 deleted_rows、edited_rows、added_rows。
+
+    返回值:
+        处理后的最终 DataFrame。
+
+    异常:
+        无。
+    """
+
+    # 复制原始数据
+    df = original.copy()
+
+    # 处理删除：按索引删除行（从大到小删除避免索引变化）
+    deleted_indices = editor_state.get("deleted_rows", [])
+    if deleted_indices:
+        # 从大到小排序，确保删除时索引不偏移
+        for idx in sorted(deleted_indices, reverse=True):
+            if idx < len(df):
+                df = df.drop(df.index[idx])
+        df = df.reset_index(drop=True)
+
+    # 处理编辑：更新指定行的数据
+    edited_rows = editor_state.get("edited_rows", {})
+    for row_idx, changes in edited_rows.items():
+        row_idx = int(row_idx)
+        if row_idx < len(df):
+            for col_name, new_value in changes.items():
+                df.at[df.index[row_idx], col_name] = new_value
+
+    # 处理新增：添加新行
+    added_rows = editor_state.get("added_rows", [])
+    for added in added_rows:
+        new_row = {"股票代码": added.get("股票代码", ""), "公司名称": added.get("公司名称", "")}
+        df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
+
+    return df
+
+
+def _apply_table_to_storage(
+    workspace_root: Path,
+    original: pd.DataFrame,
+    editor_state: dict,
+    previous: list[WatchlistItem],
+) -> tuple[bool, str]:
+    """根据编辑后的表格原子写回存储。
+
+    参数:
+        workspace_root: 工作区根目录。
+        original: 原始 DataFrame（传给 data_editor 的数据）。
+        editor_state: st.session_state[editor_key]，包含删除/编辑/新增信息。
+        previous: 保存前的列表，用于保留已有条目的 created_at。
+
+    返回值:
+        (是否成功, 说明信息)。
+
+    异常:
+        无：校验失败时返回 (False, 错误说明)，不向调用方抛出。
+    """
+
+    # 构建最终 DataFrame（应用删除、编辑、新增）
+    final_df = _build_final_dataframe(original, editor_state)
+
+    prev_by_ticker = {p.ticker.upper(): p for p in previous}
+
+    rows_out: list[WatchlistItem] = []
+    seen_tickers: set[str] = set()
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    for _, series_row in final_df.iterrows():
+        ticker = _series_cell_str(series_row, "股票代码").upper()
+        name = _series_cell_str(series_row, "公司名称")
+
+        if not ticker and not name:
+            continue
+        if not ticker:
+            return False, "存在未填写股票代码的行，请补全或删除空行。"
+        if not name:
+            return False, f"股票代码 {ticker} 未填写公司名称。"
+        if ticker in seen_tickers:
+            return False, f"股票代码 {ticker} 重复，请保留唯一一行。"
+        seen_tickers.add(ticker)
+
+        prev = prev_by_ticker.get(ticker)
+        if prev is not None:
+            if name == prev.company_name:
+                rows_out.append(prev)
+            else:
+                rows_out.append(
+                    WatchlistItem(
+                        ticker=prev.ticker,
+                        company_name=name,
+                        created_at=prev.created_at,
+                        updated_at=now,
+                    )
+                )
+        else:
+            rows_out.append(
+                WatchlistItem(
+                    ticker=ticker,
+                    company_name=name,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+    save_watchlist_items(workspace_root, rows_out)
+    return True, f"已保存 {len(rows_out)} 条自选股。"
+
+
+def _trigger_sidebar_refresh() -> None:
+    """标记并触发整页重跑，确保左侧自选股导航栏立即刷新。
+
+    参数:
+        无。
+
+    返回值:
+        无。
+
+    异常:
+        无。`st.rerun()` 的控制流异常由 Streamlit 内部处理。
+    """
+
+    st.session_state["watchlist_needs_refresh"] = True
+    st.rerun()
+
+
+@st.dialog("自选股管理", width="large")
+def render_watchlist_manager(workspace_root: Path) -> None:
+    """弹出对话框：在表格内添加、删除、编辑自选股，保存后写回文件。
+
+    参数:
+        workspace_root: 工作区根目录。
+
+    异常:
+        无：加载失败时在界面提示，不向调用方抛出。
+    """
+
+    editor_key = "watchlist_table_editor"
+
+    # 检查是否有保存后的刷新标记，用于重新加载数据
+    refresh_key = "watchlist_needs_refresh"
+    if st.session_state.get(refresh_key, False):
+        st.session_state[refresh_key] = False
+        # 清除 data_editor 状态以重新加载最新数据
+        if editor_key in st.session_state:
+            del st.session_state[editor_key]
+
+    st.markdown("在表格中编辑；底部可新增行；删除行即移除该自选股。编辑后检查代码与名称是否正确，然后点击 **保存**。")
+
+    try:
+        previous = load_watchlist_items(workspace_root)
+    except Exception as exc:
+        st.error(f"加载自选股失败: {exc}")
+        previous = []
+
+    df = _items_to_dataframe(previous)
+
+    # 注意：不要在这里删除 session_state[editor_key]，否则会丢失删除/编辑记录
+    edited_df = st.data_editor(
+        df,
+        num_rows="dynamic",
+        key=editor_key,
+        column_config={
+            "股票代码": st.column_config.TextColumn(
+                "股票代码",
+                help="如 AAPL、MSFT；新增行填写代码",
+            ),
+            "公司名称": st.column_config.TextColumn(
+                "公司名称",
+                help="公司显示名称",
+            ),
+        },
+        hide_index=True,
+        width="stretch",
+    )
+
+    _, btn_col = st.columns([4, 1])
+    with btn_col:
+        save_clicked = st.button("保存", type="secondary", key="watchlist_save_btn", width="stretch")
+
+    if save_clicked:
+        # 从 session_state 获取编辑器的完整状态（包含删除、编辑、新增记录）
+        editor_state = st.session_state.get(editor_key, {})
+        ok, msg = _apply_table_to_storage(workspace_root, df, editor_state, previous)
+        if ok:
+            st.success(msg)
+            _trigger_sidebar_refresh()
+        else:
+            st.error(msg)

--- a/dayu/web/streamlit/pages/chat_tab.py
+++ b/dayu/web/streamlit/pages/chat_tab.py
@@ -1,0 +1,65 @@
+from dayu.web.streamlit.components.watchlist import WatchlistItem
+
+
+import streamlit as st
+
+from dataclasses import dataclass
+from dayu.services.protocols import ChatServiceProtocol, HostAdminServiceProtocol, ReplyDeliveryServiceProtocol
+
+@dataclass(frozen=True)
+class ChatServiceClient:
+    """聊天服务客户端。
+
+    参数:
+        chat_service: 聊天服务协议实例。
+        host_admin_service: 宿主管理服务协议实例。
+        reply_delivery_service: 回复投递服务协议实例。
+
+    返回值:
+        无。
+
+    异常:
+        无。
+    """
+
+    chat_service: ChatServiceProtocol
+    host_admin_service: HostAdminServiceProtocol
+    reply_delivery_service: ReplyDeliveryServiceProtocol
+
+
+def create_chat_service_client(
+    *,
+    chat_service: ChatServiceProtocol,
+    host_admin_service: HostAdminServiceProtocol,
+    reply_delivery_service: ReplyDeliveryServiceProtocol,
+) -> ChatServiceClient:
+    """创建聊天服务客户端。
+
+    参数:
+        chat_service: 聊天服务协议实例。
+        host_admin_service: 宿主管理服务协议实例。
+        reply_delivery_service: 回复投递服务协议实例。
+
+    返回值:
+        组装完成的聊天服务客户端。
+
+    异常:
+        无。
+    """
+
+    return ChatServiceClient(
+        chat_service=chat_service,
+        host_admin_service=host_admin_service,
+        reply_delivery_service=reply_delivery_service,
+    )
+
+
+def render_chat_tab(
+    *,
+    selected_stock: WatchlistItem,
+    chat_service_client: ChatServiceClient | None,
+) -> None:
+    """渲染交互式分析 Tab。"""
+
+    st.write(f"交互式分析: {selected_stock.ticker}")
+

--- a/dayu/web/streamlit/pages/filing_tab.py
+++ b/dayu/web/streamlit/pages/filing_tab.py
@@ -1,0 +1,21 @@
+import streamlit as st
+from dayu.web.streamlit.components.watchlist import WatchlistItem
+from pathlib import Path
+from dayu.services.protocols import FinsServiceProtocol
+
+
+def render_filing_tab(
+    selected_stock: WatchlistItem,
+    workspace_root: Path,
+    fins_service: FinsServiceProtocol | None,
+) -> None:
+    """渲染财报管理 Tab。
+
+    参数:
+        selected_stock: 当前选中的自选股。
+        workspace_root: 工作区根目录。
+        fins_service: 财报服务实例；为 None 时部分功能不可用。
+    """
+
+    st.write(f"财报管理: {selected_stock.ticker}")
+    st.write(f"工作区根目录: {workspace_root}")

--- a/dayu/web/streamlit/pages/main_page.py
+++ b/dayu/web/streamlit/pages/main_page.py
@@ -1,0 +1,96 @@
+"""Streamlit 主功能区页面。
+
+根据是否选中自选股，展示系统介绍或功能 Tab 页面。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from dayu.services.protocols import FinsServiceProtocol, WriteServiceProtocol
+from dayu.web.streamlit.components.watchlist import WatchlistItem
+from dayu.web.streamlit.pages.chat_tab import ChatServiceClient, render_chat_tab
+from dayu.web.streamlit.pages.filing_tab import render_filing_tab
+from dayu.web.streamlit.pages.report_tab import render_report_tab
+
+
+def render_welcome_page() -> None:
+    """渲染欢迎页面（未选中自选股时展示）。"""
+
+    # 系统标题
+    st.title("大禹 Agent")
+    st.markdown("### 每个投资者的助理分析师")
+    st.markdown("---")
+
+    # 系统介绍
+    st.markdown("""
+    #### 系统介绍
+
+    **大愚 Agent** 是一个面向买方财报分析场景的 Agent 系统，它让AI读财报的方式从丢给它整份财报“大海捞针”变成“按图索骥”，让数据有**置信度**，让投资结论、投资报告可审计、可追踪。  
+    """)
+    
+
+    # 操作指引
+    st.markdown("---")
+    st.markdown("""
+    ### 环境配置：
+    1. **模型配置**：点击左侧「配置」按钮，完成工作区初始化与模型配置。
+    2. **管理自选股**：点击左侧「管理自选股」按钮，添加您关注的公司
+    3. **选择模型**：在左侧模型列表中选择您想要使用的模型
+    """)
+    st.caption("ℹ️ 提示：请先配置模型 API Key 的环境变量，否则无法使用交互式分析和分析报告功能")
+
+    st.markdown("---")
+    st.markdown("""
+    ### 操作指引：
+    1. **选择股票**：在左侧自选股列表中点击任意股票
+    2. **下载财报**：在「财报管理」页面点击「下载财报」按钮获取最新财报，从 SEC EDGAR 获取上市公司财报文件（10-K、10-Q、8-K 等）
+    3. **交互式分析**：财报下载完成后，可以进行交互式分析，通过自然语言对话，深度分析公司财务状况与业务趋势
+    4. **生成报告**：财报下载完成后，可以根据内置的定性分析模板生成完整的分析报告，报告分析时间约为 10-30 分钟
+    """)
+    st.info("注意：交互式分析或报告生成过程中不要关闭或刷新页面，否则应答会中断，需要重新开始对话或报告生成", icon="⚠️")
+
+
+def render_stock_detail_page(
+    selected_stock: WatchlistItem,
+    workspace_root: Path,
+    fins_service: FinsServiceProtocol,
+    write_service: WriteServiceProtocol | None = None,
+    chat_service_client: ChatServiceClient | None = None,
+) -> None:
+    """渲染股票详情页面（选中自选股后展示）。
+
+    参数:
+        selected_stock: 当前选中的自选股。
+        workspace_root: 工作区根目录。
+        fins_service: 财报服务实例。
+        write_service: 写作服务实例；为 None 时分析报告功能受限。
+        chat_service_client: 聊天Service客户端；为 None 时交互式分析功能不可用。
+    """
+    # 功能 Tab（带图标）
+    tabs = st.tabs(["🧾 财报管理", "🧠 交互式分析", "📊 分析报告"])
+
+    # Tab 1: 财报管理
+    with tabs[0]:
+        render_filing_tab(
+            selected_stock=selected_stock,
+            workspace_root=workspace_root,
+            fins_service=fins_service,
+        )
+
+    # Tab 2: 交互式分析
+    with tabs[1]:
+        render_chat_tab(
+            selected_stock=selected_stock,
+            chat_service_client=chat_service_client,
+        )
+
+    # Tab 3: 分析报告
+    with tabs[2]:
+        render_report_tab(
+            selected_stock=selected_stock,
+            workspace_root=workspace_root,
+            write_service=write_service,
+        )

--- a/dayu/web/streamlit/pages/report_tab.py
+++ b/dayu/web/streamlit/pages/report_tab.py
@@ -1,0 +1,24 @@
+import streamlit as st
+from dayu.web.streamlit.components.watchlist import WatchlistItem
+from pathlib import Path
+from dayu.services.protocols import WriteServiceProtocol
+
+def render_report_tab(
+    selected_stock: WatchlistItem,
+    workspace_root: Path,
+    write_service: WriteServiceProtocol | None,
+) -> None:
+    """渲染分析报告 Tab。
+
+    根据报告存在性和任务运行状态，展示三种不同UI：
+    1. 无报告：引导用户启动分析任务
+    2. 有报告：展示详细分析报告
+
+    参数:
+        selected_stock: 当前选中的自选股。
+        workspace_root: 工作区根目录。
+        write_service: 写作服务实例；为 None 时部分功能不可用。
+    """
+
+    st.write(f"分析报告: {selected_stock.ticker}")
+    st.write(f"工作区根目录: {workspace_root}")

--- a/dayu/web/streamlit_app.py
+++ b/dayu/web/streamlit_app.py
@@ -1,0 +1,156 @@
+"""Streamlit Web 应用入口。
+
+大禹 Agent 的 Web UI 实现，基于 Streamlit 框架。
+提供自选股管理、财报下载、财务分析等功能。
+
+自选股数据存储于 workspace/.dayu/streamlit/watchlist.json，刷新不丢失。
+
+页面布局：
+- 左侧边栏：自选股列表 + 管理按钮
+- 主功能区：
+  - 未选中自选股时：系统介绍 + 操作指引
+  - 选中自选股后：财报管理 / 交互式分析 / 分析报告 Tab
+
+Usage:
+    streamlit run dayu/web/streamlit_app.py
+    # 或使用 CLI：
+    dayu-web
+    # 或使用模块入口：
+    python -m dayu.web
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import streamlit as st
+
+if TYPE_CHECKING:
+    from dayu.services.protocols import FinsServiceProtocol, WriteServiceProtocol
+    from dayu.web.streamlit.components.watchlist import WatchlistItem
+    from dayu.web.streamlit.pages.chat_tab import ChatServiceClient
+from dayu.web.streamlit.bootstrap import initialize_services
+
+
+
+def _configure_streamlit_page() -> None:
+    """配置 Streamlit 页面元信息。"""
+
+    st.set_page_config(
+        page_title="大禹 Agent",
+        page_icon="📊",
+        layout="wide",
+        initial_sidebar_state="expanded",
+    )
+
+
+def _ensure_session_state_initialized() -> None:
+    """初始化 Streamlit 会话状态默认键。"""
+
+    if "initialized" not in st.session_state:
+        st.session_state["initialized"] = False
+        st.session_state["workspace_root"] = None
+        st.session_state["fins_service"] = None
+        st.session_state["write_service"] = None
+        st.session_state["chat_service_client"] = None
+        st.session_state["host_admin_service"] = None
+
+
+def main() -> None:
+    """Streamlit 应用主入口。"""
+
+    from dayu.web.streamlit.components.sidebar import render_sidebar
+    from dayu.web.streamlit.pages.main_page import render_welcome_page, render_stock_detail_page
+
+    _configure_streamlit_page()
+    _ensure_session_state_initialized()
+
+    # 初始化服务（只执行一次）
+    if not bool(st.session_state["initialized"]):
+        try:
+            workspace_root, fins_service, write_service, chat_service_client = initialize_services()
+            st.session_state["workspace_root"] = workspace_root
+            st.session_state["fins_service"] = fins_service
+            st.session_state["write_service"] = write_service
+            st.session_state["chat_service_client"] = chat_service_client
+            st.session_state["initialized"] = True
+        except Exception as e:
+            st.error(f"服务初始化失败: {e}")
+            st.stop()
+
+    # 从会话状态获取工作区路径和服务
+    workspace_root = st.session_state["workspace_root"]
+    fins_service = st.session_state["fins_service"]
+    write_service = st.session_state["write_service"]
+    chat_service_client = st.session_state["chat_service_client"]
+
+
+    # 左侧边栏：渲染自选股列表（直接从文件读取）
+    selected_stock = render_sidebar(
+        workspace_root=workspace_root,
+        on_select_callback=_on_stock_selected,
+    )
+
+    # 主功能区（自选股管理对话框由侧边栏「管理」按钮触发）
+    if selected_stock is None:
+        # 未选中自选股：展示欢迎页面
+        render_welcome_page()
+    elif fins_service is not None:
+        # 选中自选股且服务可用：展示详情页面
+        render_stock_detail_page(
+            selected_stock=selected_stock,
+            workspace_root=workspace_root,
+            fins_service=fins_service,
+            write_service=write_service,
+            chat_service_client=chat_service_client,
+        )
+    else:
+        # 选中自选股但服务不可用：提示错误
+        st.error("财报服务不可用，无法展示股票详情。请检查配置后刷新页面。")
+
+
+def _on_stock_selected(stock: WatchlistItem) -> None:
+    """自选股选中回调。
+
+    参数:
+        stock: 被选中的自选股。
+    """
+
+    # 可以在这里添加选中后的逻辑
+    pass
+
+
+def run_streamlit() -> int:
+    """启动 Streamlit 服务并返回进程退出码。
+
+    参数:
+        无。
+
+    返回值:
+        Streamlit 子进程退出码；正常退出通常为 `0`。
+
+    异常:
+        无。子进程启动失败时由 `subprocess.run` 抛出异常。
+    """
+
+    import subprocess
+
+    # 获取当前文件路径
+    app_path = Path(__file__).resolve()
+
+    # 构建 streamlit 命令
+    cmd = [
+        sys.executable, "-m", "streamlit", "run",
+        str(app_path),
+        *sys.argv[1:],  # 传递所有原始参数
+    ]
+
+    # 执行命令
+    completed = subprocess.run(cmd, check=False)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "markdownify>=0.13.1",
     "html2text>=2024.2.26",
     "tabulate>=0.9.0",
+    "streamlit>=1.40.0",
 ]
 
 [project.optional-dependencies]
@@ -90,8 +91,10 @@ Issues = "https://github.com/noho/dayu-agent/issues"
 
 [project.scripts]
 dayu-cli = "dayu.cli.main:main"
+dayu-web = "dayu.web.__main__:main"
 dayu-wechat = "dayu.wechat.main:main"
 dayu-render = "dayu.render.render:main"
+
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/README.md
+++ b/tests/README.md
@@ -120,6 +120,7 @@ pip install -r requirements.txt
 - `tests/fins/test_storage_batch_recovery.py` 这类跨进程锁测试同样不得把 5 秒级硬编码收口时间当成必然成立的环境保证；应使用具名超时常量和轮询等待，让较慢的 Windows runner 仍能验证同一套锁语义，而不是把时序抖动误报成存储回归。
 - `test_web_routes.py` 还要守住 Web 的客户端错误语义：像 `PromptService.submit()`、`ChatService.resume_pending_turn()` 这类已经在 Service 边界同步抛出的 `ValueError/KeyError`，router 必须映射成对应 `4xx`，且 `/api/chat/resume` 只能在 resume 成功后才创建后台消费任务，不能漏成 `500` 或先受理后失败。
 - `test_web_routes.py` 还要守住 `/api/write` 的未支持语义：当 Web 当前不支持在线写作时，route 必须显式返回 `501`，不能再用 `202` / `accepted=true` 伪装成已受理。
+- `test_streamlit_watchlist.py` 负责守住 Streamlit 自选股组件的本地持久化与表格合并边界：`workspace/.dayu/streamlit/watchlist.json` 读写、删除/编辑/新增合并、必填校验与 ticker 去重语义不能漂移。
 - `test_fins_service.py`、`test_sec_process_workflow.py`、`test_sec_pipeline_process_filing_source.py`、`test_cn_pipeline_process.py` 与 `test_tool_snapshot_export.py` 还要共同守住 Fins 取消传播链路：`Host` 的取消状态只能以窄 `cancel_checker` 形式从 `FinsService -> FinsRuntime -> Pipeline` 下传；同步 `process_filing/process_material` 与已支持取消协作的流式 `download/process` 都必须在阶段边界及时抛出 `CancelledError` 或收口为 cancelled，不能等 direct operation 整体结束后才统一收口。
 - `test_sec_pipeline_process_filing_source.py` 还要继续守住 snapshot 导出后的仓储可发现性：当 `tool_snapshot_*.json` 已成功写入 `processed/{document_id}` 时，`FsProcessedDocumentRepository.list_processed_documents()` 必须能同步发现该文档，不能再出现“目录里有 snapshot、manifest 里没有登记”的漂移。
 - `test_host_admin_service.py` 负责守住宿主管理面已经收口到 `HostAdminService`，避免 Web / CLI 管理面重新直接触碰 Host。

--- a/tests/application/test_streamlit_watchlist.py
+++ b/tests/application/test_streamlit_watchlist.py
@@ -1,0 +1,124 @@
+"""Streamlit 自选股组件基础单元测试。"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+watchlist_module = importlib.import_module("dayu.web.streamlit.components.watchlist")
+
+
+@pytest.mark.unit
+def test_watchlist_storage_path_uses_workspace_dayu_streamlit(tmp_path: Path) -> None:
+    """验证自选股存储路径固定落在 `workspace/.dayu/streamlit/watchlist.json`。"""
+
+    storage_path = watchlist_module._watchlist_storage_path(tmp_path)
+
+    assert storage_path == tmp_path / ".dayu" / "streamlit" / "watchlist.json"
+
+
+@pytest.mark.unit
+def test_load_watchlist_items_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    """验证存储文件不存在时返回空列表。"""
+
+    loaded = watchlist_module.load_watchlist_items(tmp_path)
+
+    assert loaded == []
+
+
+@pytest.mark.unit
+def test_save_and_load_watchlist_items_round_trip(tmp_path: Path) -> None:
+    """验证自选股持久化后可正确读回。"""
+
+    items = [
+        watchlist_module.WatchlistItem(
+            ticker="AAPL",
+            company_name="Apple",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        ),
+        watchlist_module.WatchlistItem(
+            ticker="MSFT",
+            company_name="Microsoft",
+            created_at="2026-01-02T00:00:00+00:00",
+            updated_at="2026-01-02T00:00:00+00:00",
+        ),
+    ]
+
+    watchlist_module.save_watchlist_items(tmp_path, items)
+    loaded = watchlist_module.load_watchlist_items(tmp_path)
+
+    assert loaded == items
+
+
+@pytest.mark.unit
+def test_load_watchlist_items_returns_empty_on_invalid_json(tmp_path: Path) -> None:
+    """验证 JSON 解析失败时返回空列表而不是抛异常。"""
+
+    storage_path = watchlist_module._watchlist_storage_path(tmp_path)
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_text("{not-json}", encoding="utf-8")
+
+    loaded = watchlist_module.load_watchlist_items(tmp_path)
+
+    assert loaded == []
+
+
+@pytest.mark.unit
+def test_series_cell_str_trims_and_handles_empty_cells() -> None:
+    """验证表格单元格字符串规整逻辑。"""
+
+    row = pd.Series({"股票代码": "  aapl  ", "公司名称": pd.NA})
+
+    assert watchlist_module._series_cell_str(row, "股票代码") == "aapl"
+    assert watchlist_module._series_cell_str(row, "公司名称") == ""
+    assert watchlist_module._series_cell_str(row, "不存在列") == ""
+
+
+@pytest.mark.unit
+def test_build_final_dataframe_applies_delete_edit_and_add() -> None:
+    """验证删除、编辑、新增三类变更都会合并到最终表格。"""
+
+    original = pd.DataFrame(
+        [
+            {"股票代码": "AAPL", "公司名称": "Apple"},
+            {"股票代码": "TSLA", "公司名称": "Tesla"},
+        ]
+    )
+    editor_state = {
+        "deleted_rows": [0],
+        "edited_rows": {"0": {"公司名称": "Tesla Motors"}},
+        "added_rows": [{"股票代码": "MSFT", "公司名称": "Microsoft"}],
+    }
+
+    final_df = watchlist_module._build_final_dataframe(original, editor_state)
+
+    assert final_df.to_dict(orient="records") == [
+        {"股票代码": "TSLA", "公司名称": "Tesla Motors"},
+        {"股票代码": "MSFT", "公司名称": "Microsoft"},
+    ]
+
+
+@pytest.mark.unit
+def test_apply_table_to_storage_rejects_duplicate_ticker(tmp_path: Path) -> None:
+    """验证保存时会拒绝重复股票代码。"""
+
+    original = pd.DataFrame([{"股票代码": "AAPL", "公司名称": "Apple"}])
+    editor_state = {
+        "edited_rows": {},
+        "deleted_rows": [],
+        "added_rows": [{"股票代码": "aapl", "公司名称": "Apple Inc."}],
+    }
+
+    ok, message = watchlist_module._apply_table_to_storage(
+        workspace_root=tmp_path,
+        original=original,
+        editor_state=editor_state,
+        previous=[],
+    )
+
+    assert ok is False
+    assert "重复" in message


### PR DESCRIPTION
整个项目PR 较大，参考 review 建议拆分为多个：
1. streamlit web 服务的基础框架，包含自选股管理，及页面导航 （本PR）
2. 配置及模型切换
3. 财报下载
4. 交互式分析
5. 分析报告



相关Issue ：https://github.com/noho/dayu-agent/issues/19

相关PR https://github.com/noho/dayu-agent/pull/44