### PR TITLE
feat/issue 80 dayu cli init enhance

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ API Key 申请地址：
 说明：
 - 默认推荐 Mimo Token Plan（mimo-v2.5-pro-plan），性价比最优。（注： MIMO_PLAN_API_KEY / MIMO_API_KEY 是两个不同的KEY，不能混用）。
 - 海外用户选Mimo Token Plan SG。
-- 如需接入 OpenRouter 等聚合服务，可在 `init` 中选择“自定义 OpenAI 兼容 API”，填写 `CUSTOM_OPENAI_API_KEY`、Base URL 与模型 ID。
+- 如需接入 OpenRouter 等聚合服务，可在 `init` 中选择”自定义 OpenAI 兼容 API”，填写 `CUSTOM_OPENAI_API_KEY`、Base URL、模型 ID 与最大上下文 tokens。
+- 本地 Ollama 模型和自定义 OpenAI 兼容 API 在 `init` 时会根据最大上下文 tokens 自动配置 `conversation_memory`（>= 100 万 tokens 扩大工作记忆上限，< 100 万收紧情景记忆预算）；Ollama 的 `write_chapter` 并发 lane 默认设为 2。
 - `--reset` 确认后会删除 `workspace/.dayu/`、`workspace/config/`、`workspace/assets/`，再按首次初始化流程重建；它比 `--overwrite` 更彻底，会一并清空运行时状态。
 - 联网搜索默认可走 `auto`，若配置了 Tavily / Serper，会优先使用对应 provider。
 - 若运行环境需要访问 `localhost`、私网 IP 或内网域名，可在 `workspace/config/run.json` 的 `web_tools_config.allow_private_network_url` 中显式打开内网访问开关。

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -66,6 +66,7 @@ _PROVIDER_OPTION_CUSTOM_OPENAI = "custom_openai"
 _OLLAMA_CATALOG_KEY = "ollama"
 _OLLAMA_DEFAULT_ENDPOINT = "http://localhost:11434"
 _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS = 262144
+_OLLAMA_DEFAULT_WRITE_CHAPTER_LANE = 2
 _OLLAMA_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "write": {"temperature": 0.6},
     "overview": {"temperature": 0.1},
@@ -76,13 +77,68 @@ _OLLAMA_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "infer": {"temperature": 0.1},
     "conversation_compaction": {"temperature": 0.1},
 }
-_OLLAMA_CONVERSATION_MEMORY: dict[str, int] = {
-    "episodic_memory_token_budget_floor": 6000,
-    "episodic_memory_token_budget_cap": 6000,
-}
+_CONTEXT_TOKENS_LARGE_THRESHOLD = 1_000_000
+_LARGE_CONTEXT_WORKING_MEMORY_CAP = 80000
+_SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR = 6000
+_SMALL_CONTEXT_EPISODIC_MEMORY_CAP = 6000
+
+
+def _build_conversation_memory_overrides(max_context_tokens: int) -> dict[str, int]:
+    """根据 ``max_context_tokens`` 构建 ``conversation_memory`` 覆盖项。
+
+    大上下文模型（>= 100 万 tokens）侧重扩大工作记忆上限；
+    小上下文模型侧重收紧情景记忆以节省预算。
+
+    Args:
+        max_context_tokens: 模型的最大上下文 tokens 数。
+
+    Returns:
+        可直接写入 ``runtime_hints.conversation_memory`` 的覆盖字典。
+    """
+
+    if max_context_tokens >= _CONTEXT_TOKENS_LARGE_THRESHOLD:
+        return {"working_memory_token_budget_cap": _LARGE_CONTEXT_WORKING_MEMORY_CAP}
+    return {
+        "episodic_memory_token_budget_floor": _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
+        "episodic_memory_token_budget_cap": _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
+    }
+
+
+def _prompt_max_context_tokens(default: int) -> int:
+    """交互式收集最大上下文 tokens 数。
+
+    Args:
+        default: 用户直接回车时使用的默认值。
+
+    Returns:
+        用户输入的或默认的最大上下文 tokens 正整数。
+
+    Raises:
+        SystemExit: 用户中断或输入非法值。
+    """
+
+    try:
+        raw_tokens = input(
+            f"  最大上下文 tokens（直接回车使用默认值 {default}）: "
+        ).strip()
+        if raw_tokens:
+            value = int(raw_tokens)
+            if value <= 0:
+                print("错误: 最大上下文 tokens 必须为正整数")
+                sys.exit(1)
+            return value
+        return default
+    except (EOFError, KeyboardInterrupt):
+        print()
+        sys.exit(1)
+    except ValueError:
+        print("错误: 最大上下文 tokens 必须为正整数")
+        sys.exit(1)
+
 
 # 自定义 OpenAI 兼容 API（OpenRouter 等）统一使用的目录键
 _CUSTOM_CATALOG_KEY = "custom-openai"
+_CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS = 131072
 _CUSTOM_OPENAI_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "write": {"temperature": 1.0},
     "overview": {"temperature": 1.0},
@@ -92,10 +148,6 @@ _CUSTOM_OPENAI_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "prompt": {"temperature": 1.0},
     "infer": {"temperature": 0.5},
     "conversation_compaction": {"temperature": 0.4},
