### PR TITLE
fix(engine): SSE tool call delta 兼容 Gemini 和 Qwen 非标协议行为

### DIFF
--- a/dayu/engine/sse_parser.py
+++ b/dayu/engine/sse_parser.py
@@ -619,19 +619,27 @@ class SSEStreamParser:
         # 获取工具调用索引
         tool_index = tc.get("index")
         if tool_index is None or not isinstance(tool_index, int):
-            Log.warn(
-                f"{self._log_prefix} 工具调用增量 index 缺失或类型异常: {tool_index!r}",
-                module=MODULE,
-            )
-            self._record_protocol_error(
-                "tool_call_incomplete",
-                "Tool call arguments incomplete or invalid",
-                body=json.dumps(
-                    [f"tool_call entry invalid index: {tool_index!r}"],
-                    ensure_ascii=False,
-                ),
-            )
-            return
+            # Gemini OpenAI 兼容模式不发 index 字段，需自动推断。
+            # 策略：如果该 delta 携带了新的 id（缓冲区中没有），分配下一个连续索引；
+            # 否则（id 为空或与已有条目匹配），归入最后一个活跃条目。
+            tc_id_raw = tc.get("id")
+            existing_index = None
+            if tc_id_raw and isinstance(tc_id_raw, str):
+                for idx, buf in self._tool_calls_buffer.items():
+                    if buf.get("id") == tc_id_raw:
+                        existing_index = idx
+                        break
+            if existing_index is not None:
+                tool_index = existing_index
+            elif not tc_id_raw and self._tool_calls_buffer:
+                tool_index = max(self._tool_calls_buffer.keys())
+            else:
+                tool_index = max(self._tool_calls_buffer.keys()) + 1 if self._tool_calls_buffer else 0
+            if self._running_config.debug_tool_delta:
+                Log.debug(
+                    f"{self._log_prefix} 工具调用增量 index 缺失，自动推断为 {tool_index}",
+                    module=MODULE,
+                )
 
         entry = self._tool_calls_buffer.setdefault(
             tool_index,
@@ -660,7 +668,11 @@ class SSEStreamParser:
         args_delta: str | None = None
         if "arguments" in func:
             raw_args_delta = func["arguments"]
-            if not isinstance(raw_args_delta, str):
+            if raw_args_delta is None:
+                # 某些 provider（如 Qwen thinking 模式）在 tool call delta 中
+                # 会发送 "arguments": null，等价于不存在该字段，安全忽略。
+                pass
+            elif not isinstance(raw_args_delta, str):
                 self._record_protocol_error(
                     "tool_call_incomplete",
                     "Tool call arguments incomplete or invalid",
@@ -675,7 +687,8 @@ class SSEStreamParser:
                     ),
                 )
                 return
-            args_delta = raw_args_delta
+            else:
+                args_delta = raw_args_delta
 
         # 记录 id（首次出现即写入）；只接受非空字符串，非字符串或空字符串均视为未提供
         tc_id_raw = tc.get("id")

--- a/dayu/engine/sse_parser.py
+++ b/dayu/engine/sse_parser.py
@@ -603,6 +603,10 @@ class SSEStreamParser:
                         ),
                     )
                     continue
+                # 兼容不发 index 的 provider（如 Gemini OpenAI 兼容模式），
+                # 用数组下标补齐，使下游 _handle_tool_call_delta 无需特殊处理。
+                if "index" not in tc:
+                    tc = {**tc, "index": index}
                 async for event in self._handle_tool_call_delta(tc):
                     yield event
 
@@ -619,27 +623,19 @@ class SSEStreamParser:
         # 获取工具调用索引
         tool_index = tc.get("index")
         if tool_index is None or not isinstance(tool_index, int):
