### PR TITLE
fix: 添加模型运行时参数覆盖功能以修复stream_idle_timeout设置不生效问题

### DIFF
--- a/dayu/execution/options.py
+++ b/dayu/execution/options.py
@@ -13,7 +13,7 @@ from dayu.contracts.execution_options import (
     ExecutionOptions,
     TraceSettings,
 )
-from dayu.contracts.model_config import ConversationMemoryRuntimeHints, ModelConfig
+from dayu.contracts.model_config import ConversationMemoryRuntimeHints, ModelConfig, RunnerType, normalize_runner_type
 from dayu.contracts.tool_configs import (
     DocToolLimits,
     FinsToolLimits,
@@ -1182,6 +1182,55 @@ def resolve_conversation_memory_settings(
     return settings
 
 
+def apply_model_runner_runtime_overrides(
+    *,
+    resolved_execution_options: ResolvedExecutionOptions,
+    model_config: ModelConfig,
+) -> ResolvedExecutionOptions:
+    """按模型配置覆盖 Runner 运行时参数。
+
+    Args:
+        resolved_execution_options: 已解析的执行选项基线。
+        model_config: 当前模型配置。
+
+    Returns:
+        应用模型级 Runner 覆盖后的执行选项。
+
+    Raises:
+        无。
+    """
+
+    runner_type = normalize_runner_type(model_config.get("runner_type"))
+    if runner_type != RunnerType.OPENAI_COMPATIBLE:
+        return resolved_execution_options
+    runner_running_config = resolved_execution_options.runner_running_config
+    if not isinstance(runner_running_config, OpenAIRunnerRuntimeConfig):
+        return resolved_execution_options
+    stream_idle_timeout = model_config.get("stream_idle_timeout")
+    stream_idle_heartbeat_sec = model_config.get("stream_idle_heartbeat_sec")
+    merged_stream_idle_timeout = (
+        float(stream_idle_timeout)
+        if isinstance(stream_idle_timeout, int | float) and not isinstance(stream_idle_timeout, bool)
+        else runner_running_config.stream_idle_timeout
+    )
+    merged_stream_idle_heartbeat_sec = (
+        float(stream_idle_heartbeat_sec)
+        if isinstance(stream_idle_heartbeat_sec, int | float) and not isinstance(stream_idle_heartbeat_sec, bool)
+        else runner_running_config.stream_idle_heartbeat_sec
+    )
+    next_runner_running_config = replace(
+        runner_running_config,
+        stream_idle_timeout=merged_stream_idle_timeout,
+        stream_idle_heartbeat_sec=merged_stream_idle_heartbeat_sec,
+    )
+    if next_runner_running_config == runner_running_config:
+        return resolved_execution_options
+    return replace(
+        resolved_execution_options,
+        runner_running_config=next_runner_running_config,
+    )
+
+
 def _resolve_trace_output_dir(path_value: str | Path, *, workspace_dir: Path) -> Path:
     """解析 trace 输出目录。"""
 
@@ -1483,6 +1532,7 @@ __all__ = [
     "deserialize_execution_options_snapshot",
     "merge_execution_options",
     "normalize_temperature",
+    "apply_model_runner_runtime_overrides",
     "resolve_scene_temperature",
     "resolve_scene_execution_options",
     "resolve_conversation_memory_settings",

--- a/dayu/host/scene_preparer.py
+++ b/dayu/host/scene_preparer.py
@@ -37,6 +37,7 @@ from dayu.execution.runtime_config import build_agent_running_config_from_snapsh
 from dayu.execution.options import (
     ConversationMemorySettings,
     ResolvedExecutionOptions,
+    apply_model_runner_runtime_overrides,
     resolve_web_tools_config_from_toolset_configs,
     resolve_scene_execution_options,
     resolve_scene_temperature,
@@ -581,6 +582,10 @@ class DefaultScenePreparer(ScenePreparationProtocol):
                 if build_toolset_config_snapshot("web", effective_web_tools_config) is not None
                 else (),
             ),
+        )
+        resolved_options = apply_model_runner_runtime_overrides(
+            resolved_execution_options=resolved_options,
+            model_config=model_config,
         )
         agent_create_args = build_agent_create_args(
             resolved_execution_options=resolved_options,

--- a/dayu/services/scene_execution_acceptance.py
+++ b/dayu/services/scene_execution_acceptance.py
@@ -19,6 +19,7 @@ from dayu.execution.runtime_config import build_agent_running_config_snapshot, b
 from dayu.execution.options import (
     ExecutionOptions,
     ResolvedExecutionOptions,
+    apply_model_runner_runtime_overrides,
     resolve_scene_temperature,
     resolve_scene_execution_options,
 )
@@ -151,7 +152,10 @@ class SceneExecutionAcceptancePreparer:
             model_config=model_config,
         )
         resolved_execution_options = replace(
-            resolved_execution_options,
+            apply_model_runner_runtime_overrides(
+                resolved_execution_options=resolved_execution_options,
+                model_config=model_config,
+            ),
             conversation_memory_settings=conversation_memory_settings,
         )
         accepted_scene = AcceptedSceneExecution(

--- a/tests/application/test_agent_builder_extra.py
+++ b/tests/application/test_agent_builder_extra.py
@@ -86,6 +86,43 @@ def test_build_agent_create_args_maps_execution_options_to_openai_runner_params(
 
 
 @pytest.mark.unit
+def test_build_agent_create_args_uses_resolved_runner_running_config_snapshot() -> None:
+    """Agent builder 只透传已解析的 runner_running_config，不再理解模型级覆盖细节。"""
+
+    resolved = ResolvedExecutionOptions(
+        model_name="resolved-model",
+        runner_running_config=OpenAIRunnerRuntimeConfig(
+            tool_timeout_seconds=12.0,
+            stream_idle_timeout=120.0,
+            stream_idle_heartbeat_sec=10.0,
+        ),
+        agent_running_config=AgentRuntimeConfig(max_iterations=7),
+        trace_settings=TraceSettings(enabled=False, output_dir=Path("/tmp/trace")),
+        temperature=0.4,
+        conversation_memory_settings=ConversationMemorySettings(),
+        toolset_configs=(ToolsetConfigSnapshot("doc", payload={"limit": 1}),),
+    )
+    model_config = cast(
+        dict[str, object],
+        {
+            "runner_type": RunnerType.OPENAI_COMPATIBLE,
+            "endpoint_url": "http://example.com",
+            "model": "provider-model",
+            "headers": {"Authorization": "Bearer token"},
+        },
+    )
+
+    created = module.build_agent_create_args(
+        resolved_execution_options=resolved,
+        model_config=cast(Any, model_config),
+    )
+
+    assert created.runner_running_config.get("stream_idle_timeout") == pytest.approx(120.0)
+    assert created.runner_running_config.get("stream_idle_heartbeat_sec") == pytest.approx(10.0)
+    assert created.runner_running_config.get("tool_timeout_seconds") == pytest.approx(12.0)
+
+
+@pytest.mark.unit
 def test_build_async_agent_delegates_runner_and_running_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """构造 AsyncAgent 时应把 runner、运行配置和追踪身份完整透传。"""
 

--- a/tests/application/test_scene_execution.py
+++ b/tests/application/test_scene_execution.py
@@ -42,6 +42,7 @@ from dayu.execution.runtime_config import (
     OpenAIRunnerRuntimeConfig,
 )
 from dayu.execution.options import (
+    apply_model_runner_runtime_overrides,
     ConversationMemorySettings,
     DocToolLimits,
     ExecutionOptions,
@@ -398,6 +399,44 @@ def test_resolve_scene_execution_options_accepts_toolset_config_overrides() -> N
     assert resolved_doc_limits.get_sections_max == 999
     assert resolved_fins_limits.read_section_max_chars == 1200
     assert resolved_web_config.fetch_truncate_chars == 12345
+
+
+def test_apply_model_runner_runtime_overrides_prefers_model_stream_idle_values() -> None:
+    """模型级 stream idle 配置应覆盖已解析 execution options 的 runner 配置。"""
+
+    resolved_options = ResolvedExecutionOptions(
+        model_name="test-model",
+        runner_running_config=OpenAIRunnerRuntimeConfig(
+            tool_timeout_seconds=45.0,
+            stream_idle_timeout=120.0,
+            stream_idle_heartbeat_sec=10.0,
+        ),
+        agent_running_config=AgentRuntimeConfig(),
+        toolset_configs=_build_toolset_configs(
+            doc_tool_limits=DocToolLimits(),
+            fins_tool_limits=FinsToolLimits(),
+            web_tools_config=WebToolsConfig(provider="off"),
+        ),
+        trace_settings=TraceSettings(enabled=False, output_dir=Path("/tmp/trace")),
+        conversation_memory_settings=ConversationMemorySettings(),
+    )
+
+    updated = apply_model_runner_runtime_overrides(
+        resolved_execution_options=resolved_options,
+        model_config=cast(
+            ModelConfig,
+            {
+                "runner_type": "openai_compatible",
+                "stream_idle_timeout": 1800.0,
+                "stream_idle_heartbeat_sec": 3.0,
+            },
+        ),
+    )
+
+    runner_config = cast(OpenAIRunnerRuntimeConfig, updated.runner_running_config)
+    assert runner_config.tool_timeout_seconds == pytest.approx(45.0)
+    assert runner_config.stream_idle_timeout == pytest.approx(1800.0)
+    assert runner_config.stream_idle_heartbeat_sec == pytest.approx(3.0)
 
 
 def test_resolve_scene_temperature_prefers_explicit_override() -> None:


### PR DESCRIPTION
- 在 `dayu/execution/options.py` 中新增 `apply_model_runner_runtime_overrides` 函数，用于根据模型配置覆盖运行时参数。
- 更新 `DefaultScenePreparer` 和 `SceneExecutionAcceptancePreparer` 类，调用新函数以应用模型级的运行时参数。
- 增加单元测试，验证覆盖逻辑的正确性，确保模型配置的 `stream_idle_timeout` 和 `stream_idle_heartbeat_sec` 能正确应用于已解析的执行选项。