-}
-_CUSTOM_OPENAI_CONVERSATION_MEMORY: dict[str, int] = {
-    "episodic_memory_token_budget_floor": 4000,
-    "episodic_memory_token_budget_cap": 4000,
 }
 
 _PROVIDER_OPTIONS: tuple[_ProviderOption, ...] = (
@@ -913,6 +965,7 @@ class _CustomOpenAIConfig:
     base_url: str
     api_key_value: str
     model_id: str
+    max_context_tokens: int
 
 
 def _prompt_custom_openai_config(api_key_name: str) -> _CustomOpenAIConfig:
@@ -960,10 +1013,13 @@ def _prompt_custom_openai_config(api_key_name: str) -> _CustomOpenAIConfig:
         print()
         sys.exit(1)
 
+    max_context_tokens = _prompt_max_context_tokens(_CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS)
+
     return _CustomOpenAIConfig(
         base_url=base_url,
         api_key_value=api_key_value,
         model_id=model_id,
+        max_context_tokens=max_context_tokens,
     )
 
 
@@ -972,6 +1028,7 @@ def _build_custom_openai_catalog_entry(
     endpoint_url: str,
     api_key_name: str,
     model_id: str,
+    max_context_tokens: int,
     description: str,
 ) -> dict[str, object]:
     """构造自定义 OpenAI 兼容模型的 catalog 条目。
@@ -980,6 +1037,7 @@ def _build_custom_openai_catalog_entry(
         endpoint_url: OpenAI 兼容接口的 ``/chat/completions`` 地址。
         api_key_name: 对应 API Key 的环境变量名。
         model_id: 用户输入的目标模型 ID。
+        max_context_tokens: 最大上下文 tokens 数。
         description: 写入 catalog 的描述信息。
 
     Returns:
@@ -995,7 +1053,7 @@ def _build_custom_openai_catalog_entry(
     }
     runtime_hints = {
         "temperature_profiles": _CUSTOM_OPENAI_TEMPERATURE_PROFILES,
-        "conversation_memory": _CUSTOM_OPENAI_CONVERSATION_MEMORY,
+        "conversation_memory": _build_conversation_memory_overrides(max_context_tokens),
     }
     return {
         "runner_type": "openai_compatible",
@@ -1010,7 +1068,7 @@ def _build_custom_openai_catalog_entry(
         "supports_tool_calling": True,
         "supports_usage": True,
         "supports_stream_usage": True,
-        "max_context_tokens": 131072,
+        "max_context_tokens": max_context_tokens,
         "extra_payloads": {},
         "description": description,
         "runtime_hints": runtime_hints,
@@ -1056,6 +1114,7 @@ def _write_custom_openai_catalog_entries(
         endpoint_url=endpoint_url,
         api_key_name=api_key_name,
         model_id=custom.model_id,
+        max_context_tokens=custom.max_context_tokens,
         description=f"自定义 OpenAI 兼容 API（{custom.base_url}）",
     )
 
@@ -1094,23 +1153,11 @@ def _prompt_ollama_config() -> _OllamaConfig:
         if not model_id:
             print("错误: 模型 ID 不能为空")
             sys.exit(1)
-
-        raw_tokens = input(
-            f"  最大上下文 tokens（直接回车使用默认值 {_OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS}）: "
-        ).strip()
-        if raw_tokens:
-            max_context_tokens = int(raw_tokens)
-            if max_context_tokens <= 0:
-                print("错误: 最大上下文 tokens 必须为正整数")
-                sys.exit(1)
-        else:
-            max_context_tokens = _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS
     except (EOFError, KeyboardInterrupt):
         print()
         sys.exit(1)
-    except ValueError:
-        print(f"错误: 最大上下文 tokens 必须为正整数")
-        sys.exit(1)
+
+    max_context_tokens = _prompt_max_context_tokens(_OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS)
 
     return _OllamaConfig(
         model_id=model_id,
@@ -1137,7 +1184,7 @@ def _build_ollama_catalog_entry(
 
     runtime_hints: dict[str, object] = {
         "temperature_profiles": _OLLAMA_TEMPERATURE_PROFILES,
-        "conversation_memory": _OLLAMA_CONVERSATION_MEMORY,
+        "conversation_memory": _build_conversation_memory_overrides(max_context_tokens),
     }
     return {
         "runner_type": "openai_compatible",
@@ -1159,6 +1206,44 @@ def _build_ollama_catalog_entry(
         "description": description,
         "runtime_hints": runtime_hints,
     }
+
+
+def _override_ollama_write_chapter_lane(config_dir: Path) -> None:
+    """将 ``run.json`` 中 ``write_chapter`` lane 覆盖为 Ollama 推荐值。
+
+    仅当当前值等于迁移脚本的默认值（5）时才覆写，以尊重用户自定义。
+
+    Args:
+        config_dir: 工作区配置目录，即 ``workspace/config``。
+
+    Raises:
+        无：文件缺失、解析失败或结构不符预期均安静跳过。
+    """
+
+    run_json_path = config_dir / "run.json"
+    if not run_json_path.exists():
+        return
+    try:
+        raw_text = run_json_path.read_text(encoding="utf-8")
+        payload: object = json.loads(raw_text)
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(payload, dict):
+        return
+    host_config = payload.get("host_config")
+    if not isinstance(host_config, dict):
+        return
+    lane_section = host_config.get("lane")
+    if not isinstance(lane_section, dict):
+        return
+    current = lane_section.get("write_chapter")
+    if current != 5:
+        return
+    lane_section["write_chapter"] = _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE
+    run_json_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _write_ollama_catalog_entries(
@@ -1426,6 +1511,7 @@ def run_init_command(args: Namespace) -> int:
             print(f"\n❌ {exc}")
             return 1
         print(f"✓ 已写入 Ollama 模型条目到 {config_dir / 'llm_models.json'}")
+        _override_ollama_write_chapter_lane(config_dir)
     elif chosen_option_key == _PROVIDER_OPTION_CUSTOM_OPENAI:
         effective_api_key_name = chosen_option.api_key_name
         custom = _prompt_custom_openai_config(effective_api_key_name)

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -67,11 +67,6 @@ _OLLAMA_CATALOG_KEY = "ollama"
 _OLLAMA_DEFAULT_ENDPOINT = "http://localhost:11434"
 _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS = 262144
 _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE = 2
-_DEFAULT_WRITE_CHAPTER_LANE = 5
-_PROVIDER_DEFAULT_WRITE_CHAPTER_LANES: frozenset[int] = frozenset({
-    _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
-    _DEFAULT_WRITE_CHAPTER_LANE,
-})
 _OLLAMA_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "write": {"temperature": 0.6},
     "overview": {"temperature": 0.1},
@@ -1213,19 +1208,55 @@ def _build_ollama_catalog_entry(
     }
 
 
-def _set_write_chapter_lane(config_dir: Path, target: int) -> None:
+def _read_package_default_write_chapter_lane() -> int | None:
+    """从包内 ``run.json`` 读取 ``write_chapter`` lane 默认值。
+
+    Returns:
+        包内配置的 ``write_chapter`` 值；文件缺失、解析失败或结构不符时返回 None。
+
+    Raises:
+        无。
+    """
+
+    try:
+        pkg_run_json = resolve_package_config_path() / "run.json"
+        raw_text = pkg_run_json.read_text(encoding="utf-8")
+        payload: object = json.loads(raw_text)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    host_config = payload.get("host_config")
+    if not isinstance(host_config, dict):
+        return None
+    lane_section = host_config.get("lane")
+    if not isinstance(lane_section, dict):
+        return None
+    value = lane_section.get("write_chapter")
+    return value if isinstance(value, int) else None
+
+
+def _set_write_chapter_lane(
+    config_dir: Path,
+    target: int,
+    *,
+    previous_default: int | None,
+) -> None:
     """设置 ``run.json`` 中 ``write_chapter`` lane 为指定供应商默认值。
 
-    仅当当前值属于已知的供应商默认值（2 或 5）时才覆写，
-    以尊重用户手动自定义的值。
+    仅当当前值等于 ``previous_default`` 时才覆写，以尊重用户手动自定义。
 
     Args:
         config_dir: 工作区配置目录，即 ``workspace/config``。
         target: 目标供应商默认值。
+        previous_default: 前一个供应商的默认值；为 None 时不做任何覆写。
 
     Raises:
         无：文件缺失、解析失败或结构不符预期均安静跳过。
     """
+
+    if previous_default is None:
+        return
 
     run_json_path = config_dir / "run.json"
     if not run_json_path.exists():
@@ -1244,7 +1275,7 @@ def _set_write_chapter_lane(config_dir: Path, target: int) -> None:
     if not isinstance(lane_section, dict):
         return
     current = lane_section.get("write_chapter")
-    if not isinstance(current, int) or current not in _PROVIDER_DEFAULT_WRITE_CHAPTER_LANES:
+    if current != previous_default:
         return
     if current == target:
         return
@@ -1520,7 +1551,10 @@ def run_init_command(args: Namespace) -> int:
             print(f"\n❌ {exc}")
             return 1
         print(f"✓ 已写入 Ollama 模型条目到 {config_dir / 'llm_models.json'}")
-        _set_write_chapter_lane(config_dir, _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE)
+        _pkg_lane = _read_package_default_write_chapter_lane()
+        _set_write_chapter_lane(
+            config_dir, _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE, previous_default=_pkg_lane,
+        )
     elif chosen_option_key == _PROVIDER_OPTION_CUSTOM_OPENAI:
         effective_api_key_name = chosen_option.api_key_name
         custom = _prompt_custom_openai_config(effective_api_key_name)
@@ -1562,9 +1596,12 @@ def run_init_command(args: Namespace) -> int:
                 print(f"   为避免切换模型后下次启动找不到 API Key，跳过 manifest 更新。")
                 print(f"   请手动配置环境变量后重新运行 dayu-cli init。")
 
-    # 非 Ollama 供应商恢复 write_chapter lane 为默认值（从 Ollama 切换时需要）
+    # 非 Ollama 供应商恢复 write_chapter lane 为包内默认值（从 Ollama 切换时需要）
     if chosen_option_key != _PROVIDER_OPTION_OLLAMA:
-        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+        _pkg_lane = _read_package_default_write_chapter_lane()
+        _set_write_chapter_lane(
+            config_dir, _pkg_lane or 5, previous_default=_OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
+        )
 
     # 3. 更新 manifest 默认模型（仅在主 key 持久化成功或已存在时执行）
     non_thinking = chosen_option.non_thinking_model

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -1149,7 +1149,7 @@ def _prompt_ollama_config() -> _OllamaConfig:
     print("\n— 本地 Ollama 模型配置 —")
     print(f"  默认 endpoint: {_OLLAMA_DEFAULT_ENDPOINT}/v1/chat/completions")
     try:
-        model_id = input("  模型 ID（如 qwen3:30b-thinking、llama3:70b）: ").strip()
+        model_id = input("  模型 ID（如 qwen3:30b-thinking、gemma4:31b、llama3:70b）: ").strip()
         if not model_id:
             print("错误: 模型 ID 不能为空")
             sys.exit(1)

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -67,6 +67,11 @@ _OLLAMA_CATALOG_KEY = "ollama"
 _OLLAMA_DEFAULT_ENDPOINT = "http://localhost:11434"
 _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS = 262144
 _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE = 2
+_DEFAULT_WRITE_CHAPTER_LANE = 5
+_PROVIDER_DEFAULT_WRITE_CHAPTER_LANES: frozenset[int] = frozenset({
+    _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
+    _DEFAULT_WRITE_CHAPTER_LANE,
+})
 _OLLAMA_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "write": {"temperature": 0.6},
     "overview": {"temperature": 0.1},
@@ -1208,13 +1213,15 @@ def _build_ollama_catalog_entry(
     }
 
 
-def _override_ollama_write_chapter_lane(config_dir: Path) -> None:
-    """将 ``run.json`` 中 ``write_chapter`` lane 覆盖为 Ollama 推荐值。
+def _set_write_chapter_lane(config_dir: Path, target: int) -> None:
+    """设置 ``run.json`` 中 ``write_chapter`` lane 为指定供应商默认值。
 
-    仅当当前值等于迁移脚本的默认值（5）时才覆写，以尊重用户自定义。
+    仅当当前值属于已知的供应商默认值（2 或 5）时才覆写，
+    以尊重用户手动自定义的值。
 
     Args:
         config_dir: 工作区配置目录，即 ``workspace/config``。
+        target: 目标供应商默认值。
 
     Raises:
         无：文件缺失、解析失败或结构不符预期均安静跳过。
@@ -1237,9 +1244,11 @@ def _override_ollama_write_chapter_lane(config_dir: Path) -> None:
     if not isinstance(lane_section, dict):
         return
     current = lane_section.get("write_chapter")
-    if current != 5:
+    if not isinstance(current, int) or current not in _PROVIDER_DEFAULT_WRITE_CHAPTER_LANES:
         return
-    lane_section["write_chapter"] = _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE
+    if current == target:
+        return
+    lane_section["write_chapter"] = target
     run_json_path.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
@@ -1511,7 +1520,7 @@ def run_init_command(args: Namespace) -> int:
             print(f"\n❌ {exc}")
             return 1
         print(f"✓ 已写入 Ollama 模型条目到 {config_dir / 'llm_models.json'}")
-        _override_ollama_write_chapter_lane(config_dir)
+        _set_write_chapter_lane(config_dir, _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE)
     elif chosen_option_key == _PROVIDER_OPTION_CUSTOM_OPENAI:
         effective_api_key_name = chosen_option.api_key_name
         custom = _prompt_custom_openai_config(effective_api_key_name)
@@ -1552,6 +1561,10 @@ def run_init_command(args: Namespace) -> int:
                 print(f"   已为当前进程设置，但重开终端后会丢失。")
                 print(f"   为避免切换模型后下次启动找不到 API Key，跳过 manifest 更新。")
                 print(f"   请手动配置环境变量后重新运行 dayu-cli init。")
+
+    # 非 Ollama 供应商恢复 write_chapter lane 为默认值（从 Ollama 切换时需要）
+    if chosen_option_key != _PROVIDER_OPTION_OLLAMA:
+        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
 
     # 3. 更新 manifest 默认模型（仅在主 key 持久化成功或已存在时执行）
     non_thinking = chosen_option.non_thinking_model

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -11,15 +11,23 @@ from unittest.mock import patch
 import pytest
 
 from dayu.cli.commands.init import (
+    _build_conversation_memory_overrides,
+    _CONTEXT_TOKENS_LARGE_THRESHOLD,
     _CUSTOM_CATALOG_KEY,
+    _CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS,
     _CustomOpenAIConfig,
     _HF_MIRROR_URL,
     _INIT_ROLE_KEY,
+    _LARGE_CONTEXT_WORKING_MEMORY_CAP,
     _OLLAMA_CATALOG_KEY,
     _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS,
     _OLLAMA_DEFAULT_ENDPOINT,
+    _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
     _OllamaConfig,
+    _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
+    _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
     _build_ollama_catalog_entry,
+    _override_ollama_write_chapter_lane,
     _PROVIDER_OPTION_CUSTOM_OPENAI,
     _PROVIDER_OPTION_DEEPSEEK_FLASH,
     _PROVIDER_OPTION_DEEPSEEK_PRO,
@@ -550,7 +558,7 @@ class TestPromptCustomOpenAIConfig:
     def test_collects_values_and_normalizes_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """正常输入时返回收集结果，并去掉 base URL 末尾斜杠。"""
         monkeypatch.delenv("CUSTOM_OPENAI_API_KEY", raising=False)
-        inputs = iter(["https://openrouter.ai/api/v1/", "sk-custom", "openai/gpt-4o"])
+        inputs = iter(["https://openrouter.ai/api/v1/", "sk-custom", "openai/gpt-4o", ""])
         monkeypatch.setattr("builtins.input", lambda *_args: next(inputs))
 
         config = _prompt_custom_openai_config("CUSTOM_OPENAI_API_KEY")
@@ -559,18 +567,20 @@ class TestPromptCustomOpenAIConfig:
             base_url="https://openrouter.ai/api/v1",
             api_key_value="sk-custom",
             model_id="openai/gpt-4o",
+            max_context_tokens=_CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS,
         )
 
     def test_reuses_existing_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """环境变量已存在时复用现有 API Key，不再重复输入。"""
         monkeypatch.setenv("CUSTOM_OPENAI_API_KEY", "sk-existing-123456")
-        inputs = iter(["https://openrouter.ai/api/v1", "anthropic/claude-sonnet-4"])
+        inputs = iter(["https://openrouter.ai/api/v1", "anthropic/claude-sonnet-4", "200000"])
         monkeypatch.setattr("builtins.input", lambda *_args: next(inputs))
 
         config = _prompt_custom_openai_config("CUSTOM_OPENAI_API_KEY")
 
         assert config.api_key_value == "sk-existing-123456"
         assert config.model_id == "anthropic/claude-sonnet-4"
+        assert config.max_context_tokens == 200000
 
     def test_empty_base_url_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Base URL 为空时退出。"""
@@ -613,6 +623,7 @@ class TestWriteCustomOpenAICatalogEntries:
                 base_url="https://openrouter.ai/api/v1",
                 api_key_value="sk-custom",
                 model_id="openai/gpt-4o",
+                max_context_tokens=_CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS,
             ),
             api_key_name="CUSTOM_OPENAI_API_KEY",
         )
