### PR TITLE
fix(windows): docling 后端排序 + debug 日志 + chcp 65001 中文 REM 规避

### DIFF
--- a/dayu/docling_runtime.py
+++ b/dayu/docling_runtime.py
@@ -12,12 +12,17 @@
 
 - 若显式设置环境变量 ``DAYU_DOCLING_DEVICE``，则以该值为准。
 - 若未显式设置，则默认使用 ``auto``。
-- 转换尝试链按下列顺序展开：
-  1. ``backend=docling-parse, device=resolved``：默认行为，保留现状。
-  2. ``backend=pypdfium2, device=resolved``：专治 docling-parse 解析
-     阶段把合法 PDF 判 invalid 的故障。
-  3. ``backend=docling-parse, device=cpu``：仅当 ``resolved == auto``
-     时追加，专治加速器栈在 ``auto`` 阶段崩溃的故障。
+- 转换尝试链按平台展开：
+  - 非 Windows（macOS / Linux）：
+    1. ``backend=docling-parse, device=resolved``：保留现状，覆盖正常路径。
+    2. ``backend=pypdfium2, device=resolved``：救 docling-parse 解析失败。
+    3. ``backend=docling-parse, device=cpu``：仅当 ``resolved == auto`` 追加，
+       救加速器栈在 ``auto`` 阶段崩溃的故障。
+  - Windows：
+    1. ``backend=pypdfium2, device=resolved``：优先，规避 docling-parse 在
+       Windows 上的 ``std::bad_alloc`` 与 mbcs 路径编码两类已知崩溃。
+    2. ``backend=docling-parse, device=resolved``：兜底，给特殊文档保留机会。
+    3. ``backend=docling-parse, device=cpu``：仅当 ``resolved == auto`` 追加。
 - 任意一档成功即返回；全部失败时抛出最后一次异常，并以**首次**失败
   作为 ``__cause__``，便于排查首因。
 """
@@ -25,6 +30,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
@@ -49,6 +55,7 @@ _SUPPORTED_DOCLING_BACKENDS = frozenset({_DOCLING_PARSE_BACKEND_NAME, _PYPDFIUM2
 _TABLE_MODE_ACCURATE = "accurate"
 _TABLE_MODE_FAST = "fast"
 _MODULE = __name__
+_WINDOWS_PLATFORM_NAME = "win32"
 _TResult = TypeVar("_TResult")
 # Protocol 返回值需要协变，才能让更具体的转换结果回调安全替换更宽的调用点。
 _TResultCovariant = TypeVar("_TResultCovariant", covariant=True)
@@ -194,15 +201,29 @@ def resolve_docling_device_name() -> str:
     return _AUTO_DEVICE_NAME
 
 
+def _is_windows_platform() -> bool:
+    """判断当前进程是否运行在 Windows 平台。
+
+    Args:
+        无。
+
+    Returns:
+        True 表示当前为 Windows，False 表示 macOS / Linux 等其它平台。
+
+    Raises:
+        无。
+    """
+
+    return sys.platform == _WINDOWS_PLATFORM_NAME
+
+
 def _plan_conversion_attempts(resolved_device_name: str) -> list[_DoclingConversionAttempt]:
     """按二维回退策略生成 Docling 转换尝试链。
 
-    顺序设计：
-
-    1. ``(docling-parse, resolved)``：保留现状，覆盖正常路径。
-    2. ``(pypdfium2, resolved)``：救 docling-parse 解析失败（已实证）。
-    3. ``(docling-parse, cpu)``：仅当 ``resolved == auto`` 时追加，
-       救加速器栈在 ``auto`` 阶段崩溃的故障。
+    Windows 上 docling-parse 后端在某些 PDF 上会在 C++ 层抛 ``std::bad_alloc``，
+    且对 mbcs 路径编码也存在已知 bug；为减少首次失败概率与日志刷屏，
+    Windows 平台把 ``pypdfium2`` 提到首位，``docling-parse`` 作为兜底。
+    其它平台保持 ``docling-parse`` 优先以维持既有解析质量。
 
     Args:
         resolved_device_name: 已规范化的 Docling 设备名。
