### PR TITLE
[codex] Windows GPU 下优先使用 docling-parse

### DIFF
--- a/dayu/docling_runtime.py
+++ b/dayu/docling_runtime.py
@@ -18,7 +18,11 @@
     2. ``backend=pypdfium2, device=resolved``：救 docling-parse 解析失败。
     3. ``backend=docling-parse, device=cpu``：仅当 ``resolved == auto`` 追加，
        救加速器栈在 ``auto`` 阶段崩溃的故障。
-  - Windows：
+  - Windows + 显式加速器设备（``cuda/mps/xpu``）或 ``auto`` 且 CUDA 可用：
+    1. ``backend=docling-parse, device=resolved``：GPU 路径实测稳定，
+       优先保留解析质量。
+    2. ``backend=pypdfium2, device=resolved``：救 docling-parse 解析失败。
+  - Windows + ``cpu``，或 ``auto`` 但 CUDA 不可用：
     1. ``backend=pypdfium2, device=resolved``：优先，规避 docling-parse 在
        Windows 上的 ``std::bad_alloc`` 与 mbcs 路径编码两类已知崩溃。
     2. ``backend=docling-parse, device=resolved``：兜底，给特殊文档保留机会。
@@ -49,6 +53,12 @@ DOCLING_DEVICE_ENV = "DAYU_DOCLING_DEVICE"
 _SUPPORTED_DOCLING_DEVICES = frozenset({"auto", "cpu", "cuda", "mps", "xpu"})
 _AUTO_DEVICE_NAME = "auto"
 _CPU_DEVICE_NAME = "cpu"
+_CUDA_DEVICE_NAME = "cuda"
+_MPS_DEVICE_NAME = "mps"
+_XPU_DEVICE_NAME = "xpu"
+_ACCELERATOR_DEVICE_NAMES = frozenset(
+    {_CUDA_DEVICE_NAME, _MPS_DEVICE_NAME, _XPU_DEVICE_NAME}
+)
 _DOCLING_PARSE_BACKEND_NAME = "docling-parse"
 _PYPDFIUM2_BACKEND_NAME = "pypdfium2"
 _SUPPORTED_DOCLING_BACKENDS = frozenset({_DOCLING_PARSE_BACKEND_NAME, _PYPDFIUM2_BACKEND_NAME})
@@ -217,13 +227,73 @@ def _is_windows_platform() -> bool:
     return sys.platform == _WINDOWS_PLATFORM_NAME
 
 
+def _is_explicit_accelerator_device(device_name: str) -> bool:
+    """判断设备名是否指向显式加速器设备。
+
+    Args:
+        device_name: 已规范化的 Docling 设备名。
+
+    Returns:
+        True 表示设备名是显式加速器，False 表示 ``auto`` 或 ``cpu``。
+
+    Raises:
+        无。
+    """
+
+    return device_name in _ACCELERATOR_DEVICE_NAMES
+
+
+def _is_windows_cuda_available() -> bool:
+    """探测当前 Windows 运行环境是否可用 CUDA。
+
+    此处 lazy import `torch` 是为了把硬件探测成本限制在 Windows auto 设备
+    的策略分支内；Docling 运行时本身已经依赖 torch，探测失败时保守视为
+    CUDA 不可用。
+
+    Args:
+        无。
+
+    Returns:
+        True 表示 CUDA 当前可用，False 表示不可用或探测失败。
+
+    Raises:
+        无。
+    """
+
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
+def _should_prefer_docling_parse_first_on_windows(resolved_device_name: str) -> bool:
+    """判断 Windows 平台是否应优先使用 docling-parse。
+
+    Args:
+        resolved_device_name: 已规范化的 Docling 设备名。
+
+    Returns:
+        True 表示优先使用 ``docling-parse``，False 表示优先使用 ``pypdfium2``。
+
+    Raises:
+        无。
+    """
+
+    if _is_explicit_accelerator_device(resolved_device_name):
+        return True
+    return resolved_device_name == _AUTO_DEVICE_NAME and _is_windows_cuda_available()
+
+
 def _plan_conversion_attempts(resolved_device_name: str) -> list[_DoclingConversionAttempt]:
     """按二维回退策略生成 Docling 转换尝试链。
 
     Windows 上 docling-parse 后端在某些 PDF 上会在 C++ 层抛 ``std::bad_alloc``，
-    且对 mbcs 路径编码也存在已知 bug；为减少首次失败概率与日志刷屏，
-    Windows 平台把 ``pypdfium2`` 提到首位，``docling-parse`` 作为兜底。
-    其它平台保持 ``docling-parse`` 优先以维持既有解析质量。
+    且对 mbcs 路径编码也存在已知 bug；为减少 CPU/auto 路径的首次失败概率
+    与日志刷屏，Windows 在未显式选择加速器设备且 CUDA 不可用时把
+    ``pypdfium2`` 提到首位。Windows 显式加速器设备、Windows auto 且 CUDA
+    可用、以及其它平台保持 ``docling-parse`` 优先，以维持既有解析质量。
 
     Args:
         resolved_device_name: 已规范化的 Docling 设备名。
@@ -235,7 +305,10 @@ def _plan_conversion_attempts(resolved_device_name: str) -> list[_DoclingConvers
         无。
     """
 