@@ -637,6 +648,7 @@ class TestWriteCustomOpenAICatalogEntries:
                     base_url="https://openrouter.ai/api/v1",
                     api_key_value="sk-custom",
                     model_id="openai/gpt-4o",
+                    max_context_tokens=_CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS,
                 ),
                 api_key_name="CUSTOM_OPENAI_API_KEY",
             )
@@ -977,6 +989,7 @@ class TestRunInit:
                 "https://openrouter.ai/api/v1/",
                 "sk-custom-openrouter",
                 "openai/gpt-4o",
+                "",                    # max_context_tokens（使用默认值）
                 "",
                 "",
                 "",
@@ -1967,7 +1980,7 @@ class TestRunInitFailurePaths:
             "dayu.cli.commands.init._prompt_provider_selection",
             lambda: _PROVIDER_OPTION_CUSTOM_OPENAI,
         )
-        inputs = iter(["https://openrouter.ai/api/v1", "sk-custom", "openai/gpt-4o"])
+        inputs = iter(["https://openrouter.ai/api/v1", "sk-custom", "openai/gpt-4o", ""])
         monkeypatch.setattr("builtins.input", lambda *_args: next(inputs))
 
         args = Namespace(base=str(base), overwrite=False)
@@ -2348,3 +2361,222 @@ class TestInitPrewarm:
         args = Namespace(base=str(base), overwrite=False)
         exit_code = run_init_command(args)
         assert exit_code == 0
