### PR TITLE
[codex] init 配置第三方输出降噪环境变量

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ dayu-cli init
 3. 输入对应 API Key 并永久写入环境变量。
 4. 可选配置联网检索 API Key（TAVILY / SERPER / FMP）
 5. 自动检测 HuggingFace 官方 Hub 连通性：不可达时默认启用镜像加速，可达时默认跳过。可选配置 `HF_TOKEN` 提升下载稳定性。
+6. 自动配置 `transformers` / `huggingface_hub` / `tqdm` 输出降噪环境变量，避免下载进度打断终端状态栏。
 
 
 可选参数：

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -177,6 +177,12 @@ _ROLE_THINKING = "thinking"
 # 时静默降级到声明顺序靠前的另一档。
 _INIT_PROVIDER_OPTION_ENV = "DAYU_INIT_PROVIDER_OPTION"
 
+_THIRD_PARTY_OUTPUT_QUIET_ENV: tuple[tuple[str, str], ...] = (
+    ("TRANSFORMERS_VERBOSITY", "error"),
+    ("HF_HUB_DISABLE_PROGRESS_BARS", "1"),
+    ("TQDM_DISABLE", "1"),
+)
+
 _OPTIONAL_SEARCH_KEYS: list[str] = [
     TAVILY_API_KEY_ENV,
     SERPER_API_KEY_ENV,
@@ -337,6 +343,46 @@ def _persist_env_var(key: str, value: str) -> tuple[str, bool]:
     except OSError:
         return str(profile), False
     return str(profile), True
+
+
+def _configure_third_party_output_quiet_env() -> tuple[bool, bool]:
+    """配置第三方模型下载库的终端输出降噪环境变量。
+
+    Args:
+        无。
+
+    Returns:
+        ``(env_vars_written, persist_failed)`` 元组。
+        ``env_vars_written`` 表示本次是否尝试写入持久化环境变量；
+        ``persist_failed`` 表示是否存在至少一个变量持久化失败。
+
+    Raises:
+        无。
+    """
+
+    env_vars_written = False
+    persist_failed = False
+    configured_items: list[str] = []
+
+    for key, value in _THIRD_PARTY_OUTPUT_QUIET_ENV:
+        configured_items.append(f"{key}={value}")
+        if os.environ.get(key) == value:
+            continue
+
+        _target, ok = _persist_env_var(key, value)
+        env_vars_written = True
+        if not ok:
+            persist_failed = True
+
+    configured_text = "、".join(configured_items)
+    if persist_failed:
+        print(f"⚠️  第三方库输出降噪已应用到当前进程，部分变量未能持久化: {configured_text}")
+    elif not env_vars_written:
+        print(f"✓ 第三方库输出降噪已存在，跳过写入: {configured_text}")
+    else:
+        print(f"✓ 第三方库输出降噪已配置: {configured_text}")
+
+    return env_vars_written, persist_failed
 
 
 # --------------------------------------------------------------------------- #
@@ -1259,13 +1305,13 @@ def run_init_command(args: Namespace) -> int:
     )
 
     # 4. 可选联网检索 Key
-    search_persist_failed = False
+    auxiliary_env_persist_failed = False
     search_keys = _prompt_optional_search_keys()
     for key, value in search_keys:
         _search_target, search_ok = _persist_env_var(key, value)
         env_vars_written = True
         if not search_ok:
-            search_persist_failed = True
+            auxiliary_env_persist_failed = True
         print(f"✓ {key} 已配置")
 
     # 5. HuggingFace 镜像与 Token
@@ -1274,17 +1320,24 @@ def run_init_command(args: Namespace) -> int:
         _hf_target, hf_ok = _persist_env_var(key, value)
         env_vars_written = True
         if not hf_ok:
-            search_persist_failed = True
+            auxiliary_env_persist_failed = True
         display = value if key == "HF_ENDPOINT" else f"{value[:4]}***"
         print(f"✓ {key} 已配置: {display}")
 
