### PR TITLE
feat(engine): 支持模型级 runner 运行时覆盖（stream_idle_timeout / stream_idle_heartbeat_sec）

### DIFF
--- a/dayu/config/README.md
+++ b/dayu/config/README.md
@@ -207,6 +207,8 @@ Prompt 装配还遵循一条 Prefix Cache 导向的顺序约束：
 | `max_context_tokens` | 最大上下文 token |
 | `extra_payloads` | Provider 扩展请求参数；禁止放入 `model`、`messages`、`temperature`、`stream`、`tools` 等显式字段 |
 
+`stream_idle_timeout` 与 `stream_idle_heartbeat_sec` 是模型级 Runner 运行时覆盖项；Service / Host 在解析 scene 时会把它们写入 `runner_running_config` 快照，最终由 OpenAI 兼容 Runner 使用。
+
 ### 4.2 CLI runner 状态
 
 CLI runner 已彻底禁用，不再允许通过 `llm_models.json` 配置或使用 `runner_type=cli`。

--- a/dayu/execution/options.py
+++ b/dayu/execution/options.py
@@ -13,7 +13,7 @@ from dayu.contracts.execution_options import (
     ExecutionOptions,
     TraceSettings,
 )
-from dayu.contracts.model_config import ConversationMemoryRuntimeHints, ModelConfig
+from dayu.contracts.model_config import ConversationMemoryRuntimeHints, ModelConfig, RunnerType, normalize_runner_type
 from dayu.contracts.tool_configs import (
     DocToolLimits,
     FinsToolLimits,
@@ -63,6 +63,7 @@ _MAX_TEMPERATURE = 2.0
 
 ExecutionOptionsOverrideValue: TypeAlias = str | int | float | bool | None
 ExecutionOptionsOverridePayload: TypeAlias = dict[str, ExecutionOptionsOverrideValue]
+ModelRunnerRuntimeOverrideValue: TypeAlias = str | int | float | bool | None
 
 ExecutionOptionsSnapshotValue: TypeAlias = (
     str
@@ -1182,6 +1183,98 @@ def resolve_conversation_memory_settings(
     return settings
 
 
+def _parse_model_runner_positive_float(
+    value: ModelRunnerRuntimeOverrideValue,
+    *,
+    field_name: str,
+) -> float | None:
+    """解析模型级 Runner 正数秒值。
+
+    Args:
+        value: 模型配置中的原始秒值。
+        field_name: 字段名，仅用于错误提示。
+
+    Returns:
+        解析后的正数秒值；未配置时返回 ``None``。
+
+    Raises:
+        ValueError: 当值不是正有限数值时抛出。
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} 必须是正数")
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError(f"{field_name} 必须是正数")
+        try:
+            normalized = float(stripped)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} 必须是正数") from exc
+    elif isinstance(value, int | float):
+        normalized = float(value)
+    else:
+        raise ValueError(f"{field_name} 必须是正数")
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise ValueError(f"{field_name} 必须是正有限数值")
+    return normalized
+
+
+def apply_model_runner_runtime_overrides(
+    *,
+    resolved_execution_options: ResolvedExecutionOptions,
+    model_config: ModelConfig,
+) -> ResolvedExecutionOptions:
+    """按模型配置覆盖 Runner 运行时参数。
+
+    Args:
+        resolved_execution_options: 已解析的执行选项基线。
+        model_config: 当前模型配置。
+
+    Returns:
+        应用模型级 Runner 覆盖后的执行选项。
+
+    Raises:
+        ValueError: 当 runner_type 或模型级 Runner 运行时配置非法时抛出。
+    """
+
+    runner_type = normalize_runner_type(model_config.get("runner_type"))
+    if runner_type != RunnerType.OPENAI_COMPATIBLE:
+        return resolved_execution_options
+    runner_running_config = resolved_execution_options.runner_running_config
+    if not isinstance(runner_running_config, OpenAIRunnerRuntimeConfig):
+        return resolved_execution_options
+    stream_idle_timeout = _parse_model_runner_positive_float(
+        cast(ModelRunnerRuntimeOverrideValue, model_config.get("stream_idle_timeout")),
+        field_name="stream_idle_timeout",
+    )
+    stream_idle_heartbeat_sec = _parse_model_runner_positive_float(
+        cast(ModelRunnerRuntimeOverrideValue, model_config.get("stream_idle_heartbeat_sec")),
+        field_name="stream_idle_heartbeat_sec",
+    )
+    next_runner_running_config = replace(
+        runner_running_config,
+        stream_idle_timeout=(
+            stream_idle_timeout
+            if stream_idle_timeout is not None
+            else runner_running_config.stream_idle_timeout
+        ),
+        stream_idle_heartbeat_sec=(
+            stream_idle_heartbeat_sec
+            if stream_idle_heartbeat_sec is not None
+            else runner_running_config.stream_idle_heartbeat_sec
+        ),
+    )
+    if next_runner_running_config == runner_running_config:
+        return resolved_execution_options
+    return replace(
+        resolved_execution_options,
+        runner_running_config=next_runner_running_config,
+    )
+
+
 def _resolve_trace_output_dir(path_value: str | Path, *, workspace_dir: Path) -> Path:
     """解析 trace 输出目录。"""
 
@@ -1477,8 +1570,10 @@ __all__ = [
     "ExecutionOptionsOverrideValue",
     "ExecutionOptionsSnapshot",
     "ExecutionOptionsSnapshotValue",
+    "ModelRunnerRuntimeOverrideValue",
     "ResolvedExecutionOptions",
     "TraceSettings",
+    "apply_model_runner_runtime_overrides",
     "build_base_execution_options",
     "deserialize_execution_options_snapshot",
     "merge_execution_options",

--- a/dayu/host/scene_preparer.py
+++ b/dayu/host/scene_preparer.py
@@ -37,6 +37,7 @@ from dayu.execution.runtime_config import build_agent_running_config_from_snapsh
 from dayu.execution.options import (
     ConversationMemorySettings,
     ResolvedExecutionOptions,
+    apply_model_runner_runtime_overrides,
     resolve_web_tools_config_from_toolset_configs,
     resolve_scene_execution_options,
     resolve_scene_temperature,
@@ -581,6 +582,10 @@ class DefaultScenePreparer(ScenePreparationProtocol):
                 if build_toolset_config_snapshot("web", effective_web_tools_config) is not None
                 else (),
             ),
+        )
+        resolved_options = apply_model_runner_runtime_overrides(
+            resolved_execution_options=resolved_options,
+            model_config=model_config,
         )
         agent_create_args = build_agent_create_args(
             resolved_execution_options=resolved_options,

--- a/dayu/services/scene_execution_acceptance.py
+++ b/dayu/services/scene_execution_acceptance.py
@@ -19,6 +19,7 @@ from dayu.execution.runtime_config import build_agent_running_config_snapshot, b
 from dayu.execution.options import (
     ExecutionOptions,
     ResolvedExecutionOptions,
+    apply_model_runner_runtime_overrides,
     resolve_scene_temperature,
     resolve_scene_execution_options,
 )
@@ -151,7 +152,10 @@ class SceneExecutionAcceptancePreparer:
             model_config=model_config,
         )
         resolved_execution_options = replace(
-            resolved_execution_options,
+            apply_model_runner_runtime_overrides(
+                resolved_execution_options=resolved_execution_options,
+                model_config=model_config,
+            ),
             conversation_memory_settings=conversation_memory_settings,
         )
         accepted_scene = AcceptedSceneExecution(

--- a/tests/application/test_scene_execution.py
+++ b/tests/application/test_scene_execution.py
@@ -24,6 +24,9 @@ from dayu.contracts.model_config import ModelConfig, RunnerType
 from dayu.contracts.protocols import PromptToolExecutorProtocol
 from dayu.contracts.toolset_config import ToolsetConfigSnapshot, build_toolset_config_snapshot
 from dayu.services.contract_preparation import prepare_execution_contract
+from dayu.services.conversation_policy_reader import ConversationPolicyReader
+from dayu.services.scene_execution_acceptance import SceneExecutionAcceptancePreparer
+from dayu.services.scene_definition_reader import SceneDefinitionReader
 from dayu.host.agent_builder import build_agent_running_config, build_async_runner
 import dayu.host.scene_preparer as scene_preparer_module
 from dayu.host.scene_preparer import DefaultScenePreparer, PreparedSceneState, _resolve_enabled_toolsets
@@ -42,6 +45,7 @@ from dayu.execution.runtime_config import (
     OpenAIRunnerRuntimeConfig,
 )
 from dayu.execution.options import (
+    apply_model_runner_runtime_overrides,
     ConversationMemorySettings,
     DocToolLimits,
     ExecutionOptions,
@@ -189,6 +193,91 @@ class _MissingRegistrarConfigLoader(_ConfigLoaderStub):
         return {"doc": "x.y.z"}
 
 
+class _ModelCatalogStub:
+    """返回固定模型配置的模型目录桩。"""
+
+    def __init__(self, model_config: ModelConfig) -> None:
+        """初始化模型目录桩。
+
+        Args:
+            model_config: 测试用模型配置。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        self._model_config = model_config
+
+    def load_model(self, model_name: str) -> ModelConfig:
+        """读取指定模型配置。
+
+        Args:
+            model_name: 模型名称。
+
+        Returns:
+            固定的测试模型配置。
+
+        Raises:
+            无。
+        """
+
+        del model_name
+        return self._model_config
+
+    def load_models(self) -> dict[str, ModelConfig]:
+        """读取全部模型配置。
+
+        Args:
+            无。
+
+        Returns:
+            模型名称到测试模型配置的映射。
+
+        Raises:
+            无。
+        """
+
+        return {"test-model": self._model_config}
+
+
+class _SceneDefinitionReaderStub:
+    """返回固定 scene 定义的读取器桩。"""
+
+    def __init__(self, scene_definition: SceneDefinition) -> None:
+        """初始化 scene 定义读取器桩。
+
+        Args:
+            scene_definition: 测试用 scene 定义。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        self._scene_definition = scene_definition
+
+    def read(self, scene_name: str) -> SceneDefinition:
+        """读取指定 scene 定义。
+
+        Args:
+            scene_name: scene 名称。
+
+        Returns:
+            固定的测试 scene 定义。
+
+        Raises:
+            无。
+        """
+
+        del scene_name
+        return self._scene_definition
+
+
 def _build_toolset_configs(
     *,
     doc_tool_limits: DocToolLimits | None = None,
@@ -205,6 +294,39 @@ def _build_toolset_configs(
             build_toolset_config_snapshot("web", web_tools_config),
         )
         if snapshot is not None
+    )
+
+
+def _build_openai_model_config(
+    *,
+    stream_idle_timeout: float = 1800.0,
+    stream_idle_heartbeat_sec: float = 3.0,
+) -> ModelConfig:
+    """构造包含 stream idle 配置的 OpenAI 兼容模型配置。
+
+    Args:
+        stream_idle_timeout: 流式响应空闲读超时秒数。
+        stream_idle_heartbeat_sec: 流式响应空闲心跳日志间隔秒数。
+
+    Returns:
+        测试用模型配置。
+
+    Raises:
+        无。
+    """
+
+    return cast(
+        ModelConfig,
+        {
+            "runner_type": "openai_compatible",
+            "name": "test-model",
+            "endpoint_url": "http://example.com",
+            "model": "provider-model",
+            "headers": {"Authorization": "Bearer token"},
+            "stream_idle_timeout": stream_idle_timeout,
+            "stream_idle_heartbeat_sec": stream_idle_heartbeat_sec,
+            "max_context_tokens": 8192,
+        },
     )
 
 
@@ -400,6 +522,182 @@ def test_resolve_scene_execution_options_accepts_toolset_config_overrides() -> N
     assert resolved_web_config.fetch_truncate_chars == 12345
 
 
+def test_apply_model_runner_runtime_overrides_prefers_model_stream_idle_values() -> None:
+    """模型级 stream idle 配置应覆盖已解析 execution options 的 runner 配置。"""
+
+    resolved_options = ResolvedExecutionOptions(
+        model_name="test-model",
+        runner_running_config=OpenAIRunnerRuntimeConfig(
+            tool_timeout_seconds=45.0,
+            stream_idle_timeout=120.0,
+            stream_idle_heartbeat_sec=10.0,
+        ),
+        agent_running_config=AgentRuntimeConfig(),
+        toolset_configs=_build_toolset_configs(
+            doc_tool_limits=DocToolLimits(),
+            fins_tool_limits=FinsToolLimits(),
+            web_tools_config=WebToolsConfig(provider="off"),
+        ),
+        trace_settings=TraceSettings(enabled=False, output_dir=Path("/tmp/trace")),
+        conversation_memory_settings=ConversationMemorySettings(),
+    )
+
+    updated = apply_model_runner_runtime_overrides(
+        resolved_execution_options=resolved_options,
+        model_config=_build_openai_model_config(
+            stream_idle_timeout=1800.0,
+            stream_idle_heartbeat_sec=3.0,
+        ),
+    )
+
+    runner_config = cast(OpenAIRunnerRuntimeConfig, updated.runner_running_config)
+    assert runner_config.tool_timeout_seconds == pytest.approx(45.0)
+    assert runner_config.stream_idle_timeout == pytest.approx(1800.0)
+    assert runner_config.stream_idle_heartbeat_sec == pytest.approx(3.0)
+
+
+def test_apply_model_runner_runtime_overrides_preserves_baseline_when_model_values_missing() -> None:
+    """模型未配置 stream idle 字段时应保留已解析 runner 基线值。"""
+
+    resolved_options = ResolvedExecutionOptions(
+        model_name="test-model",
+        runner_running_config=OpenAIRunnerRuntimeConfig(
+            tool_timeout_seconds=45.0,
+            stream_idle_timeout=120.0,
+            stream_idle_heartbeat_sec=10.0,
+        ),
+        agent_running_config=AgentRuntimeConfig(),
+        toolset_configs=_build_toolset_configs(web_tools_config=WebToolsConfig(provider="off")),
+        trace_settings=TraceSettings(enabled=False, output_dir=Path("/tmp/trace")),
+        conversation_memory_settings=ConversationMemorySettings(),
+    )
+
+    updated = apply_model_runner_runtime_overrides(
+        resolved_execution_options=resolved_options,
+        model_config=cast(ModelConfig, {"runner_type": "openai_compatible"}),
+    )
+
+    runner_config = cast(OpenAIRunnerRuntimeConfig, updated.runner_running_config)
+    assert runner_config.tool_timeout_seconds == pytest.approx(45.0)
+    assert runner_config.stream_idle_timeout == pytest.approx(120.0)
+    assert runner_config.stream_idle_heartbeat_sec == pytest.approx(10.0)
+
+
+def test_apply_model_runner_runtime_overrides_preserves_unconfigured_stream_idle_field() -> None:
+    """模型只配置一个 stream idle 字段时，未配置字段应保留 runner 基线值。"""
+
+    resolved_options = ResolvedExecutionOptions(
+        model_name="test-model",
+        runner_running_config=OpenAIRunnerRuntimeConfig(
+            tool_timeout_seconds=45.0,
+            stream_idle_timeout=120.0,
+            stream_idle_heartbeat_sec=10.0,
+        ),
+        agent_running_config=AgentRuntimeConfig(),
+        toolset_configs=_build_toolset_configs(web_tools_config=WebToolsConfig(provider="off")),
+        trace_settings=TraceSettings(enabled=False, output_dir=Path("/tmp/trace")),
+        conversation_memory_settings=ConversationMemorySettings(),
+    )
+
+    timeout_only = apply_model_runner_runtime_overrides(
+        resolved_execution_options=resolved_options,
+        model_config=cast(
+            ModelConfig,
+            {
+                "runner_type": "openai_compatible",
+                "stream_idle_timeout": 1800.0,
+            },
+        ),
+    )
+    heartbeat_only = apply_model_runner_runtime_overrides(
+        resolved_execution_options=resolved_options,
+        model_config=cast(
+            ModelConfig,
+            {
+                "runner_type": "openai_compatible",
+                "stream_idle_heartbeat_sec": 3.0,
+            },
+        ),
+    )
+
+    timeout_only_config = cast(OpenAIRunnerRuntimeConfig, timeout_only.runner_running_config)
+    heartbeat_only_config = cast(OpenAIRunnerRuntimeConfig, heartbeat_only.runner_running_config)
+    assert timeout_only_config.stream_idle_timeout == pytest.approx(1800.0)
+    assert timeout_only_config.stream_idle_heartbeat_sec == pytest.approx(10.0)
+    assert heartbeat_only_config.stream_idle_timeout == pytest.approx(120.0)
+    assert heartbeat_only_config.stream_idle_heartbeat_sec == pytest.approx(3.0)
+
+
+def test_apply_model_runner_runtime_overrides_rejects_invalid_stream_idle_values() -> None:
+    """模型级 stream idle 配置非法时应显式失败，避免配置静默不生效。"""
+
+    resolved_options = ResolvedExecutionOptions(
+        model_name="test-model",
+        runner_running_config=OpenAIRunnerRuntimeConfig(),
+        agent_running_config=AgentRuntimeConfig(),
+        toolset_configs=_build_toolset_configs(web_tools_config=WebToolsConfig(provider="off")),
+        trace_settings=TraceSettings(enabled=False, output_dir=Path("/tmp/trace")),
+        conversation_memory_settings=ConversationMemorySettings(),
+    )
+    model_config = cast(
+        ModelConfig,
+        {
+            "runner_type": "openai_compatible",
+            "stream_idle_timeout": 0.0,
+            "stream_idle_heartbeat_sec": 3.0,
+        },
+    )
+
+    with pytest.raises(ValueError, match="stream_idle_timeout"):
+        apply_model_runner_runtime_overrides(
+            resolved_execution_options=resolved_options,
+            model_config=model_config,
+        )
+
+
+def test_scene_execution_acceptance_includes_model_stream_idle_in_snapshot(tmp_path: Path) -> None:
+    """Service 接受规格应把模型级 stream idle 配置写入 runner 快照。"""
+
+    model_config = _build_openai_model_config(
+        stream_idle_timeout=1800.0,
+        stream_idle_heartbeat_sec=3.0,
+    )
+    base_options = ResolvedExecutionOptions(
+        model_name="",
+        runner_running_config=OpenAIRunnerRuntimeConfig(
+            tool_timeout_seconds=45.0,
+            stream_idle_timeout=120.0,
+            stream_idle_heartbeat_sec=10.0,
+        ),
+        agent_running_config=AgentRuntimeConfig(max_iterations=5),
+        toolset_configs=_build_toolset_configs(web_tools_config=WebToolsConfig(provider="off")),
+        trace_settings=TraceSettings(enabled=False, output_dir=tmp_path / "trace"),
+        conversation_memory_settings=ConversationMemorySettings(),
+    )
+    scene_definition = SceneDefinition(
+        name="prompt",
+        model=SceneModelDefinition(default_name="test-model", allowed_names=("test-model",)),
+        version="v1",
+        description="test",
+    )
+    preparer = SceneExecutionAcceptancePreparer(
+        workspace_dir=tmp_path,
+        base_execution_options=base_options,
+        model_catalog=_ModelCatalogStub(model_config),
+        scene_definition_reader=cast(SceneDefinitionReader, _SceneDefinitionReaderStub(scene_definition)),
+        conversation_policy_reader=ConversationPolicyReader(),
+    )
+
+    accepted_scene = preparer.prepare("prompt", ExecutionOptions(temperature=0.2))
+
+    runner_config = cast(OpenAIRunnerRuntimeConfig, accepted_scene.resolved_execution_options.runner_running_config)
+    runner_snapshot = accepted_scene.accepted_execution_spec.runtime.runner_running_config
+    assert runner_config.stream_idle_timeout == pytest.approx(1800.0)
+    assert runner_config.stream_idle_heartbeat_sec == pytest.approx(3.0)
+    assert runner_snapshot.get("stream_idle_timeout") == pytest.approx(1800.0)
+    assert runner_snapshot.get("stream_idle_heartbeat_sec") == pytest.approx(3.0)
+
+
 def test_resolve_scene_temperature_prefers_explicit_override() -> None:
     """显式 temperature 应优先于模型 profile。"""
 
@@ -490,6 +788,44 @@ def _build_scene_preparer(tmp_path: Path, *, web_provider: str) -> DefaultSceneP
         default_execution_options=resolved_options,
         tool_registry_factory=lambda: ToolRegistry(),
     )
+
+
+@pytest.mark.unit
+def test_host_owned_scene_state_includes_model_stream_idle_in_agent_create_args(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Host 自有子执行应把模型级 stream idle 配置写入 AgentCreateArgs。"""
+
+    preparer = _build_scene_preparer(tmp_path, web_provider="off")
+    model_config = _build_openai_model_config(
+        stream_idle_timeout=1800.0,
+        stream_idle_heartbeat_sec=3.0,
+    )
+    scene_definition = SceneDefinition(
+        name="prompt",
+        model=SceneModelDefinition(default_name="test-model", allowed_names=("test-model",)),
+        version="v1",
+        description="test",
+    )
+    tool_registry = cast(PromptToolExecutorProtocol, ToolRegistry())
+    preparer.model_catalog = _ModelCatalogStub(model_config)
+    monkeypatch.setattr("dayu.host.scene_preparer.load_scene_definition", lambda *_args, **_kwargs: scene_definition)
+    monkeypatch.setattr(preparer, "_build_tool_registry", lambda **_kwargs: tool_registry)
+    monkeypatch.setattr(preparer._trace_provider, "get_or_create", lambda _settings: "trace-factory")
+
+    prepared_scene = preparer._prepare_host_owned_scene_state(
+        scene_name="prompt",
+        execution_options=ExecutionOptions(temperature=0.2),
+        web_tools_config=WebToolsConfig(provider="off"),
+    )
+
+    runner_snapshot = prepared_scene.agent_create_args.runner_running_config
+    runner_config = cast(OpenAIRunnerRuntimeConfig, prepared_scene.resolved_options.runner_running_config)
+    assert runner_config.stream_idle_timeout == pytest.approx(1800.0)
+    assert runner_config.stream_idle_heartbeat_sec == pytest.approx(3.0)
+    assert runner_snapshot.get("stream_idle_timeout") == pytest.approx(1800.0)
+    assert runner_snapshot.get("stream_idle_heartbeat_sec") == pytest.approx(3.0)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

在 `llm_models.json` 的模型配置中支持 `stream_idle_timeout` 和 `stream_idle_heartbeat_sec` 两个字段，覆盖已解析 `ResolvedExecutionOptions` 中 `runner_running_config` 的对应值。

**行为契约**：
- 仅对 `openai_compatible` runner 类型生效；其它 runner 类型原样返回。
- 模型未配置的字段保留 runner 基线值（不覆为 `None`）。
- 配置非法值（非正数、非有限数、`bool`）显式抛 `ValueError`，避免静默不生效。
- 该覆盖在 Service（`scene_execution_acceptance`）和 Host（`scene_preparer`）两个入口均应用，保证两条路径行为一致。

## 涉及文件

| 文件 | 改动 |
|------|------|
| `dayu/execution/options.py` | 新增 `ModelRunnerRuntimeOverrideValue` 类型别名、`_parse_model_runner_positive_float` 校验函数、`apply_model_runner_runtime_overrides` 主函数；通过 `__all__` 导出 |
| `dayu/host/scene_preparer.py` | `_prepare_host_owned_scene_state` 中 `resolve_scene_execution_options` 之后调用 `apply_model_runner_runtime_overrides` |
| `dayu/services/scene_execution_acceptance.py` | `SceneExecutionAcceptancePreparer.prepare` 中同理调用 |
| `dayu/config/README.md` | 补充两个字段的文档说明 |
| `tests/application/test_scene_execution.py` | 新增 5 个单元测试覆盖核心路径 |

## Test plan

- [x] `pytest tests/application/test_scene_execution.py` — 全部通过
- [x] `pyright dayu/execution/options.py dayu/host/scene_preparer.py dayu/services/scene_execution_acceptance.py` — 0 errors
- [ ] 真实 `llm_models.json` 中配 `stream_idle_timeout: 1800` 后跑 `dayu-cli prompt` 验证端到端生效

## 不在本 PR 范围

- Prompt / Service 层读取 `llm_models.json` 的流程不在本 PR 改动范围内（已有现成通路，本 PR 只在 resolve 之后加一步覆盖）。
- 其它 runner 类型（如未来新增的 cli runner）的运行时覆盖支持不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)