@@ -214,16 +235,28 @@ def _plan_conversion_attempts(resolved_device_name: str) -> list[_DoclingConvers
         无。
     """
 
-    attempts: list[_DoclingConversionAttempt] = [
-        _DoclingConversionAttempt(
-            backend_name=_DOCLING_PARSE_BACKEND_NAME,
-            device_name=resolved_device_name,
-        ),
-        _DoclingConversionAttempt(
-            backend_name=_PYPDFIUM2_BACKEND_NAME,
-            device_name=resolved_device_name,
-        ),
-    ]
+    if _is_windows_platform():
+        attempts: list[_DoclingConversionAttempt] = [
+            _DoclingConversionAttempt(
+                backend_name=_PYPDFIUM2_BACKEND_NAME,
+                device_name=resolved_device_name,
+            ),
+            _DoclingConversionAttempt(
+                backend_name=_DOCLING_PARSE_BACKEND_NAME,
+                device_name=resolved_device_name,
+            ),
+        ]
+    else:
+        attempts = [
+            _DoclingConversionAttempt(
+                backend_name=_DOCLING_PARSE_BACKEND_NAME,
+                device_name=resolved_device_name,
+            ),
+            _DoclingConversionAttempt(
+                backend_name=_PYPDFIUM2_BACKEND_NAME,
+                device_name=resolved_device_name,
+            ),
+        ]
     if resolved_device_name == _AUTO_DEVICE_NAME:
         attempts.append(
             _DoclingConversionAttempt(
@@ -433,9 +466,27 @@ def run_docling_pdf_conversion(
     resolved_device_name = resolve_docling_device_name()
     attempts = _plan_conversion_attempts(resolved_device_name)
     total_attempts = len(attempts)
+    Log.debug(
+        (
+            "Docling 转换尝试链装配完成: "
+            f"platform={'windows' if _is_windows_platform() else 'unix'} "
+            f"resolved_device={resolved_device_name} "
+            f"total_attempts={total_attempts} "
+            f"chain={[(a.backend_name, a.device_name) for a in attempts]}"
+        ),
+        module=_MODULE,
+    )
     first_failure: Exception | None = None
     last_failure: Exception | None = None
     for attempt_index, attempt in enumerate(attempts):
+        Log.debug(
+            (
+                "Docling 转换尝试启动: "
+                f"attempt={attempt_index + 1}/{total_attempts} "
+                f"backend={attempt.backend_name} device={attempt.device_name}"
+            ),
+            module=_MODULE,
+        )
         converter = _build_attempt_converter(
             attempt,
             do_ocr=do_ocr,
@@ -446,7 +497,7 @@ def run_docling_pdf_conversion(
             total_attempts=total_attempts,
         )
         try:
-            return convert_operation(converter)
+            result = convert_operation(converter)
         except Exception as exc:
             last_failure = exc
             if first_failure is None:
@@ -466,6 +517,16 @@ def run_docling_pdf_conversion(
                     module=_MODULE,
                 )
                 continue
+        else:
+            Log.debug(
+                (
+                    "Docling 转换尝试成功: "
+                    f"attempt={attempt_index + 1}/{total_attempts} "
+                    f"backend={attempt.backend_name} device={attempt.device_name}"
+                ),
+                module=_MODULE,
+            )
+            return result
     # 全链失败：保留首次失败为 __cause__，便于排查首因。
     assert last_failure is not None
     if first_failure is not None and first_failure is not last_failure:

--- a/dayu/fins/cli_support.py
+++ b/dayu/fins/cli_support.py
@@ -2078,13 +2078,16 @@ def _build_upload_script_header(
     """
 
     if script_platform == "windows":
+        # 注意：Windows 分支故意不在头部放置含中文的 `REM 重新生成脚本：` 注释。
+        # cmd.exe 在 `chcp 65001` 下解析批处理时，若某行末尾为多字节字符，
+        # 会吃掉紧随其后命令的若干字节（典型表现是下一行 `python -m dayu.cli`
+        # 被截断为 `yu.cli`，触发 "is not recognized" 报错）。
+        # 重生成命令注释由 `_build_upload_script_footer` 放在脚本末尾，
+        # 那里之后没有任何要执行的命令，从结构上规避该缺陷。
         return [
             "@echo off",
             "chcp 65001 > nul",
             "setlocal",
-            "",
-            "REM 重新生成脚本：",
-            f"REM {regenerate_command}",
             "",
         ]
     shebang = "#!/bin/zsh" if script_platform == "mac" else "#!/usr/bin/env bash"
@@ -2095,6 +2098,33 @@ def _build_upload_script_header(
         "# 重新生成脚本：",
         f"# {regenerate_command}",
         "",
+    ]
+
+
+def _build_upload_script_footer(
+    *,
+    script_platform: str,
+    regenerate_command: str,
+) -> list[str]:
+    """构建批量上传脚本尾部。
+
+    Args:
+        script_platform: 脚本平台标识。
+        regenerate_command: 重生成命令。
+
+    Returns:
+        脚本尾部行列表；非 Windows 平台返回空列表（重生成注释已写在头部）。
+
+    Raises:
+        无。
+    """
+
+    if script_platform != "windows":
+        return []
+    return [
+        "",
+        "REM 重新生成脚本：",
+        f"REM {regenerate_command}",
     ]
 
 
@@ -2137,6 +2167,12 @@ def _write_upload_script(
             lines.append("echo 没有识别到可上传的文件")
         else:
             lines.append("echo '没有识别到可上传的文件'")
+    lines.extend(
+        _build_upload_script_footer(
+            script_platform=script_platform,
+            regenerate_command=regenerate_command,
+        )
+    )
     output_script.parent.mkdir(parents=True, exist_ok=True)
     if script_platform == "windows":
         # cmd.exe 按当前代码页解释批处理；中文路径需脚本头先执行 `chcp 65001`，

--- a/tests/engine/test_docling_runtime.py
+++ b/tests/engine/test_docling_runtime.py
@@ -200,6 +200,8 @@ def _install_recording_builder(
         return _FakeConverter(backend_name=backend_name, device_name=device_name)
 
     monkeypatch.setattr("dayu.docling_runtime.build_docling_pdf_converter", _build_converter)
+    # 默认按非 Windows 平台展开尝试链；Windows 行为由专项用例显式覆盖。
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: False)
 
 
 def test_run_docling_pdf_conversion_recovers_via_pypdfium2_after_parse_failure(
@@ -443,6 +445,7 @@ def test_run_docling_pdf_conversion_wraps_initialization_failure(
     """
 
     monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "auto")
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: False)
 
     def _raise_unexpected_init_error(**_: str | bool) -> object:
         """模拟初始化阶段的未知异常。
@@ -506,6 +509,7 @@ def test_run_docling_pdf_conversion_wraps_followup_initialization_failure(
     """
 
     monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "auto")
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: False)
 
     def _build_converter(**kwargs: str | bool) -> _FakeConverter:
         """模拟首档成功、第二档（pypdfium2/auto）初始化失败。
@@ -637,3 +641,99 @@ def test_convert_pdf_bytes_with_docling_uses_document_stream(
     assert isinstance(captured_source.stream, BytesIO)
     assert captured_source.stream.getvalue() == b"hello-bytes"
     assert captured["pipeline"] == (True, True, "accurate", True)
+
+
+def test_run_docling_pdf_conversion_on_windows_prefers_pypdfium2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """验证 Windows 平台尝试链把 pypdfium2 提到首位。
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    build_log: list[tuple[str, str]] = []
+    monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "auto")
+    _install_recording_builder(monkeypatch, build_log)
+    # 覆盖 _install_recording_builder 内部默认的非 Windows stub，模拟 Windows。
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: True)
+
+    def _convert(converter: object) -> str:
+        """首档（pypdfium2）即成功。
+
+        Args:
+            converter: Docling 转换器对象。
+
+        Returns:
+            成功标记字符串。
+
+        Raises:
+            无。
+        """
+
+        del converter
+        return "ok"
+
+    result = run_docling_pdf_conversion(_convert)
+
+    assert result == "ok"
+    # Windows 链：pypdfium2 优先，docling-parse 兜底，auto 时再追加 (parse, cpu)
+    # 首档命中即返回，build_log 仅有一条 pypdfium2 记录。
+    assert build_log == [("pypdfium2", "auto")]
+
+
+def test_run_docling_pdf_conversion_on_windows_full_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """验证 Windows 平台 auto 设备时全链按 (pypdfium2,auto)->(parse,auto)->(parse,cpu) 展开。
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    build_log: list[tuple[str, str]] = []
+    monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "auto")
+    _install_recording_builder(monkeypatch, build_log)
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: True)
+
+    def _convert(converter: object) -> str:
+        """前两档失败、第三档（parse, cpu）成功。
+
+        Args:
+            converter: Docling 转换器对象。
+
+        Returns:
+            成功标记字符串。
+
+        Raises:
+            RuntimeError: 在 cpu 之前固定抛出。
+        """
+
+        fake_converter = cast(_FakeConverter, converter)
+        if fake_converter.device_name == "cpu":
+            return "ok"
+        raise RuntimeError(
+            f"failure@{fake_converter.backend_name}/{fake_converter.device_name}"
+        )
+
+    result = run_docling_pdf_conversion(_convert)
+
+    assert result == "ok"
+    assert build_log == [
+        ("pypdfium2", "auto"),
+        ("docling-parse", "auto"),
+        ("docling-parse", "cpu"),
+    ]
+

--- a/tests/fins/test_cli_helpers_coverage.py
+++ b/tests/fins/test_cli_helpers_coverage.py
@@ -650,6 +650,49 @@ def test_windows_script_helpers(tmp_path: Path) -> None:
     assert "python -m dayu.cli upload_filing --ticker AAPL %*" in text
     # Windows 批处理必须使用 CRLF 行尾，避免中文 UTF-8 多字节字符被解析器错位
     assert script_path.read_bytes().count(b"\r\n") >= 5
+    # 回归保护：cmd.exe 在 chcp 65001 下，若行末是 UTF-8 多字节字符，会吞掉
+    # 紧随其后命令的若干字节（典型表现是 `python -m dayu.cli` 被截断为 `yu.cli`）。
+    # 因此 regenerate 注释必须放在最后一条可执行命令之后，禁止出现在头部。
+    lines = text.splitlines()
+    regenerate_line_index = next(
+        index for index, line in enumerate(lines) if line.startswith("REM python -m dayu.cli upload_filings_from")
+    )
+    last_command_index = max(
+        index for index, line in enumerate(lines) if line.startswith("python -m dayu.cli")
+    )
+    assert regenerate_line_index > last_command_index
+
+
+@pytest.mark.unit
+def test_windows_script_regenerate_with_chinese_path_does_not_precede_command(tmp_path: Path) -> None:
+    """回归测试：含中文路径的 regenerate 注释不得出现在任何可执行命令之前。
+
+    根因：cmd.exe 在 ``chcp 65001`` 代码页下解析 .cmd 时，若某行末尾为 UTF-8
+    多字节字符（如中文），会吞掉紧随其后命令开头的若干字节。本测试通过断言
+    "regenerate 注释行的字节偏移大于所有 ``python -m dayu.cli`` 命令行的字节偏移"
+    来保证脚本结构不会再次踩到该缺陷。
+    """
+
+    script_path = tmp_path / "upload_filings_603699.cmd"
+    module._write_upload_script(
+        output_script=script_path,
+        commands=[
+            'python -m dayu.cli upload_filing --ticker 603699 --files "C:\\tmp\\纽威股份 2024年度报告.pdf"',
+        ],
+        regenerate_command=(
+            "python -m dayu.cli upload_filings_from --ticker 603699 "
+            "--from C:\\tmp\\_603699纽威股份 --company-name 纽威股份"
+        ),
+        script_platform="windows",
+    )
+    raw = script_path.read_bytes()
+    regenerate_marker = b"REM python -m dayu.cli upload_filings_from"
+    command_marker = b"python -m dayu.cli upload_filing "
+    regenerate_offset = raw.find(regenerate_marker)
+    last_command_offset = raw.rfind(command_marker)
+    assert regenerate_offset != -1
+    assert last_command_offset != -1
+    assert regenerate_offset > last_command_offset
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

两个 Windows 平台特定的稳定性修复，合并到一条分支：

- **docling 后端排序**：实测 docling-parse 在 Windows 上对部分长 PDF 会在 C++ 层抛 `std::bad_alloc` 并刷屏，无法被 Python 重试链捕获。改为 Windows 平台把 `pypdfium2` 提到尝试链首位，从源头规避；其它平台保持 docling-parse 优先以维持解析质量。
- **docling 全程 debug 日志**：在 `run_docling_pdf_conversion` 装配链后、每次 attempt 真正 convert 之前、以及成功后各打一条 `Log.debug`，便于排查实际走的是哪一档。
- **chcp 65001 cmd 缺陷规避**（已有 commit `0b52eab`）：规避 `chcp 65001` 下中文 `REM` 吞下一行命令前缀的 cmd.exe 缺陷。

## 关键改动

- `dayu/docling_runtime.py`：新增 `_is_windows_platform()` seam；`_plan_conversion_attempts` 按平台分支；`run_docling_pdf_conversion` 加 debug 日志。
- `tests/engine/test_docling_runtime.py`：`_install_recording_builder` 默认 stub 平台为非 Windows；新增两条 Windows 专项用例覆盖首档命中与全链回退。

## Test plan

- [x] `pytest tests/engine/test_docling_runtime.py` (15 passed)
- [x] `pyright dayu/docling_runtime.py` (0 errors)
- [ ] Windows 上手动验证 \`纽威股份 2024年度报告.pdf\` 上传：首档命中 pypdfium2，无 std::bad_alloc 刷屏
- [ ] CI 全平台跑通

🤖 Generated with [Claude Code](https://claude.com/claude-code)