-    # 6. SEC User-Agent
+    # 6. 第三方库终端输出降噪
+    quiet_env_written, quiet_env_failed = _configure_third_party_output_quiet_env()
+    if quiet_env_written:
+        env_vars_written = True
+    if quiet_env_failed:
+        auxiliary_env_persist_failed = True
+
+    # 7. SEC User-Agent
     sec_ua = _prompt_sec_user_agent()
     if sec_ua is not None:
         _sec_target, sec_ok = _persist_env_var(sec_ua[0], sec_ua[1])
         env_vars_written = True
         if not sec_ok:
-            search_persist_failed = True
+            auxiliary_env_persist_failed = True
         print(f"✓ {sec_ua[0]} 已配置: {sec_ua[1]}")
 
     if should_run_prewarm and not main_key_persist_failed:
@@ -1299,15 +1352,15 @@ def run_init_command(args: Namespace) -> int:
             print(f"⚠️  CLI 运行时预热失败: {prewarm_message}")
             print("   不影响当前工作区初始化成功；后续首次运行 prompt / interactive / write 时可能更慢。")
 
-    # 6. 完成提示
+    # 8. 完成提示
     print(f"\n✓ 工作区已初始化: {base_dir}")
 
     if env_vars_written:
-        if main_key_persist_failed or search_persist_failed:
+        if main_key_persist_failed or auxiliary_env_persist_failed:
             shell_name = os.environ.get("SHELL", "").rsplit("/", 1)[-1] or "unknown"
             print(f"\n⚠️  当前环境（shell={shell_name}）不支持自动写入环境变量。")
             print(f"   已为当前进程设置环境变量，但重开终端后会丢失。")