-    if _is_windows_platform():
+    prefers_pypdfium2_first = _is_windows_platform() and not (
+        _should_prefer_docling_parse_first_on_windows(resolved_device_name)
+    )
+    if prefers_pypdfium2_first:
         attempts: list[_DoclingConversionAttempt] = [
             _DoclingConversionAttempt(
                 backend_name=_PYPDFIUM2_BACKEND_NAME,

--- a/tests/README.md
+++ b/tests/README.md
@@ -88,7 +88,7 @@ pip install -r requirements.txt
 - 必须使用固定 fixture
 - 必须走真实第三方执行链
 - 表格退化不可接受，不能只断言“返回非空字符串”
-- 当前 Dayu 已将 upload / web tool 等 Docling PDF 转换入口统一收口到 `dayu.docling_runtime`；默认设备为 `auto`，转换走二维（backend × device）有序回退尝试链：先 `(docling-parse, resolved)`，再 `(pypdfium2, resolved)`，仅当 `resolved == auto` 时追加 `(docling-parse, cpu)`；任意一档成功即返回，全链失败时以首次失败作为 `__cause__`。若需要显式覆盖加速器设备，可通过环境变量 `DAYU_DOCLING_DEVICE=auto|cpu|cuda|mps|xpu` 调整。Docling 输入统一走 `DocumentStream(BytesIO(bytes))`（封装在 `convert_pdf_bytes_with_docling()`），以规避 Windows 上 `Path` 被 mbcs 编码导致的 `not valid` 误判
+- 当前 Dayu 已将 upload / web tool 等 Docling PDF 转换入口统一收口到 `dayu.docling_runtime`；默认设备为 `auto`，转换走二维（backend × device）有序回退尝试链：非 Windows、Windows 显式加速器设备（`cuda/mps/xpu`），以及 Windows `auto` 且 `torch.cuda.is_available()` 为真时，先 `(docling-parse, resolved)`，再 `(pypdfium2, resolved)`；Windows 的 `cpu` 设备或 `auto` 但 CUDA 不可用时，先 `(pypdfium2, resolved)`，再 `(docling-parse, resolved)`，用于规避 `docling-parse` 在 Windows CPU/auto 路径上的 C++ 层崩溃刷屏风险；仅当 `resolved == auto` 时追加 `(docling-parse, cpu)`；任意一档成功即返回，全链失败时以首次失败作为 `__cause__`。若需要显式覆盖加速器设备，可通过环境变量 `DAYU_DOCLING_DEVICE=auto|cpu|cuda|mps|xpu` 调整。Docling 输入统一走 `DocumentStream(BytesIO(bytes))`（封装在 `convert_pdf_bytes_with_docling()`），以规避 Windows 上 `Path` 被 mbcs 编码导致的 `not valid` 误判
 - 与此对应，unit test 若只想隔离 Docling 转换结果，应优先 patch `convert_pdf_bytes_with_docling()` 或 `run_docling_pdf_conversion()` 这类项目内真源 seam；若只测装配参数，再 patch `build_docling_pdf_converter()`，不要继续直接 patch 第三方 `DocumentConverter` 类
 
 ### 3.2 Service / Host / Agent 路径守护

--- a/tests/engine/test_docling_runtime.py
+++ b/tests/engine/test_docling_runtime.py
@@ -643,10 +643,10 @@ def test_convert_pdf_bytes_with_docling_uses_document_stream(
     assert captured["pipeline"] == (True, True, "accurate", True)
 
 
-def test_run_docling_pdf_conversion_on_windows_prefers_pypdfium2(
+def test_run_docling_pdf_conversion_on_windows_auto_prefers_pypdfium2(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """验证 Windows 平台尝试链把 pypdfium2 提到首位。
+    """验证 Windows 平台 auto 设备尝试链把 pypdfium2 提到首位。
 
     Args:
         monkeypatch: pytest monkeypatch fixture。
@@ -663,6 +663,7 @@ def test_run_docling_pdf_conversion_on_windows_prefers_pypdfium2(
     _install_recording_builder(monkeypatch, build_log)
     # 覆盖 _install_recording_builder 内部默认的非 Windows stub，模拟 Windows。
     monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: True)
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_cuda_available", lambda: False)
 
     def _convert(converter: object) -> str:
         """首档（pypdfium2）即成功。
@@ -683,9 +684,102 @@ def test_run_docling_pdf_conversion_on_windows_prefers_pypdfium2(
     result = run_docling_pdf_conversion(_convert)
 
     assert result == "ok"
-    # Windows 链：pypdfium2 优先，docling-parse 兜底，auto 时再追加 (parse, cpu)
+    # Windows auto 链：pypdfium2 优先，docling-parse 兜底，auto 时再追加 (parse, cpu)
     # 首档命中即返回，build_log 仅有一条 pypdfium2 记录。
     assert build_log == [("pypdfium2", "auto")]
+
+
+def test_run_docling_pdf_conversion_on_windows_auto_with_cuda_prefers_docling_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """验证 Windows 平台 auto 设备检测到 CUDA 时优先使用 docling-parse。
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    build_log: list[tuple[str, str]] = []
+    monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "auto")
+    _install_recording_builder(monkeypatch, build_log)
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: True)
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_cuda_available", lambda: True)
+
+    def _convert(converter: object) -> str:
+        """前两档失败后由 docling-parse CPU 兜底成功。
+
+        Args:
+            converter: Docling 转换器对象。
+
+        Returns:
+            成功标记字符串。
+
+        Raises:
+            RuntimeError: 在 cpu 之前固定抛出。
+        """
+
+        fake_converter = cast(_FakeConverter, converter)
+        if fake_converter.device_name == "cpu":
+            return "ok"
+        raise RuntimeError(f"auto cuda failed@{fake_converter.backend_name}")
+
+    result = run_docling_pdf_conversion(_convert)
+
+    assert result == "ok"
+    assert build_log == [
+        ("docling-parse", "auto"),
+        ("pypdfium2", "auto"),
+        ("docling-parse", "cpu"),
+    ]
+
+
+def test_run_docling_pdf_conversion_on_windows_cuda_prefers_docling_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """验证 Windows 平台显式 CUDA 设备时优先使用 docling-parse。
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    build_log: list[tuple[str, str]] = []
+    monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "cuda")
+    _install_recording_builder(monkeypatch, build_log)
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: True)
+
+    def _convert(converter: object) -> str:
+        """首档 docling-parse 失败后由 pypdfium2 兜底成功。
+
+        Args:
+            converter: Docling 转换器对象。
+
+        Returns:
+            成功标记字符串。
+
+        Raises:
+            RuntimeError: 当 backend 为 docling-parse 时固定抛出。
+        """
+
+        fake_converter = cast(_FakeConverter, converter)
+        if fake_converter.backend_name == "docling-parse":
+            raise RuntimeError("cuda parse failed")
+        return "ok"
+
+    result = run_docling_pdf_conversion(_convert)
+
+    assert result == "ok"
+    assert build_log == [("docling-parse", "cuda"), ("pypdfium2", "cuda")]
 
 
 def test_run_docling_pdf_conversion_on_windows_full_chain(
@@ -707,6 +801,7 @@ def test_run_docling_pdf_conversion_on_windows_full_chain(
     monkeypatch.setattr("dayu.docling_runtime.resolve_docling_device_name", lambda: "auto")
     _install_recording_builder(monkeypatch, build_log)
     monkeypatch.setattr("dayu.docling_runtime._is_windows_platform", lambda: True)
+    monkeypatch.setattr("dayu.docling_runtime._is_windows_cuda_available", lambda: False)
 
     def _convert(converter: object) -> str:
         """前两档失败、第三档（parse, cpu）成功。
@@ -736,4 +831,3 @@ def test_run_docling_pdf_conversion_on_windows_full_chain(
         ("docling-parse", "auto"),
         ("docling-parse", "cpu"),
     ]
-


### PR DESCRIPTION
## 背景

Fixes #68。

上一轮 Windows Docling 修复把 `pypdfium2` 提到尝试链首位，用于规避 `docling-parse` 在 Windows CPU/auto 路径上可能触发的 C++ 层 `std::bad_alloc` 刷屏问题。但实测 `docling-parse + cuda` 路径可正常转换，且解析质量优于 `pypdfium2`，因此 Windows GPU 路径不应无条件牺牲解析质量。

## 改动

- 在 Windows 上将显式加速器设备（`cuda/mps/xpu`）改为 `docling-parse -> pypdfium2`。
- 在 Windows `auto` 设备下探测 `torch.cuda.is_available()`；CUDA 可用时同样保持 `docling-parse` 优先。
- Windows `cpu`，或 `auto` 但 CUDA 不可用时，继续保留 `pypdfium2 -> docling-parse` 的保护链。
- 更新 Docling runtime 单测与 `tests/README.md` 中的策略说明。

## 验证

- `source .venv/bin/activate && python -m pytest tests/engine/test_docling_runtime.py --cov=dayu.docling_runtime --cov-report=term-missing -q`
  - `17 passed`
  - `dayu/docling_runtime.py` 覆盖率 `82%`
- `source .venv/bin/activate && pyright --pythonpath .venv/bin/python`
  - `0 errors`

## 风险

尚未在真实 Windows + CUDA 机器上跑 fixture 复测；当前覆盖的是策略链单测。