### PR TITLE
fix: forms 仅通过逗号（，）分隔，不支持空格分隔，避免SC 13G被拆分成SC 和 13G

### DIFF
--- a/dayu/fins/cli_support.py
+++ b/dayu/fins/cli_support.py
@@ -1327,7 +1327,7 @@ def _coerce_forms_input(raw_forms: Optional[Sequence[str] | str]) -> Optional[st
     cleaned_items = [str(item).strip() for item in raw_forms if str(item).strip()]
     if not cleaned_items:
         raise ValueError("forms 不能为空")
-    return " ".join(cleaned_items)
+    return ",".join(cleaned_items)
 
 
 def _coerce_document_ids_input(

--- a/dayu/fins/pipelines/sec_form_utils.py
+++ b/dayu/fins/pipelines/sec_form_utils.py
@@ -121,7 +121,7 @@ def split_form_input(raw_form_input: str) -> list[str]:
         ValueError: 输入为空时抛出。
     """
 
-    values = [item.strip() for item in re.split(r"[,\s]+", raw_form_input) if item.strip()]
+    values = [item.strip() for item in re.split(r",\s*", raw_form_input) if item.strip()]
     if not values:
         raise ValueError("form_type 不能为空")
     return values

--- a/tests/fins/test_cli_helpers_coverage.py
+++ b/tests/fins/test_cli_helpers_coverage.py
@@ -461,6 +461,9 @@ def test_coerce_and_validate_helpers(tmp_path: Path) -> None:
 
     assert module._coerce_forms_input(None) is None
     assert module._coerce_forms_input("10-K") == "10-K"
+    # 序列输入使用逗号连接，不能错误拆分含空格的 form（如 SC 13G）
+    assert module._coerce_forms_input(["10-K", "10-Q"]) == "10-K,10-Q"
+    assert module._coerce_forms_input(("SC 13G", "10-K", "DEF 14A")) == "SC 13G,10-K,DEF 14A"
     assert module._coerce_document_ids_input(" fil_1 , fil_2 ") == ["fil_1", "fil_2"]
     assert module._coerce_document_ids_input(["fil_1", "fil_2", "fil_1"]) == ["fil_1", "fil_2"]
     with pytest.raises(ValueError, match="forms 不能为空"):

--- a/tests/fins/test_pipeline_cli.py
+++ b/tests/fins/test_pipeline_cli.py
@@ -1251,7 +1251,7 @@ def test_dispatch_download_supports_multiple_forms() -> None:
     result = cli._dispatch_action(fake, args)
 
     assert result["action"] == "download"
-    assert result["form_type"] == "10Q 10K DEF14A"
+    assert result["form_type"] == "10Q,10K,DEF14A"
 
 
 def test_dispatch_process_passes_ci_flag() -> None:

--- a/tests/fins/test_sec_pipeline_helpers.py
+++ b/tests/fins/test_sec_pipeline_helpers.py
@@ -3044,3 +3044,17 @@ def test_cleanup_stale_filing_dirs(tmp_path: Path) -> None:
         form_windows=form_windows,
         filing_results=[],
     ) == 0
+
+
+@pytest.mark.unit
+def test_split_form_input_preserves_forms_with_spaces() -> None:
+    """``split_form_input`` 仅按逗号拆分，不按空格拆，确保 SC 13G 等不被破坏。"""
+    assert _sec_form_utils.split_form_input("10-K,10-Q") == ["10-K", "10-Q"]
+    assert _sec_form_utils.split_form_input("SC 13G,10-K,DEF 14A") == ["SC 13G", "10-K", "DEF 14A"]
+    assert _sec_form_utils.split_form_input("SC 13G") == ["SC 13G"]
+    assert _sec_form_utils.split_form_input("10-K, 10-Q") == ["10-K", "10-Q"]
+
+    with pytest.raises(ValueError, match="form_type 不能为空"):
+        _sec_form_utils.split_form_input("")
+    with pytest.raises(ValueError, match="form_type 不能为空"):
+        _sec_form_utils.split_form_input(" , ")


### PR DESCRIPTION
forms 仅通过逗号（，）分隔，不支持空格分隔，避免SC 13G被拆分成SC 和 13G