-            print(f"   请手动将 API Key 添加到你的 shell 配置文件中。\n")
+            print(f"   请手动将相关环境变量添加到你的 shell 配置文件中。\n")
         elif platform.system() != "Windows":
             profile, _ = _detect_shell_profile()
             print(f"\n⚠️  环境变量已写入 {profile}，但当前终端尚未生效。")

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -21,7 +21,9 @@ from dayu.cli.commands.init import (
     _PROVIDER_OPTION_MIMO_PRO,
     _ROLE_NON_THINKING,
     _ROLE_THINKING,
+    _THIRD_PARTY_OUTPUT_QUIET_ENV,
     _classify_model_role,
+    _configure_third_party_output_quiet_env,
     _confirm_workspace_reset,
     _copy_assets,
     _copy_config,
@@ -64,6 +66,13 @@ def _clear_provider_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 
     for key in _PROVIDER_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
+
+
+def _set_quiet_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """设置第三方库输出降噪环境变量为 init 推荐值。"""
+
+    for key, value in _THIRD_PARTY_OUTPUT_QUIET_ENV:
+        monkeypatch.setenv(key, value)
 
 
 # --------------------------------------------------------------------------- #
@@ -737,6 +746,7 @@ class TestRunInit:
         # 预设 HF 环境变量
         monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.com")
         monkeypatch.setenv("HF_TOKEN", "hf-test-xxx")
+        _set_quiet_env_vars(monkeypatch)
 
         # _persist_env_var 不应被调用
         persist_calls: list[str] = []
@@ -1174,6 +1184,87 @@ class TestPersistEnvVar:
 
 
 # --------------------------------------------------------------------------- #
+#  _configure_third_party_output_quiet_env
+# --------------------------------------------------------------------------- #
+
+
+class TestConfigureThirdPartyOutputQuietEnv:
+    """第三方库输出降噪环境变量配置测试。"""
+
+    def test_missing_values_are_persisted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """推荐降噪变量缺失时应逐项持久化，并输出告知信息。"""
+
+        for key, _value in _THIRD_PARTY_OUTPUT_QUIET_ENV:
+            monkeypatch.delenv(key, raising=False)
+
+        persist_calls: list[tuple[str, str]] = []
+
+        def _mock_persist(key: str, value: str) -> tuple[str, bool]:
+            persist_calls.append((key, value))
+            monkeypatch.setenv(key, value)
+            return "~/.zshrc", True
+
+        monkeypatch.setattr("dayu.cli.commands.init._persist_env_var", _mock_persist)
+
+        written, failed = _configure_third_party_output_quiet_env()
+
+        assert written is True
+        assert failed is False
+        assert persist_calls == list(_THIRD_PARTY_OUTPUT_QUIET_ENV)
+        captured = capsys.readouterr()
+        assert "第三方库输出降噪已配置" in captured.out
+        assert "TRANSFORMERS_VERBOSITY=error" in captured.out
+        assert "HF_HUB_DISABLE_PROGRESS_BARS=1" in captured.out
+        assert "TQDM_DISABLE=1" in captured.out
+
+    def test_existing_values_are_idempotent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """推荐降噪变量已存在且值一致时不重复持久化。"""
+
+        _set_quiet_env_vars(monkeypatch)
+        persist_calls: list[tuple[str, str]] = []
+
+        def _mock_persist(key: str, value: str) -> tuple[str, bool]:
+            persist_calls.append((key, value))
+            return "~/.zshrc", True
+
+        monkeypatch.setattr("dayu.cli.commands.init._persist_env_var", _mock_persist)
+
+        written, failed = _configure_third_party_output_quiet_env()
+
+        assert written is False
+        assert failed is False
+        assert persist_calls == []
+        captured = capsys.readouterr()
+        assert "第三方库输出降噪已存在，跳过写入" in captured.out
+        assert "第三方库输出降噪已配置" not in captured.out
+
+    def test_persist_failure_returns_failure_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """任一降噪变量持久化失败时返回失败标记供 init 统一告警。"""
+
+        for key, _value in _THIRD_PARTY_OUTPUT_QUIET_ENV:
+            monkeypatch.delenv(key, raising=False)
+
+        def _mock_persist(key: str, value: str) -> tuple[str, bool]:
+            monkeypatch.setenv(key, value)
+            return "~/.zshrc", key != "HF_HUB_DISABLE_PROGRESS_BARS"
+
+        monkeypatch.setattr("dayu.cli.commands.init._persist_env_var", _mock_persist)
+
+        written, failed = _configure_third_party_output_quiet_env()
+
+        assert written is True
+        assert failed is True
+
+
+# --------------------------------------------------------------------------- #
 #  _resolve_role_from_package_manifest — 错误分支
 # --------------------------------------------------------------------------- #
 
@@ -1543,7 +1634,7 @@ class TestRunInitFailurePaths:
         assert prewarm_calls == []
 
     def test_search_key_persist_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """搜索 Key 持久化失败时触发 search_persist_failed 分支。"""
+        """搜索 Key 持久化失败时触发辅助环境变量持久化失败分支。"""
         base = self._prepare_mocks(tmp_path, monkeypatch)
 
         inputs = iter(["sk-test", "tvly-test", "", "", "n", "", ""])
@@ -1936,7 +2027,7 @@ class TestInitPrewarm:
         assert exit_code == 0
 
     def test_hf_persist_fails_sets_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """HF 环境变量持久化失败时也触发 search_persist_failed。"""
+        """HF 环境变量持久化失败时也触发辅助环境变量持久化失败分支。"""
         base = self._prepare_run_init_environment(tmp_path, monkeypatch)
         monkeypatch.setattr(
             "dayu.cli.commands.init._run_init_prewarm",


### PR DESCRIPTION
## 背景

`transformers`、`huggingface_hub` 和 `tqdm` 在加载模型或下载资源时会直接向终端输出进度信息，容易打断 `dayu-cli` 的单行状态栏，造成残影或错位。

Closes #52

## 改动

- 在 `dayu-cli init` 中新增无交互降噪步骤，自动配置：
  - `TRANSFORMERS_VERBOSITY=error`
  - `HF_HUB_DISABLE_PROGRESS_BARS=1`
  - `TQDM_DISABLE=1`
- 复用现有环境变量持久化机制，并在已存在推荐值时输出“已存在，跳过写入”。
- 将辅助环境变量持久化失败标记重命名为更准确的 `auxiliary_env_persist_failed`。
- 更新 README 中的 `init` 流程说明。
- 补充缺失写入、幂等跳过、持久化失败三类测试。

## 验证

- `source .venv/bin/activate && pytest tests/cli/test_init_command.py`
- `source .venv/bin/activate && pyright`
- `git diff --check`