-            # Gemini OpenAI 兼容模式不发 index 字段，需自动推断。
-            # 策略：如果该 delta 携带了新的 id（缓冲区中没有），分配下一个连续索引；
-            # 否则（id 为空或与已有条目匹配），归入最后一个活跃条目。
-            tc_id_raw = tc.get("id")
-            existing_index = None
-            if tc_id_raw and isinstance(tc_id_raw, str):
-                for idx, buf in self._tool_calls_buffer.items():
-                    if buf.get("id") == tc_id_raw:
-                        existing_index = idx
-                        break
-            if existing_index is not None:
-                tool_index = existing_index
-            elif not tc_id_raw and self._tool_calls_buffer:
-                tool_index = max(self._tool_calls_buffer.keys())
-            else:
-                tool_index = max(self._tool_calls_buffer.keys()) + 1 if self._tool_calls_buffer else 0
-            if self._running_config.debug_tool_delta:
-                Log.debug(
-                    f"{self._log_prefix} 工具调用增量 index 缺失，自动推断为 {tool_index}",
-                    module=MODULE,
-                )
+            Log.warn(
+                f"{self._log_prefix} 工具调用增量 index 缺失或类型异常: {tool_index!r}",
+                module=MODULE,
+            )
+            self._record_protocol_error(
+                "tool_call_incomplete",
+                "Tool call arguments incomplete or invalid",
+                body=json.dumps(
+                    [f"tool_call entry invalid index: {tool_index!r}"],
+                    ensure_ascii=False,
+                ),
+            )
+            return
 
         entry = self._tool_calls_buffer.setdefault(
             tool_index,

--- a/tests/engine/test_sse_parser.py
+++ b/tests/engine/test_sse_parser.py
@@ -461,21 +461,43 @@ async def test_handle_tool_call_delta_covers_missing_index_and_debug_logs(monkey
         running_config=_RunningConfigStub(debug_tool_delta=True),
     )
 
-    missing_index_events = await _collect_events(parser._handle_tool_call_delta({"id": "tc_1"}))
+    # 1. 验证 Gemini 兼容模式下的 index 推断行为
+    # 1.1 携带新 id 但无 index -> 推断为 index 0
+    events_infer_1 = await _collect_events(parser._handle_tool_call_delta({
+        "id": "tc_infer_1",
+        "function": {"name": "tool_1", "arguments": ""}
+    }))
+    assert len(events_infer_1) == 1
+    assert events_infer_1[0].type == EventType.TOOL_CALL_START
+    
+    # 1.2 无 id 无 index -> 归入最后一个活跃条目 (index 0)
+    events_infer_2 = await _collect_events(parser._handle_tool_call_delta({
+        "function": {"arguments": "{"}
+    }))
+    assert len(events_infer_2) == 1
+    assert events_infer_2[0].type == EventType.TOOL_CALL_DELTA
+    assert events_infer_2[0].data["arguments_delta"] == "{"
+    
+    # 1.3 携带另一个新 id 无 index -> 推断为 index 1
+    events_infer_3 = await _collect_events(parser._handle_tool_call_delta({
+        "id": "tc_infer_2",
+        "function": {"name": "tool_2", "arguments": ""}
+    }))
+    assert len(events_infer_3) == 1
+    assert events_infer_3[0].type == EventType.TOOL_CALL_START
+    
+    assert any("工具调用增量 index 缺失" in message for message in debug_collector.messages)
 
+    # 2. 验证常规带有 index 时的日志行为
     full_events = await _collect_events(
         parser._handle_tool_call_delta(
             {
-                "index": 0,
-                "id": "tc_2",
+                "index": 2,
+                "id": "tc_normal",
                 "function": {"name": "read_file", "arguments": "{}"},
             }
         )
     )
-
-    assert missing_index_events == []
-    assert any("index" in message and ("缺失" in message or "异常" in message) for message in warn_collector.messages)
-
     assert [event.type for event in full_events] == [EventType.TOOL_CALL_START, EventType.TOOL_CALL_DELTA]
     assert any("记录 tool_call_id" in message for message in debug_collector.messages)
     assert any("记录工具名" in message for message in debug_collector.messages)

--- a/tests/engine/test_sse_parser.py
+++ b/tests/engine/test_sse_parser.py
@@ -461,43 +461,21 @@ async def test_handle_tool_call_delta_covers_missing_index_and_debug_logs(monkey
         running_config=_RunningConfigStub(debug_tool_delta=True),
     )
 
-    # 1. 验证 Gemini 兼容模式下的 index 推断行为
-    # 1.1 携带新 id 但无 index -> 推断为 index 0
-    events_infer_1 = await _collect_events(parser._handle_tool_call_delta({
-        "id": "tc_infer_1",
-        "function": {"name": "tool_1", "arguments": ""}
-    }))
-    assert len(events_infer_1) == 1
-    assert events_infer_1[0].type == EventType.TOOL_CALL_START
-    
-    # 1.2 无 id 无 index -> 归入最后一个活跃条目 (index 0)
-    events_infer_2 = await _collect_events(parser._handle_tool_call_delta({
-        "function": {"arguments": "{"}
-    }))
-    assert len(events_infer_2) == 1
-    assert events_infer_2[0].type == EventType.TOOL_CALL_DELTA
-    assert events_infer_2[0].data["arguments_delta"] == "{"
-    
-    # 1.3 携带另一个新 id 无 index -> 推断为 index 1
-    events_infer_3 = await _collect_events(parser._handle_tool_call_delta({
-        "id": "tc_infer_2",
-        "function": {"name": "tool_2", "arguments": ""}
-    }))
-    assert len(events_infer_3) == 1
-    assert events_infer_3[0].type == EventType.TOOL_CALL_START
-    
-    assert any("工具调用增量 index 缺失" in message for message in debug_collector.messages)
+    missing_index_events = await _collect_events(parser._handle_tool_call_delta({"id": "tc_1"}))
 
-    # 2. 验证常规带有 index 时的日志行为
     full_events = await _collect_events(
         parser._handle_tool_call_delta(
             {
-                "index": 2,
-                "id": "tc_normal",
+                "index": 0,
+                "id": "tc_2",
                 "function": {"name": "read_file", "arguments": "{}"},
             }
         )
     )
+
+    assert missing_index_events == []
+    assert any("index" in message and ("缺失" in message or "异常" in message) for message in warn_collector.messages)
+
     assert [event.type for event in full_events] == [EventType.TOOL_CALL_START, EventType.TOOL_CALL_DELTA]
     assert any("记录 tool_call_id" in message for message in debug_collector.messages)
     assert any("记录工具名" in message for message in debug_collector.messages)
@@ -1187,3 +1165,80 @@ async def test_indented_data_line_not_parsed() -> None:
     assert len(content_deltas) == 1
     assert content_deltas[0].data == "visible"
     assert result.done_received is True
+
+
+@pytest.mark.asyncio
+async def test_parse_stream_gemini_parallel_tool_calls_without_index() -> None:
+    """验证 Gemini 风格的并行工具调用（无 index 字段）在 parse_stream 层正确解析。
+
+    Gemini OpenAI 兼容模式不发 index 字段，每个 tool call 在一个 delta 中一次给全。
+    本测试模拟一个 chunk 内并行调用 3 个工具的场景，验证上游自动补齐 index 后
+    下游正确组装出 3 个独立的工具调用。
+    """
+    parser = SSEStreamParser(
+        name="gemini",
+        request_id="req_gemini_parallel",
+        running_config=_RunningConfigStub(),
+    )
+
+    # 模拟 Gemini 并行 3 个 tool call（真实抓包结构，无 index 字段）
+    payload = json.dumps({
+        "choices": [{
+            "delta": {
+                "tool_calls": [
+                    {
+                        "id": "function-call-001",
+                        "type": "function",
+                        "function": {
+                            "name": "search_web",
+                            "arguments": '{"query":"杭州天气"}',
+                        },
+                    },
+                    {
+                        "id": "function-call-002",
+                        "type": "function",
+                        "function": {
+                            "name": "search_web",
+                            "arguments": '{"query":"北京天气"}',
+                        },
+                    },
+                    {
+                        "id": "function-call-003",
+                        "type": "function",
+                        "function": {
+                            "name": "search_web",
+                            "arguments": '{"query":"上海天气"}',
+                        },
+                    },
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }],
+    })
+
+    response = _ResponseStub([
+        f"data: {payload}\n\n".encode("utf-8"),
+        b"data: [DONE]\n\n",
+    ])
+
+    events = await _collect_events(_parse_stream(parser, response))
+    result = parser.get_result()
+
+    # 应产出 3 组 tool_call_start + tool_call_delta 事件
+    start_events = [e for e in events if e.type == EventType.TOOL_CALL_START]
+    delta_events = [e for e in events if e.type == EventType.TOOL_CALL_DELTA]
+    assert len(start_events) == 3
+    assert len(delta_events) == 3
+
+    # 验证组装结果：3 个独立的工具调用，各自参数正确
+    assert len(result.tool_calls) == 3
+    assert result.tool_calls[0]["id"] == "function-call-001"
+    assert result.tool_calls[0]["arguments"] == {"query": "杭州天气"}
+    assert result.tool_calls[1]["id"] == "function-call-002"
+    assert result.tool_calls[1]["arguments"] == {"query": "北京天气"}
+    assert result.tool_calls[2]["id"] == "function-call-003"
+    assert result.tool_calls[2]["arguments"] == {"query": "上海天气"}
+
+    # 无 protocol_errors 和 validation_errors
+    assert result.protocol_errors == []
+    assert result.validation_errors == []


### PR DESCRIPTION
## Summary

  Closes #56

  - **Gemini OpenAI 兼容模式**不携带 `index` 字段：基于 buffer 状态和 `id` 自动推断归属，替代之前的 fatal
  error。已验证单工具和并行 3 工具场景。
  - **Qwen thinking 模式**在 tool call 结束时发送 `arguments: null`
  尾包：安全忽略，等同于字段不存在，替代之前的 protocol_error。
  - 两处改动均为纯增量 fallback 分支，标准 OpenAI 协议（`index: int` + `arguments:
  str`）的处理路径不受影响。

  ## 涉及文件

  | 文件 | 改动 |
  |------|------|
  | `dayu/engine/sse_parser.py` | `_handle_tool_call_delta` 中 index 推断 + arguments null 兼容 |
  | `tests/engine/test_sse_parser.py` | 更新测试覆盖三种 index 推断场景（新 id 新建 / 无 id 归入 / 多 id
  并行） |

  ## Test plan

  - [x] `dayu-cli prompt "周末杭州天气" --model-name gemini-2.5-flash` 正常完成工具调用
  - [x] `dayu-cli prompt "总结苹果最新财报的主要风险" --model-name qwen3-thinking` 正常完成多轮工具调用
  - [x] Gemini 并行调用 3 个工具正确推断 index 0/1/2
  - [x] pyright: 0 errors, 0 warnings
  - [x] pytest test_sse_parser: 30/30 passed
  - [x] 全量 pytest: 4509 passed, 6 skipped
  - [ ] DeepSeek / MiMo / GPT 等标准 provider 的 tool calling 回归验证

## 注意点

- Open AI 协议兼容逻辑代码会越来越臃肿
- 针对当前 Provider 的个性化兼容，可能会造成对未来未知 Provider 的影响或者对其他当前正常 Provider 的隐性伤害