+
+
+# --------------------------------------------------------------------------- #
+#  _build_conversation_memory_overrides
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildConversationMemoryOverrides:
+    """conversation_memory 动态构建测试。"""
+
+    def test_large_context_returns_working_memory_cap(self) -> None:
+        """max_context_tokens >= 100 万时返回 working_memory_token_budget_cap。"""
+        result = _build_conversation_memory_overrides(1_000_000)
+        assert result == {"working_memory_token_budget_cap": _LARGE_CONTEXT_WORKING_MEMORY_CAP}
+
+    def test_large_context_above_threshold(self) -> None:
+        """远超阈值时仍返回 working_memory_token_budget_cap。"""
+        result = _build_conversation_memory_overrides(2_000_000)
+        assert result == {"working_memory_token_budget_cap": _LARGE_CONTEXT_WORKING_MEMORY_CAP}
+
+    def test_small_context_returns_episodic_memory(self) -> None:
+        """max_context_tokens < 100 万时返回 episodic_memory 覆盖。"""
+        result = _build_conversation_memory_overrides(262144)
+        assert result == {
+            "episodic_memory_token_budget_floor": _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
+            "episodic_memory_token_budget_cap": _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
+        }
+
+    def test_threshold_boundary(self) -> None:
+        """恰好等于阈值时走大上下文分支。"""
+        result = _build_conversation_memory_overrides(_CONTEXT_TOKENS_LARGE_THRESHOLD)
+        assert "working_memory_token_budget_cap" in result
+
+    def test_just_below_threshold(self) -> None:
+        """阈值减 1 时走小上下文分支。"""
+        result = _build_conversation_memory_overrides(_CONTEXT_TOKENS_LARGE_THRESHOLD - 1)
+        assert "episodic_memory_token_budget_cap" in result
+
+
+# --------------------------------------------------------------------------- #
+#  _override_ollama_write_chapter_lane
+# --------------------------------------------------------------------------- #
+
+
+class TestOverrideOllamaWriteChapterLane:
+    """Ollama write_chapter lane 覆盖测试。"""
+
+    def test_overrides_default_5_to_2(self, tmp_path: Path) -> None:
+        """当前值为迁移默认值 5 时覆盖为 2。"""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        run_json = config_dir / "run.json"
+        run_json.write_text(
+            json.dumps({
+                "host_config": {
+                    "lane": {
+                        "llm_api": 8,
+                        "write_chapter": 5,
+                    }
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        _override_ollama_write_chapter_lane(config_dir)
+
+        data = json.loads(run_json.read_text(encoding="utf-8"))
+        assert data["host_config"]["lane"]["write_chapter"] == _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE
+
+    def test_preserves_custom_value(self, tmp_path: Path) -> None:
+        """当前值不是 5 时保留用户自定义值。"""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        run_json = config_dir / "run.json"
+        run_json.write_text(
+            json.dumps({
+                "host_config": {
+                    "lane": {
+                        "write_chapter": 3,
+                    }
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        _override_ollama_write_chapter_lane(config_dir)
+
+        data = json.loads(run_json.read_text(encoding="utf-8"))
+        assert data["host_config"]["lane"]["write_chapter"] == 3
+
+    def test_missing_run_json_noop(self, tmp_path: Path) -> None:
+        """run.json 不存在时安静跳过。"""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        _override_ollama_write_chapter_lane(config_dir)
+
+    def test_missing_lane_section_noop(self, tmp_path: Path) -> None:
+        """host_config.lane 不存在时安静跳过。"""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        run_json = config_dir / "run.json"
+        run_json.write_text(json.dumps({"host_config": {}}), encoding="utf-8")
+        _override_ollama_write_chapter_lane(config_dir)
+
+
+# --------------------------------------------------------------------------- #
+#  集成测试：conversation_memory 与 write_chapter lane 验证
+# --------------------------------------------------------------------------- #
+
+
+class TestInitConversationMemoryAndLane:
+    """init 流程中 conversation_memory 和 write_chapter lane 集成验证。"""
+
+    def test_ollama_small_context_conversation_memory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ollama 小上下文模型应写入 episodic_memory 覆盖。"""
+        src = tmp_path / "pkg_config"
+        src.mkdir()
+        (src / "run.json").write_text(
+            json.dumps({
+                "host_config": {
+                    "lane": {"llm_api": 8, "write_chapter": 5}
+                }
+            }),
+            encoding="utf-8",
+        )
+        manifests = src / "prompts" / "manifests"
+        manifests.mkdir(parents=True)
+        (manifests / "write.json").write_text(
+            json.dumps({"model": {"default_name": "mimo-v2.5-pro-plan"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("dayu.cli.commands.init.resolve_package_config_path", lambda: src)
+        pkg_assets = tmp_path / "pkg_assets"
+        pkg_assets.mkdir()
+        (pkg_assets / "template.md").write_text("# t", encoding="utf-8")
+        monkeypatch.setattr("dayu.cli.commands.init.resolve_package_assets_path", lambda: pkg_assets)
+
+        _clear_provider_env_vars(monkeypatch)
+        for k in ("TAVILY_API_KEY", "SERPER_API_KEY", "FMP_API_KEY", "HF_ENDPOINT", "HF_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv(SEC_USER_AGENT_ENV, raising=False)
+        monkeypatch.setattr("dayu.cli.commands.init._is_hf_hub_reachable", lambda: True)
+        monkeypatch.setattr("dayu.cli.commands.init._run_init_prewarm", lambda **_kw: (True, ""))
+        monkeypatch.setattr("dayu.cli.commands.init._prompt_provider_selection", lambda: _PROVIDER_OPTION_OLLAMA)
+        monkeypatch.setattr("dayu.cli.commands.init._persist_env_var", lambda _k, _v: ("~/.zshrc", True))
+        inputs = iter([
+            "qwen3:30b-thinking",
+            "262144",              # max_context_tokens < 100 万
+            "", "", "",            # search keys
+            "", "",                # HF
+            "",                    # SEC
+        ])
+        monkeypatch.setattr("builtins.input", lambda *_args: next(inputs))
+
+        base = tmp_path / "workspace"
+        base.mkdir()
+        exit_code = run_init_command(Namespace(base=str(base), overwrite=False))
+        assert exit_code == 0
+
+        llm_models = json.loads((base / "config" / "llm_models.json").read_text(encoding="utf-8"))
+        cm = llm_models[_OLLAMA_CATALOG_KEY]["runtime_hints"]["conversation_memory"]
+        assert cm["episodic_memory_token_budget_floor"] == _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR
+        assert cm["episodic_memory_token_budget_cap"] == _SMALL_CONTEXT_EPISODIC_MEMORY_CAP
+        assert "working_memory_token_budget_cap" not in cm
+
+        # 验证 write_chapter lane 从 5 覆盖为 2
+        run_data = json.loads((base / "config" / "run.json").read_text(encoding="utf-8"))
+        assert run_data["host_config"]["lane"]["write_chapter"] == _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE
+
+    def test_custom_openai_large_context_conversation_memory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Custom OpenAI 大上下文模型应写入 working_memory_token_budget_cap。"""
+        src = tmp_path / "pkg_config"
+        src.mkdir()
+        (src / "run.json").write_text("{}", encoding="utf-8")
+        manifests = src / "prompts" / "manifests"
+        manifests.mkdir(parents=True)
+        (manifests / "write.json").write_text(
+            json.dumps({"model": {"default_name": "mimo-v2.5-pro-plan"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("dayu.cli.commands.init.resolve_package_config_path", lambda: src)
+        pkg_assets = tmp_path / "pkg_assets"
+        pkg_assets.mkdir()
+        (pkg_assets / "template.md").write_text("# t", encoding="utf-8")
+        monkeypatch.setattr("dayu.cli.commands.init.resolve_package_assets_path", lambda: pkg_assets)
+
+        _clear_provider_env_vars(monkeypatch)
+        for k in ("TAVILY_API_KEY", "SERPER_API_KEY", "FMP_API_KEY", "HF_ENDPOINT", "HF_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv(SEC_USER_AGENT_ENV, raising=False)
+        monkeypatch.setattr("dayu.cli.commands.init._is_hf_hub_reachable", lambda: True)
+        monkeypatch.setattr("dayu.cli.commands.init._run_init_prewarm", lambda **_kw: (True, ""))
+        monkeypatch.setattr(
+            "dayu.cli.commands.init._prompt_provider_selection",
+            lambda: _PROVIDER_OPTION_CUSTOM_OPENAI,
+        )
+        monkeypatch.setattr("dayu.cli.commands.init._persist_env_var", lambda _k, _v: ("~/.zshrc", True))
+        inputs = iter([
+            "https://openrouter.ai/api/v1",
+            "sk-custom",
+            "openai/gpt-4o",
+            "1000000",             # max_context_tokens >= 100 万
+            "", "", "",            # search keys
+            "", "",                # HF
+            "",                    # SEC
+        ])
+        monkeypatch.setattr("builtins.input", lambda *_args: next(inputs))
+
+        base = tmp_path / "workspace"
+        base.mkdir()
+        exit_code = run_init_command(Namespace(base=str(base), overwrite=False))
+        assert exit_code == 0
+
+        llm_models = json.loads((base / "config" / "llm_models.json").read_text(encoding="utf-8"))
+        cm = llm_models[_CUSTOM_CATALOG_KEY]["runtime_hints"]["conversation_memory"]
+        assert cm["working_memory_token_budget_cap"] == _LARGE_CONTEXT_WORKING_MEMORY_CAP
+        assert "episodic_memory_token_budget_cap" not in cm

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -23,11 +23,12 @@ from dayu.cli.commands.init import (
     _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS,
     _OLLAMA_DEFAULT_ENDPOINT,
     _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
+    _DEFAULT_WRITE_CHAPTER_LANE,
     _OllamaConfig,
     _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
     _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
     _build_ollama_catalog_entry,
-    _override_ollama_write_chapter_lane,
+    _set_write_chapter_lane,
     _PROVIDER_OPTION_CUSTOM_OPENAI,
     _PROVIDER_OPTION_DEEPSEEK_FLASH,
     _PROVIDER_OPTION_DEEPSEEK_PRO,
@@ -2405,57 +2406,85 @@ class TestBuildConversationMemoryOverrides:
 # --------------------------------------------------------------------------- #
 
 
-class TestOverrideOllamaWriteChapterLane:
-    """Ollama write_chapter lane 覆盖测试。"""
+class TestSetWriteChapterLane:
+    """write_chapter lane 供应商切换测试。"""
 
-    def test_overrides_default_5_to_2(self, tmp_path: Path) -> None:
-        """当前值为迁移默认值 5 时覆盖为 2。"""
+    def test_ollama_overrides_5_to_2(self, tmp_path: Path) -> None:
+        """当前值为 5（非 Ollama 默认）时覆盖为 2。"""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
         run_json = config_dir / "run.json"
         run_json.write_text(
             json.dumps({
                 "host_config": {
-                    "lane": {
-                        "llm_api": 8,
-                        "write_chapter": 5,
-                    }
+                    "lane": {"llm_api": 8, "write_chapter": 5}
                 }
             }),
             encoding="utf-8",
         )
 
-        _override_ollama_write_chapter_lane(config_dir)
+        _set_write_chapter_lane(config_dir, _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE)
 
         data = json.loads(run_json.read_text(encoding="utf-8"))
         assert data["host_config"]["lane"]["write_chapter"] == _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE
 
-    def test_preserves_custom_value(self, tmp_path: Path) -> None:
-        """当前值不是 5 时保留用户自定义值。"""
+    def test_switch_from_ollama_to_other_restores_5(self, tmp_path: Path) -> None:
+        """当前值为 2（Ollama 默认）时恢复为 5。"""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
         run_json = config_dir / "run.json"
         run_json.write_text(
             json.dumps({
                 "host_config": {
-                    "lane": {
-                        "write_chapter": 3,
-                    }
+                    "lane": {"llm_api": 8, "write_chapter": 2}
                 }
             }),
             encoding="utf-8",
         )
 
-        _override_ollama_write_chapter_lane(config_dir)
+        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+
+        data = json.loads(run_json.read_text(encoding="utf-8"))
+        assert data["host_config"]["lane"]["write_chapter"] == _DEFAULT_WRITE_CHAPTER_LANE
+
+    def test_preserves_custom_value(self, tmp_path: Path) -> None:
+        """当前值不属于已知供应商默认值时保留用户自定义值。"""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        run_json = config_dir / "run.json"
+        run_json.write_text(
+            json.dumps({
+                "host_config": {
+                    "lane": {"write_chapter": 3}
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
 
         data = json.loads(run_json.read_text(encoding="utf-8"))
         assert data["host_config"]["lane"]["write_chapter"] == 3
+
+    def test_same_value_noop(self, tmp_path: Path) -> None:
+        """当前值与目标值相同时不写入。"""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        run_json = config_dir / "run.json"
+        original = json.dumps({
+            "host_config": {"lane": {"write_chapter": 5}}
+        }, ensure_ascii=False, indent=2) + "\n"
+        run_json.write_text(original, encoding="utf-8")
+
+        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+
+        assert run_json.read_text(encoding="utf-8") == original
 
     def test_missing_run_json_noop(self, tmp_path: Path) -> None:
         """run.json 不存在时安静跳过。"""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        _override_ollama_write_chapter_lane(config_dir)
+        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
 
     def test_missing_lane_section_noop(self, tmp_path: Path) -> None:
         """host_config.lane 不存在时安静跳过。"""
@@ -2463,7 +2492,7 @@ class TestOverrideOllamaWriteChapterLane:
         config_dir.mkdir()
         run_json = config_dir / "run.json"
         run_json.write_text(json.dumps({"host_config": {}}), encoding="utf-8")
-        _override_ollama_write_chapter_lane(config_dir)
+        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -23,7 +23,6 @@ from dayu.cli.commands.init import (
     _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS,
     _OLLAMA_DEFAULT_ENDPOINT,
     _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
-    _DEFAULT_WRITE_CHAPTER_LANE,
     _OllamaConfig,
     _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
     _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
@@ -2423,13 +2422,16 @@ class TestSetWriteChapterLane:
             encoding="utf-8",
         )
 
-        _set_write_chapter_lane(config_dir, _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE)
+        _set_write_chapter_lane(
+            config_dir, _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE, previous_default=5,
+        )
 
         data = json.loads(run_json.read_text(encoding="utf-8"))
         assert data["host_config"]["lane"]["write_chapter"] == _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE
 
-    def test_switch_from_ollama_to_other_restores_5(self, tmp_path: Path) -> None:
-        """当前值为 2（Ollama 默认）时恢复为 5。"""
+    def test_switch_from_ollama_to_other_restores_default(self, tmp_path: Path) -> None:
+        """当前值为 2（Ollama 默认）时恢复为包内默认值。"""
+        _pkg_default = 5
         config_dir = tmp_path / "config"
         config_dir.mkdir()
         run_json = config_dir / "run.json"
@@ -2442,13 +2444,15 @@ class TestSetWriteChapterLane:
             encoding="utf-8",
         )
 
-        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+        _set_write_chapter_lane(
+            config_dir, _pkg_default, previous_default=_OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
+        )
 
         data = json.loads(run_json.read_text(encoding="utf-8"))
-        assert data["host_config"]["lane"]["write_chapter"] == _DEFAULT_WRITE_CHAPTER_LANE
+        assert data["host_config"]["lane"]["write_chapter"] == _pkg_default
 
     def test_preserves_custom_value(self, tmp_path: Path) -> None:
-        """当前值不属于已知供应商默认值时保留用户自定义值。"""
+        """当前值不属于前一个供应商默认值时保留用户自定义值。"""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
         run_json = config_dir / "run.json"
@@ -2461,7 +2465,7 @@ class TestSetWriteChapterLane:
             encoding="utf-8",
         )
 
-        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+        _set_write_chapter_lane(config_dir, 5, previous_default=_OLLAMA_DEFAULT_WRITE_CHAPTER_LANE)
 
         data = json.loads(run_json.read_text(encoding="utf-8"))
         assert data["host_config"]["lane"]["write_chapter"] == 3
@@ -2476,7 +2480,7 @@ class TestSetWriteChapterLane:
         }, ensure_ascii=False, indent=2) + "\n"
         run_json.write_text(original, encoding="utf-8")
 
-        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+        _set_write_chapter_lane(config_dir, 5, previous_default=5)
 
         assert run_json.read_text(encoding="utf-8") == original
 
@@ -2484,7 +2488,7 @@ class TestSetWriteChapterLane:
         """run.json 不存在时安静跳过。"""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+        _set_write_chapter_lane(config_dir, 5, previous_default=5)
 
     def test_missing_lane_section_noop(self, tmp_path: Path) -> None:
         """host_config.lane 不存在时安静跳过。"""
@@ -2492,7 +2496,7 @@ class TestSetWriteChapterLane:
         config_dir.mkdir()
         run_json = config_dir / "run.json"
         run_json.write_text(json.dumps({"host_config": {}}), encoding="utf-8")
-        _set_write_chapter_lane(config_dir, _DEFAULT_WRITE_CHAPTER_LANE)
+        _set_write_chapter_lane(config_dir, 5, previous_default=5)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- `dayu-cli init` 的 Ollama 供应商新增 `write_chapter` lane 默认值 2，避免本地模型并发争抢
- Custom OpenAI 新增 `max_context_tokens` 交互输入（不再硬编码 131072）
- Ollama 和 Custom OpenAI 均根据 `max_context_tokens` 动态设置 `conversation_memory`（>= 100 万 tokens 时 `working_memory_token_budget_cap: 80000`，< 100 万时 `episodic_memory` floor/cap 均为 6000）
- 供应商切换时 `write_chapter` lane 正确恢复：Ollama 设为 2，切回其它供应商时从包内 `run.json` 动态读取默认值恢复（非硬编码 5）
- Ollama 默认模型列表新增 `gemma4:31b`

## Test plan

- [ ] `dayu-cli init` 选择 Ollama，确认 `workspace/config/run.json` 中 `write_chapter` 为 2
- [ ] `dayu-cli init` 选择 Ollama，输入小上下文模型（如 262144），确认 `llm_models.json` 中 `conversation_memory` 写入 `episodic_memory` 覆盖
- [ ] `dayu-cli init` 选择 Custom OpenAI，输入大上下文（如 1000000），确认 `conversation_memory` 写入 `working_memory_token_budget_cap: 80000`
- [ ] 先选 Ollama 再重新 init 选其它供应商，确认 `write_chapter` 恢复为包内默认值
- [ ] pyright 0 errors，pytest 全部通过

Closes #80
