### PR TITLE
mig/macos x64 docling

### DIFF
--- a/constraints/lock-common-py311.txt
+++ b/constraints/lock-common-py311.txt
@@ -45,7 +45,6 @@ htmldate==1.9.4
 httpcore==1.0.9
 httpx==0.28.1
 httpxthrottlecache==0.3.5
-huggingface_hub==1.11.0
 humanize==4.15.0
 idna==3.11
 iniconfig==2.3.0
@@ -73,9 +72,7 @@ mypy_extensions==1.1.0
 nest-asyncio==1.6.0
 networkx==3.6.1
 nodeenv==1.10.0
-numpy==2.4.4
 omegaconf==2.3.0
-opencv-python==4.13.0.92
 openpyxl==3.1.5
 orjson==3.11.8
 packaging==26.1
@@ -142,7 +139,6 @@ tld==0.13.2
 tokenizers==0.22.2
 tqdm==4.67.3
 trafilatura==2.0.0
-transformers==5.5.4
 tree-sitter==0.25.2
 tree-sitter-c==0.24.1
 tree-sitter-javascript==0.25.0

--- a/constraints/lock-linux-x64-py311.txt
+++ b/constraints/lock-linux-x64-py311.txt
@@ -3,3 +3,7 @@
 
 torch==2.4.1
 torchvision==0.19.1
+transformers==5.5.4
+huggingface_hub==1.11.0
+numpy==2.4.4
+opencv-python==4.13.0.92

--- a/constraints/lock-macos-arm64-py311.txt
+++ b/constraints/lock-macos-arm64-py311.txt
@@ -3,6 +3,10 @@
 
 torch==2.4.1
 torchvision==0.19.1
+transformers==5.5.4
+huggingface_hub==1.11.0
+numpy==2.4.4
+opencv-python==4.13.0.92
 ocrmac==1.0.1
 pyobjc-core==12.1
 pyobjc-framework-Cocoa==12.1

--- a/constraints/lock-macos-x64-py311.txt
+++ b/constraints/lock-macos-x64-py311.txt
@@ -3,6 +3,12 @@
 
 torch==2.2.2
 torchvision==0.17.2
+# transformers 5.x 运行时硬性要求 torch>=2.4，macOS x64 最高只有 2.2.2，降级到 4.x 最新版
+transformers==4.57.6
+huggingface_hub==0.36.2
+# torch 2.2.2 用 numpy 1.x 编译，与 common 锁定的 numpy 2.x 不兼容
+numpy==1.26.4
+opencv-python==4.10.0.84
 ocrmac==1.0.1
 pyobjc-core==12.1
 pyobjc-framework-Cocoa==12.1

--- a/constraints/lock-windows-x64-py311.txt
+++ b/constraints/lock-windows-x64-py311.txt
@@ -3,3 +3,7 @@
 
 torch==2.4.1
 torchvision==0.19.1
+transformers==5.5.4
+huggingface_hub==1.11.0
+numpy==2.4.4
+opencv-python==4.13.0.92

--- a/utils/build_offline_bundle.py
+++ b/utils/build_offline_bundle.py
@@ -184,7 +184,18 @@ def _flatten_constraints_text(constraints_path: Path) -> str:
         visited.remove(resolved_path)
         return expanded_lines
 
-    return "\n".join(_expand(constraints_path)).strip() + "\n"
+    # 后出现的同名包约束覆盖先出现的（last-wins），使平台 lock 文件可以覆盖 common lock。
+    seen: dict[str, int] = {}
+    deduped: list[str] = []
+    for line in _expand(constraints_path):
+        pkg_name = line.split("==")[0].split(">=")[0].split("<=")[0].split("!=")[0].strip().lower()
+        if pkg_name in seen:
+            deduped[seen[pkg_name]] = line
+        else:
+            seen[pkg_name] = len(deduped)
+            deduped.append(line)
+
+    return "\n".join(deduped).strip() + "\n"
 
 
 def _write_install_script(bundle_dir: Path, *, version: str, platform_id: str) -> None:


### PR DESCRIPTION
- **macos-x64 上torch最高支持到2.2，只能锁定transformers版本到4.57.6**
- **torch, torchvision, transformers, huggingface_hub, numpy, opencv-python在各平台的约束中单独定义**
