### PR TITLE
fix(engine): SSE tool call quirk follow-up — 可观测性 + 测试加强 + docstring 同步

### DIFF
--- a/dayu/engine/sse_parser.py
+++ b/dayu/engine/sse_parser.py
@@ -486,6 +486,13 @@ class SSEStreamParser:
         """
         解析单个 SSE payload（data 行内容），产出内容与工具调用增量事件。
 
+        非标 provider 兼容：
+            遍历 ``tool_calls`` 数组时，若某条目缺失 ``index`` 字段（如 Gemini
+            OpenAI 兼容模式），用 enumerate 下标补齐后再下发到
+            ``_handle_tool_call_delta``。该策略依赖 OpenAI 协议设计自洽性——
+            任何 provider 若做跨 chunk 增量必然提供 index 归属标识，因此
+            "无 index" 场景下 enumerate 下标等价于协议层应有的 index。
+
         Args:
             payload: SSE data 行载荷（JSON 字符串）。
 
@@ -605,7 +612,19 @@ class SSEStreamParser:
                     continue
                 # 兼容不发 index 的 provider（如 Gemini OpenAI 兼容模式），
                 # 用数组下标补齐，使下游 _handle_tool_call_delta 无需特殊处理。
+                # 该补齐依赖 OpenAI 协议自洽性：任何 provider 若做跨 chunk 增量，
+                # 必然提供 index 归属标识；因此 "无 index" 场景下 enumerate 下标
+                # 等价于协议层应有的 index。
                 if "index" not in tc:
+                    if self._running_config.debug_tool_delta:
+                        Log.debug(
+                            (
+                                f"{self._log_prefix} tool_call 缺失 index，"
+                                f"使用 enumerate 下标 {index} 补齐"
+                                f"（id={tc.get('id')!r}）"
+                            ),
+                            module=MODULE,
+                        )
                     tc = {**tc, "index": index}
                 async for event in self._handle_tool_call_delta(tc):
                     yield event
@@ -614,11 +633,25 @@ class SSEStreamParser:
         """
         处理单个工具调用增量（从 tool_calls 数组中的一项）。
 
+        本函数严格按 OpenAI 标准协议处理 tool call delta：
+        - 要求 ``tc`` 必须包含合法的 ``index: int``；缺失或类型异常视为协议错误。
+          非标 provider（如 Gemini OpenAI 兼容模式）不发 index 的兼容由上游
+          ``_handle_payload`` 在遍历 tool_calls 数组时用 enumerate 下标补齐后再
+          传入，本函数不做 fallback 推断。
+        - ``function.arguments`` 允许为字符串或 ``None``；``None`` 视为字段不存在
+          安全忽略（兼容 Qwen thinking 模式在 tool call 结束帧发送
+          ``arguments: null``）。其它非字符串类型仍按协议错误处理。
+
         Args:
-            tc: 工具调用增量字典（含 index、id、function 等）。
+            tc: 工具调用增量字典，标准字段含 ``index: int``、``id: str``、
+                ``function: {name: str, arguments: str | None}``。
 
         Yields:
-            StreamEvent — tool_call_start、tool_call_delta。
+            StreamEvent: ``tool_call_start``（id + name 就绪时触发一次）、
+            ``tool_call_delta``（每次有 arguments 增量时触发）。
+
+        Raises:
+            不直接抛异常；协议错误通过 ``_record_protocol_error`` 记录到 trace。
         """
         # 获取工具调用索引
         tool_index = tc.get("index")

--- a/tests/engine/test_sse_parser.py
+++ b/tests/engine/test_sse_parser.py
@@ -1239,6 +1239,70 @@ async def test_parse_stream_gemini_parallel_tool_calls_without_index() -> None:
     assert result.tool_calls[2]["id"] == "function-call-003"
     assert result.tool_calls[2]["arguments"] == {"query": "上海天气"}
 
+    # 加强：tool_call_id 互不相同，避免出现"3 个调用 args 都对但 id 被错误合并"
+    ids = {tc["id"] for tc in result.tool_calls}
+    assert len(ids) == 3, f"tool_call_id 出现重复: {ids}"
+
+    # 加强：每个 tool call 的 name 字段都非空且独立保留
+    names = [tc["name"] for tc in result.tool_calls]
+    assert all(name == "search_web" for name in names), f"name 字段错位: {names}"
+
     # 无 protocol_errors 和 validation_errors
     assert result.protocol_errors == []
     assert result.validation_errors == []
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_logs_enumerate_fallback_when_index_missing(
+    monkeypatch: Any,
+) -> None:
+    """验证 enumerate 补齐分支在 ``debug_tool_delta=True`` 时打印可观测日志。
+
+    该日志是 Gemini 行为漂移时唯一的定位线索，不能完全静默。
+
+    Args:
+        monkeypatch: pytest monkeypatch 工具，用于替换 ``Log.debug``。
+    """
+    debug_collector = _LogCollector()
+    monkeypatch.setattr(Log, "debug", debug_collector.debug)
+
+    parser = SSEStreamParser(
+        name="gemini",
+        request_id="req_enumerate_log",
+        running_config=_RunningConfigStub(debug_tool_delta=True),
+    )
+
+    payload = json.dumps({
+        "choices": [{
+            "delta": {
+                "tool_calls": [
+                    {
+                        "id": "function-call-A",
+                        "type": "function",
+                        "function": {"name": "search_web", "arguments": "{}"},
+                    },
+                    {
+                        "id": "function-call-B",
+                        "type": "function",
+                        "function": {"name": "search_web", "arguments": "{}"},
+                    },
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }],
+    })
+
+    response = _ResponseStub([
+        f"data: {payload}\n\n".encode("utf-8"),
+        b"data: [DONE]\n\n",
+    ])
+    await _collect_events(_parse_stream(parser, response))
+
+    fallback_messages = [
+        msg for msg in debug_collector.messages if "缺失 index" in msg and "enumerate" in msg
+    ]
+    assert len(fallback_messages) == 2, (
+        f"期望两条 enumerate fallback 日志，实际: {fallback_messages}"
+    )
+    assert any("下标 0" in msg for msg in fallback_messages)
+    assert any("下标 1" in msg for msg in fallback_messages)


### PR DESCRIPTION
## Summary

PR #57 review follow-up，针对 [#57 review comment](https://github.com/noho/dayu-agent/pull/57#issuecomment-4320911655) 收尾三点：

1. **可观测性**：`_handle_payload` 中 enumerate 补齐 index 的分支新增 `Log.debug`（受 `debug_tool_delta` 开关控制），日志中带数组下标 + tc.id。Gemini 当前行为下静默推断没问题，但行为漂移时这是唯一定位线索。
2. **测试加强**：`test_parse_stream_gemini_parallel_tool_calls_without_index` 补 `tool_call_id` 集合唯一性 + `name` 字段独立断言，避免出现"args 都对但 id/name 错位"的潜在 bug；新增 `test_handle_payload_logs_enumerate_fallback_when_index_missing` 覆盖日志路径。
3. **docstring 同步**：
   - `_handle_payload` 增加"非标 provider 兼容"段落，引用协议自洽性论证（任何做跨 chunk 增量的 provider 必然提供 index 归属标识）。
   - `_handle_tool_call_delta` 明确"严格协议处理器"语义，标注 index / `arguments: null` 两条契约边界，引用具体 provider 名（Gemini / Qwen thinking）。

## 涉及文件

| 文件 | 改动 |
|------|------|
| `dayu/engine/sse_parser.py` | enumerate fallback debug 日志 + 两处 docstring |
| `tests/engine/test_sse_parser.py` | 并行测试加强 + 新增 fallback 日志测试 |

## Test plan

- [x] `pytest tests/engine/test_sse_parser.py` — 32 passed
- [x] `pytest tests/engine` — 1810 passed, 2 skipped
- [x] `pyright dayu/engine/sse_parser.py tests/engine/test_sse_parser.py` — 0 errors, 0 warnings
- [ ] Gemini / Qwen thinking 真实 provider 端到端冒烟（与 #57 同样限制，可由 owner 在合适时机回归）

## 不在本 PR 范围

- README 同步：本次改动属于语义保持型 follow-up，不改变兼容契约本身，相关 README 没有需要同步的描述。
- Provider quirk 抽象层：#57 注意点中提到的"OpenAI 兼容代码越来越臃肿"长期问题，建议后续单独以 issue 跟进，本 PR 不涉及。

🤖 Generated with [Claude Code](https://claude.com/claude-code)