### PR TITLE
feat: 重构多轮会话记忆为两层结构（pinned + 单总池），修复 4 个结构性问题 (#48)

### DIFF
--- a/dayu/README.md
+++ b/dayu/README.md
@@ -70,7 +70,7 @@ playwright install chromium
   - 普通文件（非财报文件）信息提取还需要优化。
   - 优化 Fins 里的港股/A股/美股财报信息提取。
   - Anthropic 原生 API 支持。
-  - Durable memory / Retrieval layer（ Memory只实现了working memory 和 episode summary ）。
+  - Durable memory / Retrieval layer（Memory 当前只实现了单总池 raw turn 回放与 episode summary）。
   - FMP 工具（调研工作已做，见 [../docs/fmp_integration_research.md](../docs/fmp_integration_research.md) ）尚未实现。
   - 更多LLM 工具。
 
@@ -844,7 +844,7 @@ resume 属于执行真源；reply outbox 属于出站交付真源。Host interna
 
 ### 6.2 能力机制
 
-Host 九项能力的具体机制（包括 Session / Run 状态机、pending turn 与 reply outbox 状态机与 CAS 契约、并发治理 lane 合并顺序、cancel 两层语义、启动恢复顺序、分层记忆裁剪与 compaction 乐观锁等）统一收口到 [host/README.md](host/README.md)。本总览不复述。
+Host 九项能力的具体机制（包括 Session / Run 状态机、pending turn 与 reply outbox 状态机与 CAS 契约、并发治理 lane 合并顺序、cancel 两层语义、启动恢复顺序、两层记忆裁剪与 compaction 乐观锁等）统一收口到 [host/README.md](host/README.md)。本总览不复述。
 
 ### 6.3 sub-agent 扩展边界
 
@@ -928,32 +928,30 @@ Scene 当前负责声明：
 
 ## 8. 多轮会话机制
 
-多轮会话当前采用分层记忆模型，而不是简单回放所有历史消息。
-
-当前分层记忆模型由三个层次组成：
+多轮会话采用**两层记忆模型**——`pinned_state` 独立保留不参与 token 池竞争；其余历史共享一个**单总池**，按预算从新到老回放最近 raw turn 与 episode 摘要。不是简单回放所有历史消息。
 
 ```text
 ┌──────────────────────────────────────────────────────────┐
 │  Pinned State（钉住状态）                                 │
-│  ↳ 不可压缩的会话级最小状态，跨 episode 保留              │
+│  ↳ 不可压缩的会话级反幻觉锚点，跨 episode 单调演进        │
 │  ↳ 内容：当前主任务、已确认对象、用户约束、未决问题        │
+│  ↳ 不计入 token budget，独立路径渲染                      │
 ├──────────────────────────────────────────────────────────┤
-│  Episodic Memory（阶段摘要）                              │
-│  ↳ 已压缩的 episode 结构化摘要                            │
-│  ↳ 由 conversation_compaction scene 调用 LLM 生成         │
-│  ↳ 按 token 预算从最近向前回溯选入                        │
+│  单总池（budget = clamp(window*ratio, floor, cap)）       │
+│  ├─ 最近 N 轮 raw turn（recent_turns_floor 强制保留）     │
+│  │   ↳ 不计入 budget，单轮极长走 minimum_preserve 兜底    │
+│  ├─ 更老 raw turn（按 budget 从新到老回放）               │
+│  └─ Episode summaries（剩余 budget 从新到老填充）         │
+│      ↳ confirmed_facts 永远完整保留不参与截断             │
 ├──────────────────────────────────────────────────────────┤
-│  Working Memory（工作记忆）                               │
-│  ↳ 最近的未压缩 turn，高保真回放                          │
-│  ↳ 从后向前选择，受轮数上限和 token 预算双重约束           │
-├──────────────────────────────────────────────────────────┤
-│  Raw Transcript（原始 transcript）                        │
+│  Raw Transcript（原始 transcript，独立物理存储）          │
 │  ↳ 所有原始 turn 的完整记录，以文件系统落盘               │
 │  ↳ 含用户文本、助手回复、工具调用摘要、警告、错误          │
+│  ↳ 永不被 compaction 物理删除，仅 compacted_turn_count 推进│
 └──────────────────────────────────────────────────────────┘
 ```
 
-当前固定机制概述：当前轮用户输入由 `ExecutionContract.message_inputs.user_message` 带入，`system_prompt` 由 scene preparation 生成；Host 在本轮开始前执行同步压缩，再装配历史消息、memory block 与当前轮输入；compaction 预算从最终模型上下文窗口推导。具体裁剪规则、触发阈值、乐观锁写回、默认配置表见 [host/README.md](host/README.md)。
+当前固定机制概述：当前轮用户输入由 `ExecutionContract.message_inputs.user_message` 带入，`system_prompt` 由 scene preparation 生成；Host 在本轮开始前执行同步压缩（`prepare_transcript`，显式接收 `user_text`），再装配历史消息、memory block 与当前轮输入；本轮结束后 `persist_turn` 触发后台 compaction（`schedule_compaction`，不接 `user_text`，避免双计）。compaction 触发以"占模型窗口百分比"单维度判定，预算从最终模型上下文窗口推导。具体裁剪规则、触发公式、乐观锁写回、默认配置表与跨档表（含 128K 档使用注意事项）见 [host/README.md §10](host/README.md)。
 
 ### 8.1 为什么多轮会话属于 Host
 
@@ -961,18 +959,18 @@ Scene 当前负责声明：
 
 - session 持久化
 - transcript 读写
-- working memory 裁剪
+- 单总池裁剪（最近 N 轮 raw + 老 raw + episode summary）
 - episode summary 压缩
 - compaction 后台任务
 - 取消与恢复
 
-这些都属于托管执行能力，因此必须归 `Host`，而不是归 `Agent`。分层记忆模型（Pinned State / Episodic Memory / Working Memory / Raw Transcript）、裁剪顺序、compaction 触发条件、同步/后台压缩的乐观锁语义、配置默认值等机制细节收口于 [host/README.md](host/README.md)，总览不复述。
+这些都属于托管执行能力，因此必须归 `Host`，而不是归 `Agent`。两层记忆模型（Pinned State + 单总池）、裁剪顺序、compaction 触发公式、同步/后台压缩的双路径语义（`prepare_transcript` 显式接 `user_text` / `schedule_compaction` 不接）、乐观锁语义、配置默认值与跨档自适应表（含 128K 档使用注意事项）等机制细节收口于 [host/README.md §10](host/README.md)，总览不复述。
 
 ### 8.2 Durable Memory / Retrieval 扩展边界
 
 当前 memory 只实现了：
 
-- working memory
+- 单总池 raw turn 回放
 - episode summary
 
 当前代码中 `DurableMemoryStoreProtocol` 和 `ConversationRetrievalIndexProtocol` 已定义协议接口，但使用的是空实现（`NullDurableMemoryStore` / `NullConversationRetrievalIndex`）。

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -77,33 +77,6 @@ _OLLAMA_TEMPERATURE_PROFILES: dict[str, dict[str, float]] = {
     "infer": {"temperature": 0.1},
     "conversation_compaction": {"temperature": 0.1},
 }
-_CONTEXT_TOKENS_LARGE_THRESHOLD = 1_000_000
-_LARGE_CONTEXT_WORKING_MEMORY_CAP = 80000
-_SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR = 6000
-_SMALL_CONTEXT_EPISODIC_MEMORY_CAP = 6000
-
-
-def _build_conversation_memory_overrides(max_context_tokens: int) -> dict[str, int]:
-    """根据 ``max_context_tokens`` 构建 ``conversation_memory`` 覆盖项。
-
-    大上下文模型（>= 100 万 tokens）侧重扩大工作记忆上限；
-    小上下文模型侧重收紧情景记忆以节省预算。
-
-    Args:
-        max_context_tokens: 模型的最大上下文 tokens 数。
-
-    Returns:
-        可直接写入 ``runtime_hints.conversation_memory`` 的覆盖字典。
-    """
-
-    if max_context_tokens >= _CONTEXT_TOKENS_LARGE_THRESHOLD:
-        return {"working_memory_token_budget_cap": _LARGE_CONTEXT_WORKING_MEMORY_CAP}
-    return {
-        "episodic_memory_token_budget_floor": _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
-        "episodic_memory_token_budget_cap": _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
-    }
-
-
 def _prompt_max_context_tokens(default: int) -> int:
     """交互式收集最大上下文 tokens 数。
 
@@ -1053,7 +1026,6 @@ def _build_custom_openai_catalog_entry(
     }
     runtime_hints = {
         "temperature_profiles": _CUSTOM_OPENAI_TEMPERATURE_PROFILES,
-        "conversation_memory": _build_conversation_memory_overrides(max_context_tokens),
     }
     return {
         "runner_type": "openai_compatible",
@@ -1184,7 +1156,6 @@ def _build_ollama_catalog_entry(
 
     runtime_hints: dict[str, object] = {
         "temperature_profiles": _OLLAMA_TEMPERATURE_PROFILES,
-        "conversation_memory": _build_conversation_memory_overrides(max_context_tokens),
     }
     return {
         "runner_type": "openai_compatible",

--- a/dayu/config/README.md
+++ b/dayu/config/README.md
@@ -363,9 +363,8 @@ export MIMO_API_KEY="sk-xxxxxxxx"
     "interactive": {"temperature": 0.6}
   },
   "conversation_memory": {
-    "working_memory_token_budget_cap": 20000,
-    "episodic_memory_token_budget_floor": 4000,
-    "episodic_memory_token_budget_cap": 4000
+    "memory_token_budget_cap": 24000,
+    "recent_turns_floor": 3
   }
 }
 ```
@@ -374,7 +373,7 @@ Runtime 的选择规则是：
 
 - 先用 `run.json.conversation_memory.default` 作为全局公式
 - 再合并 `llm_models.json[{model_name}].runtime_hints.conversation_memory`
-- 然后结合该模型的 `max_context_tokens` 计算最终 working / episodic budget
+- 然后结合该模型的 `max_context_tokens` 计算最终单总池 budget
 
 #### 最小检查清单
 
@@ -507,155 +506,104 @@ Agent 行为控制：
 
 ### 5.8 `conversation_memory`
 
-interactive 多轮会话的分层记忆配置：
+仅作用于 `conversation.enabled = true` 的 scene（当前为 `interactive` / `wechat` / `prompt_mt`）。
+其他 scene 不读取该节配置。
 
-- `default`
-
-当前语义：
-- `default` 是所有模型共享的 memory policy 默认值。
-- 模型客观能力，例如 `max_context_tokens`，仍然只来自 `llm_models.json`；`conversation_memory` 不重复声明模型窗口大小。
-- 若某个模型需要特例 policy，配置在 `llm_models.runtime_hints.conversation_memory`，不再写在 `run.json`。
-
-可以把它理解成：
-
-- `llm_models.json` 决定模型“客观能做多少”
-- `conversation_memory` 决定多轮会话里“愿意拿多少上下文来放历史”
-
-`default` / `runtime_hints.conversation_memory` 内可配置的字段：
-
-- `working_memory_max_turns`
-- `working_memory_token_budget_ratio`
-- `working_memory_token_budget_floor`
-- `working_memory_token_budget_cap`
-- `episodic_memory_token_budget_ratio`
-- `episodic_memory_token_budget_floor`
-- `episodic_memory_token_budget_cap`
-- `compaction_trigger_turn_count`
-- `compaction_trigger_token_ratio`
-- `compaction_tail_preserve_turns`
-- `compaction_context_episode_window`
-- `compaction_scene_name`
-
-#### 5.7.1 working memory 和 episodic memory 是什么
-
-当前多轮会话上下文分成两层：
-
-- `working memory`
-  - 最近的高保真原始历史
-  - 主要服务“继续追问上一轮”这种局部连续性
-- `episodic memory`
-  - 更早历史的结构化阶段摘要
-  - 主要服务“别把更早的目标、约束、结论完全忘掉”
-
-当前轮送模时，Runtime 会把这两层和当前问题一起编译进 prompt：
-
-- 当前 scene 的 `system_prompt`
-- `[Conversation Memory]` 摘要块
-- 最近原始历史
-- 当前用户输入
-
-#### 5.7.2 关键字段是什么意思
-
-最重要的 4 个字段是：
-
-- `working_memory_token_budget_ratio`
-  - 先按当前模型 `max_context_tokens * ratio` 计算 working memory 预算
-  - 作用是让大上下文模型自然拿到更大的历史预算
-- `working_memory_token_budget_floor`
-  - working memory 的最小保底
-  - 防止小上下文模型或某些配置下，预算小到几乎什么都放不下
-- `working_memory_token_budget_cap`
-  - working memory 的最大封顶
-  - 防止大上下文模型把太多最近历史塞进 prompt，淹没当前问题
-- `episodic_memory_token_budget_ratio`
-  - 先按当前模型 `max_context_tokens * ratio` 计算 episode summaries 的预算
-- `episodic_memory_token_budget_floor`
-  - episodic memory 的最小保底
-- `episodic_memory_token_budget_cap`
-  - episodic memory 的最大封顶
-
-可以把 working memory 的预算理解成：
+#### 5.8.1 两层结构
 
 ```text
-working_budget = clamp(
-  max_context_tokens * working_memory_token_budget_ratio,
-  working_memory_token_budget_floor,
-  working_memory_token_budget_cap
+[Conversation Memory]
+├── pinned_state                                ← 永远全量、不计入 token 池
+└── 历史单总池（budget = clamp(window * ratio, floor, cap)）
+    ├── 最近 N 轮 raw turn                       ← recent_turns_floor 强制保留，不计入 budget
+    ├── 更老 raw turn（按预算从新到老回放）
+    └── episode summaries（按剩余预算从新到老填充）
+```
+
+- `pinned_state`：会话灵魂——`current_goal` / `confirmed_subjects` / `user_constraints` / `open_questions` 四个结构化字段。compaction 阶段由 LLM 增量产出 `pinned_state_patch`，单调演进、不参与池竞争。
+- 单总池：所有历史共享一份 budget，先扣 episode summaries（剩余 budget），再交给"更老 raw turn"。
+- `recent_turns_floor`：**下限**保底语义。budget 充足时随便回放更多轮；budget=0 时仍至少保最近 N 轮。极端单轮溢出时走 `_build_minimum_preserved_turn_view`：user_text 全保留、assistant 降级裁剪。
+
+#### 5.8.2 8 个配置字段
+
+| # | 字段 | 默认 | 与 `max_context_tokens` 关系 | 作用 |
+|---|---|---|---|---|
+| 1 | `memory_token_budget_ratio` | `0.10` | 池大小 = window * ratio（再被 floor/cap 截断） | 总池占模型窗口百分比 |
+| 2 | `memory_token_budget_floor` | `4000` | 无关（绝对值） | 总池下限保底 |
+| 3 | `memory_token_budget_cap` | `60000` | 无关（绝对值） | 总池上限封顶。1M 档算出 100K，被截到 60K |
+| 4 | `recent_turns_floor` | `2` | 无关 | 最近 N 轮 raw turn 强制保留（不计入 budget） |
+| 5 | `compaction_trigger_context_ratio` | `0.70` | 触发阈值 = window * ratio | 占窗口超此比例时触发压缩 |
+| 6 | `compaction_tail_preserve_turns` | `4` | 无关 | 压缩时保留最近 N 轮 raw 不压 |
+| 7 | `compaction_context_episode_window` | `2` | 无关 | 生成新 episode 时携带的最近 episode 数 |
+| 8 | `compaction_scene_name` | `"conversation_compaction"` | 无关 | 执行压缩使用的 scene |
+
+#### 5.8.3 总池预算公式
+
+```text
+budget = clamp(
+  max_context_tokens * memory_token_budget_ratio,
+  memory_token_budget_floor,
+  memory_token_budget_cap,
 )
 ```
 
-例如：
+跨档自动伸缩：
 
-- 模型 `max_context_tokens = 131072`
-- `working_memory_token_budget_ratio = 0.08`
-- 原始计算值约为 `10485`
-- 如果 `floor = 1500`、`cap = 20000`
-- 那最终 working budget 就是 `10485`
+| 模型窗口 | `window * 0.10` | clamp 后 |
+|---|---|---|
+| 1M | 100K | **60K**（cap 截断） |
+| 256K | 25.6K | **25.6K** |
+| 128K | 12.8K | **12.8K** |
+| 8K | 0.8K | **4K**（floor 兜底） |
 
-如果模型是 1M 上下文，而 ratio 算出来特别大，最终仍会被 `cap` 封顶。
+财报场景信条："长上下文优先留给财报材料、检索结果和当前章节上下文，memory 只建议小步上调"。1M 档 cap 控制在 60K 以内，把窗口让给财报材料。
 
-#### 5.7.3 其余字段的作用
+#### 5.8.4 Compaction 触发公式
 
-- `working_memory_max_turns`
-  - 最近原始历史按 turn 回放时的最大轮数上限
-  - 它和 token budget 一起起作用；先满足预算，再受 turn 数限制
-- `compaction_trigger_turn_count`
-  - 未压缩 raw turns 超过多少轮后，允许触发 episode compaction
-- `compaction_trigger_token_ratio`
-  - 未压缩 raw history 的估算体量，超过 working budget 的多少倍后触发 compaction
-- `compaction_tail_preserve_turns`
-  - 压缩时保留最近多少轮 raw turns 不压
-- `compaction_context_episode_window`
-  - 生成新 episode summary 时，带入多少个最近 episodes 作为邻近上下文
-- `compaction_scene_name`
-  - 执行结构化压缩时使用的专用 scene 名，当前默认 `conversation_compaction`
+```text
+window_used = system_prompt + pinned_state
+            + actual_episodic_in_prompt
+            + uncompressed_raw_turns + current_user_text
+should_compact = window_used > max_context_tokens * compaction_trigger_context_ratio
+```
 
-当前 working memory 策略：
-- 正常情况下按 turn 为单位，从最近历史向前回放。
-- 若最新一轮 turn 过长，不会整轮丢弃；Runtime 会保留完整 `user_text`，并对 `assistant` 内容做降级裁剪。
-- 裁剪顺序固定为：先丢历史工具摘要，再截断 `assistant` 文本前缀，并附加 `...<truncated>` 标记。
-- episodic budget 也按 `ratio/floor/cap` 公式计算，不再使用固定绝对值。
-- `compaction_*` 控制什么时候把更早的 raw turns 压成结构化 episode summary。
-- `compaction_scene_name` 指向 Runtime 使用的专用无工具压缩 scene，默认是 `conversation_compaction`。
+`actual_episodic_in_prompt` 复用 `_build_memory_block` 在当前 budget 下渲染时**实际会送进 prompt 的 episode token**（包括"最新 episode 即使超 budget 也保留一条"的兜底分支）。这样既避免把全量 `transcript.episodes` 计入触发公式带来的抖动，也避免无视兜底分支造成的真实 prompt 体积低估。
 
-#### 5.7.4 什么时候应该改这些值
+`schedule_compaction` 在 `persist_turn` 之后调用——当前轮 user_text 已写进 `transcript.turns` 最末位、自然出现在 `uncompressed_tokens` 中——本入口**不再接收** `user_text` 参数避免重复计数。开局尚未 persist 的 `prepare_transcript` 仍显式传 `user_text`。
 
-常见调参信号：
+财报场景默认 0.70，比通用代码 agent 的 0.75 略早触发——因为财报材料 + 工具结果占大头。
 
-- 如果你发现 follow-up 经常“忘记上一轮刚说过什么”
-  - 先检查 `working_memory_token_budget_cap` 是否过小
-  - 再检查是否给该模型配置了合适的 `runtime_hints.conversation_memory`
-- 如果你发现 prompt 被旧内容塞得太满、当前问题不聚焦
-  - 优先降低 `working_memory_token_budget_cap`
-  - 或适当降低 `working_memory_token_budget_ratio`
-- 如果你只是新增了一个大上下文模型
-  - 不需要在 `conversation_memory` 里重复填写它的上下文窗口
-  - 只需要按需要给它补一个 `runtime_hints.conversation_memory` policy
-  - 最佳实践不是按 `max_context_tokens` 线性放大 memory；长上下文优先留给财报材料、检索结果和当前章节上下文，memory 只建议小步上调 `working_memory_token_budget_cap`
+#### 5.8.5 调参信号
 
-#### 5.7.5 当前配置示意
+- 追问频繁忘上一轮：小步上调 `memory_token_budget_cap`（每次 +8K），或把 `recent_turns_floor` 调到 3。
+- 当前问题被旧内容淹没：下调 `memory_token_budget_cap`，或把 `compaction_trigger_context_ratio` 调到 0.50。
+- 频繁触发 compaction 拖慢响应：把 `compaction_trigger_context_ratio` 调到 0.80。
+- 单轮 user_text 极长导致追问断链：把 `recent_turns_floor` 调到 3（退化路径已由 `_build_minimum_preserved_turn_view` 兜底）。
 
-当前配置形状类似：
+#### 5.8.6 当前默认配置
+
+`run.json` 真源：
 
 ```json
 "conversation_memory": {
   "default": {
-    "working_memory_max_turns": 6,
-    "working_memory_token_budget_ratio": 0.08,
-    "working_memory_token_budget_floor": 1500,
-    "working_memory_token_budget_cap": 12000,
-    "episodic_memory_token_budget_ratio": 0.02,
-    "episodic_memory_token_budget_floor": 2000,
-    "episodic_memory_token_budget_cap": 12000
+    "memory_token_budget_ratio": 0.10,
+    "memory_token_budget_floor": 4000,
+    "memory_token_budget_cap": 60000,
+    "recent_turns_floor": 2,
+    "compaction_trigger_context_ratio": 0.70,
+    "compaction_tail_preserve_turns": 4,
+    "compaction_context_episode_window": 2,
+    "compaction_scene_name": "conversation_compaction"
   }
 }
 ```
 
-实际选择规则始终是：
+合并顺序：
 
-- 先读取 `default`
-- 再合并当前模型的 `runtime_hints.conversation_memory`
-- 然后再结合该模型在 `llm_models.json` 里的 `max_context_tokens` 算预算
+- 先读取 `run.json -> conversation_memory.default`
+- 再合并当前模型的 `llm_models.json -> runtime_hints.conversation_memory`（默认 19 个内置模型不再写覆盖；如有特殊需求可补 8 字段中的子集）
+- 结合该模型在 `llm_models.json` 的 `max_context_tokens` 计算实际 budget
 
 ## 6. `prompts/`
 

--- a/dayu/config/llm_models.json
+++ b/dayu/config/llm_models.json
@@ -51,9 +51,6 @@
         "conversation_compaction": {
           "temperature": 0.4
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -106,9 +103,6 @@
         "conversation_compaction": {
           "temperature": 0.4
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -161,9 +155,6 @@
         "conversation_compaction": {
           "temperature": 0.4
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -216,9 +207,6 @@
         "conversation_compaction": {
           "temperature": 0.4
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -269,9 +257,6 @@
         "conversation_compaction": {
           "temperature": 0.2
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -322,9 +307,6 @@
         "conversation_compaction": {
           "temperature": 0.2
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -377,9 +359,6 @@
         "conversation_compaction": {
           "temperature": 0.2
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -434,9 +413,6 @@
         "conversation_compaction": {
           "temperature": 0.2
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -493,9 +469,6 @@
         "conversation_compaction": {
           "temperature": 0.2
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -552,9 +525,6 @@
         "conversation_compaction": {
           "temperature": 0.2
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -607,9 +577,6 @@
         "conversation_compaction": {
           "temperature": 0.3
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -662,9 +629,6 @@
         "conversation_compaction": {
           "temperature": 0.3
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -717,9 +681,6 @@
         "conversation_compaction": {
           "temperature": 0.3
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -772,9 +733,6 @@
         "conversation_compaction": {
           "temperature": 0.3
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -827,9 +785,6 @@
         "conversation_compaction": {
           "temperature": 0.3
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -882,9 +837,6 @@
         "conversation_compaction": {
           "temperature": 0.3
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -935,9 +887,6 @@
         "conversation_compaction": {
           "temperature": 0.1
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -988,9 +937,6 @@
         "conversation_compaction": {
           "temperature": 0.1
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 80000
       }
     }
   },
@@ -1037,11 +983,6 @@
         "conversation_compaction": {
           "temperature": 0.1
         }
-      },
-      "conversation_memory": {
-        "working_memory_token_budget_cap": 32000,
-        "episodic_memory_token_budget_floor": 6000,
-        "episodic_memory_token_budget_cap": 6000
       }
     }
   }

--- a/dayu/config/run.json
+++ b/dayu/config/run.json
@@ -71,18 +71,14 @@
   },
   "conversation_memory": {
     "default": {
-      "working_memory_max_turns": 6,
-      "working_memory_token_budget_ratio": 0.08,
-      "working_memory_token_budget_floor": 1500,
-      "working_memory_token_budget_cap": 12000,
-      "compaction_trigger_turn_count": 8,
-      "compaction_trigger_token_ratio": 1.5,
+      "memory_token_budget_ratio": 0.10,
+      "memory_token_budget_floor": 4000,
+      "memory_token_budget_cap": 60000,
+      "recent_turns_floor": 2,
+      "compaction_trigger_context_ratio": 0.70,
       "compaction_tail_preserve_turns": 4,
       "compaction_context_episode_window": 2,
-      "compaction_scene_name": "conversation_compaction",
-      "episodic_memory_token_budget_ratio": 0.02,
-      "episodic_memory_token_budget_floor": 2000,
-      "episodic_memory_token_budget_cap": 12000
+      "compaction_scene_name": "conversation_compaction"
     }
   }
 }

--- a/dayu/contracts/agent_execution_serialization.py
+++ b/dayu/contracts/agent_execution_serialization.py
@@ -423,41 +423,25 @@ def _build_conversation_memory_settings_from_snapshot(
         return None
     defaults = ConversationMemorySettings()
     return ConversationMemorySettings(
-        working_memory_max_turns=_snapshot_int_or_default(
-            payload.get("working_memory_max_turns"),
-            default=defaults.working_memory_max_turns,
+        memory_token_budget_ratio=_snapshot_float_or_default(
+            payload.get("memory_token_budget_ratio"),
+            default=defaults.memory_token_budget_ratio,
         ),
-        working_memory_token_budget_ratio=_snapshot_float_or_default(
-            payload.get("working_memory_token_budget_ratio"),
-            default=defaults.working_memory_token_budget_ratio,
+        memory_token_budget_floor=_snapshot_int_or_default(
+            payload.get("memory_token_budget_floor"),
+            default=defaults.memory_token_budget_floor,
         ),
-        working_memory_token_budget_floor=_snapshot_int_or_default(
-            payload.get("working_memory_token_budget_floor"),
-            default=defaults.working_memory_token_budget_floor,
+        memory_token_budget_cap=_snapshot_int_or_default(
+            payload.get("memory_token_budget_cap"),
+            default=defaults.memory_token_budget_cap,
         ),
-        working_memory_token_budget_cap=_snapshot_int_or_default(
-            payload.get("working_memory_token_budget_cap"),
-            default=defaults.working_memory_token_budget_cap,
+        recent_turns_floor=_snapshot_int_or_default(
+            payload.get("recent_turns_floor"),
+            default=defaults.recent_turns_floor,
         ),
-        episodic_memory_token_budget_ratio=_snapshot_float_or_default(
-            payload.get("episodic_memory_token_budget_ratio"),
-            default=defaults.episodic_memory_token_budget_ratio,
-        ),
-        episodic_memory_token_budget_floor=_snapshot_int_or_default(
-            payload.get("episodic_memory_token_budget_floor"),
-            default=defaults.episodic_memory_token_budget_floor,
-        ),
-        episodic_memory_token_budget_cap=_snapshot_int_or_default(
-            payload.get("episodic_memory_token_budget_cap"),
-            default=defaults.episodic_memory_token_budget_cap,
-        ),
-        compaction_trigger_turn_count=_snapshot_int_or_default(
-            payload.get("compaction_trigger_turn_count"),
-            default=defaults.compaction_trigger_turn_count,
-        ),
-        compaction_trigger_token_ratio=_snapshot_float_or_default(
-            payload.get("compaction_trigger_token_ratio"),
-            default=defaults.compaction_trigger_token_ratio,
+        compaction_trigger_context_ratio=_snapshot_float_or_default(
+            payload.get("compaction_trigger_context_ratio"),
+            default=defaults.compaction_trigger_context_ratio,
         ),
         compaction_tail_preserve_turns=_snapshot_int_or_default(
             payload.get("compaction_tail_preserve_turns"),

--- a/dayu/contracts/execution_options.py
+++ b/dayu/contracts/execution_options.py
@@ -63,18 +63,19 @@ class TraceSettings:
 
 @dataclass(frozen=True)
 class ConversationMemorySettings:
-    """多轮会话分层记忆配置。
+    """多轮会话单总池两层记忆配置。
+
+    两层结构：``pinned_state`` 独立保留、不计入 token 池；其余历史共享一个总池，
+    ``budget = clamp(window * memory_token_budget_ratio, memory_token_budget_floor,
+    memory_token_budget_cap)``；``recent_turns_floor`` 给出最近 N 轮强制保留下限，
+    不计入 budget；compaction 触发改为占模型窗口百分比。
 
     Args:
-        working_memory_max_turns: 工作记忆保留的最大轮数。
-        working_memory_token_budget_ratio: 工作记忆预算比例。
-        working_memory_token_budget_floor: 工作记忆预算下限。
-        working_memory_token_budget_cap: 工作记忆预算上限。
-        episodic_memory_token_budget_ratio: 情节记忆预算比例。
-        episodic_memory_token_budget_floor: 情节记忆预算下限。
-        episodic_memory_token_budget_cap: 情节记忆预算上限。
-        compaction_trigger_turn_count: 触发压缩的轮数阈值。
-        compaction_trigger_token_ratio: 触发压缩的 token 比例阈值。
+        memory_token_budget_ratio: 单总池占模型窗口的比例。
+        memory_token_budget_floor: 单总池预算下限（绝对值）。
+        memory_token_budget_cap: 单总池预算上限（绝对值）。
+        recent_turns_floor: 最近 N 轮 raw turn 强制保留下限。
+        compaction_trigger_context_ratio: 触发压缩占模型窗口的比例阈值。
         compaction_tail_preserve_turns: 压缩后保留的尾部轮数。
         compaction_context_episode_window: 压缩时携带的 episode 窗口数。
         compaction_scene_name: 执行压缩使用的 scene 名称。
@@ -86,15 +87,11 @@ class ConversationMemorySettings:
         无。
     """
 
-    working_memory_max_turns: int = 6
-    working_memory_token_budget_ratio: float = 0.08
-    working_memory_token_budget_floor: int = 1500
-    working_memory_token_budget_cap: int = 12000
-    episodic_memory_token_budget_ratio: float = 0.02
-    episodic_memory_token_budget_floor: int = 2000
-    episodic_memory_token_budget_cap: int = 12000
-    compaction_trigger_turn_count: int = 8
-    compaction_trigger_token_ratio: float = 1.5
+    memory_token_budget_ratio: float = 0.10
+    memory_token_budget_floor: int = 4000
+    memory_token_budget_cap: int = 60000
+    recent_turns_floor: int = 2
+    compaction_trigger_context_ratio: float = 0.70
     compaction_tail_preserve_turns: int = 4
     compaction_context_episode_window: int = 2
     compaction_scene_name: str = "conversation_compaction"

--- a/dayu/contracts/model_config.py
+++ b/dayu/contracts/model_config.py
@@ -76,17 +76,18 @@ class TemperatureProfileConfig(TypedDict):
 
 
 class ConversationMemoryRuntimeHints(TypedDict, total=False):
-    """模型 runtime hints 中允许覆盖的 conversation memory 字段。"""
+    """模型 runtime hints 中允许覆盖的 conversation memory 字段。
 
-    working_memory_max_turns: int
-    working_memory_token_budget_ratio: float
-    working_memory_token_budget_floor: int
-    working_memory_token_budget_cap: int
-    episodic_memory_token_budget_ratio: float
-    episodic_memory_token_budget_floor: int
-    episodic_memory_token_budget_cap: int
-    compaction_trigger_turn_count: int
-    compaction_trigger_token_ratio: float
+    单总池两层结构：``pinned_state`` 独立、不计入 token 池；其余历史共享一个总池，
+    `budget = clamp(window * memory_token_budget_ratio, memory_token_budget_floor,
+    memory_token_budget_cap)`，``recent_turns_floor`` 给出最近 N 轮强制保留下限。
+    """
+
+    memory_token_budget_ratio: float
+    memory_token_budget_floor: int
+    memory_token_budget_cap: int
+    recent_turns_floor: int
+    compaction_trigger_context_ratio: float
     compaction_tail_preserve_turns: int
     compaction_context_episode_window: int
     compaction_scene_name: str

--- a/dayu/execution/options.py
+++ b/dayu/execution/options.py
@@ -150,15 +150,11 @@ _DEFAULT_RUN_CONFIG = _DefaultRunConfig(
     ),
     conversation_memory=ConversationMemoryConfig(
         default=ConversationMemorySettings(
-            working_memory_max_turns=6,
-            working_memory_token_budget_ratio=0.08,
-            working_memory_token_budget_floor=1500,
-            working_memory_token_budget_cap=12000,
-            episodic_memory_token_budget_ratio=0.02,
-            episodic_memory_token_budget_floor=2000,
-            episodic_memory_token_budget_cap=12000,
-            compaction_trigger_turn_count=8,
-            compaction_trigger_token_ratio=1.5,
+            memory_token_budget_ratio=0.10,
+            memory_token_budget_floor=4000,
+            memory_token_budget_cap=60000,
+            recent_turns_floor=2,
+            compaction_trigger_context_ratio=0.70,
             compaction_tail_preserve_turns=4,
             compaction_context_episode_window=2,
             compaction_scene_name="conversation_compaction",
@@ -1063,15 +1059,11 @@ def _build_conversation_memory_settings(section: dict[str, Any]) -> Conversation
     """
 
     return ConversationMemorySettings(
-        working_memory_max_turns=int(section["working_memory_max_turns"]),
-        working_memory_token_budget_ratio=float(section["working_memory_token_budget_ratio"]),
-        working_memory_token_budget_floor=int(section["working_memory_token_budget_floor"]),
-        working_memory_token_budget_cap=int(section["working_memory_token_budget_cap"]),
-        episodic_memory_token_budget_ratio=float(section["episodic_memory_token_budget_ratio"]),
-        episodic_memory_token_budget_floor=int(section["episodic_memory_token_budget_floor"]),
-        episodic_memory_token_budget_cap=int(section["episodic_memory_token_budget_cap"]),
-        compaction_trigger_turn_count=int(section["compaction_trigger_turn_count"]),
-        compaction_trigger_token_ratio=float(section["compaction_trigger_token_ratio"]),
+        memory_token_budget_ratio=float(section["memory_token_budget_ratio"]),
+        memory_token_budget_floor=int(section["memory_token_budget_floor"]),
+        memory_token_budget_cap=int(section["memory_token_budget_cap"]),
+        recent_turns_floor=int(section["recent_turns_floor"]),
+        compaction_trigger_context_ratio=float(section["compaction_trigger_context_ratio"]),
         compaction_tail_preserve_turns=int(section["compaction_tail_preserve_turns"]),
         compaction_context_episode_window=int(section["compaction_context_episode_window"]),
         compaction_scene_name=str(section["compaction_scene_name"]).strip() or "conversation_compaction",
@@ -1134,20 +1126,26 @@ def _validate_conversation_memory_settings(settings: ConversationMemorySettings)
         ValueError: 当配置违反静态约束时抛出。
     """
 
-    if settings.working_memory_max_turns <= 0:
-        raise ValueError("conversation_memory.working_memory_max_turns 必须大于 0")
-    if not math.isfinite(settings.working_memory_token_budget_ratio) or settings.working_memory_token_budget_ratio < 0:
-        raise ValueError("conversation_memory.working_memory_token_budget_ratio 必须是非负有限数值")
-    if settings.working_memory_token_budget_floor <= 0:
-        raise ValueError("conversation_memory.working_memory_token_budget_floor 必须大于 0")
-    if settings.working_memory_token_budget_cap < settings.working_memory_token_budget_floor:
-        raise ValueError("conversation_memory.working_memory_token_budget_cap 不能小于 floor")
-    if not math.isfinite(settings.episodic_memory_token_budget_ratio) or settings.episodic_memory_token_budget_ratio < 0:
-        raise ValueError("conversation_memory.episodic_memory_token_budget_ratio 必须是非负有限数值")
-    if settings.episodic_memory_token_budget_floor < 0:
-        raise ValueError("conversation_memory.episodic_memory_token_budget_floor 必须是非负整数")
-    if settings.episodic_memory_token_budget_cap < settings.episodic_memory_token_budget_floor:
-        raise ValueError("conversation_memory.episodic_memory_token_budget_cap 不能小于 floor")
+    if settings.memory_token_budget_floor <= 0:
+        raise ValueError("conversation_memory.memory_token_budget_floor 必须大于 0")
+    if not math.isfinite(settings.memory_token_budget_ratio) or settings.memory_token_budget_ratio < 0:
+        raise ValueError("conversation_memory.memory_token_budget_ratio 必须是非负有限数值")
+    if settings.memory_token_budget_ratio > 1.0:
+        raise ValueError("conversation_memory.memory_token_budget_ratio 不能大于 1")
+    if settings.memory_token_budget_cap < settings.memory_token_budget_floor:
+        raise ValueError("conversation_memory.memory_token_budget_cap 不能小于 floor")
+    if settings.recent_turns_floor < 0:
+        raise ValueError("conversation_memory.recent_turns_floor 必须是非负整数")
+    if not math.isfinite(settings.compaction_trigger_context_ratio):
+        raise ValueError("conversation_memory.compaction_trigger_context_ratio 必须是有限数值")
+    if settings.compaction_trigger_context_ratio <= 0 or settings.compaction_trigger_context_ratio > 1.0:
+        raise ValueError("conversation_memory.compaction_trigger_context_ratio 必须落在 (0, 1] 区间")
+    if settings.compaction_tail_preserve_turns < 0:
+        raise ValueError("conversation_memory.compaction_tail_preserve_turns 必须是非负整数")
+    if settings.compaction_context_episode_window < 0:
+        raise ValueError("conversation_memory.compaction_context_episode_window 必须是非负整数")
+    if not settings.compaction_scene_name.strip():
+        raise ValueError("conversation_memory.compaction_scene_name 不能为空")
 
 
 def resolve_conversation_memory_settings(

--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -31,7 +31,7 @@ Host 对外承担九项稳定能力：
 | Timeout 控制 | 注册 run 截止时间，到点触发 cancel | Deadline watcher + 取消桥 |
 | Cancel 控制 | 双层语义：取消意图 vs 终态落库 | CancellationToken + CancellationBridge |
 | Resume | 按 pending turn lease 重发用户轮，受 max_attempts 门控 | CAS lease + attempt_count 门控 |
-| 多轮会话托管 | Pinned / Episodic / Working / Raw 四层记忆 | 同步裁剪 + 后台 compaction + 乐观锁 |
+| 多轮会话托管 | Pinned State + 单总池（最近 N 轮 raw + 老 raw + episodic summary）两层记忆 | 同步裁剪 + 后台 compaction + 乐观锁 |
 | Reply outbox | 对外回复的"至少一次 + 幂等 + 失败可重试" | 5 态状态机 + delivery_key 幂等 |
 | Agent replay | 在上一次执行的完整对话历史末尾追加一条 user 消息再跑一次 | 进程内 replay stash + opaque `ReplayHandle` + engine 层 `_tools_disabled` 复用 |
 
@@ -333,36 +333,43 @@ Host 暴露的事件只有两类：
 
 ---
 
-## 10. 多轮会话托管（分层记忆）
+## 10. 多轮会话托管（两层记忆）
 
-多轮会话的上下文由四层组成，层次从"永远保留"到"原始流水"：
+多轮会话的上下文由**两层结构**组成：`pinned_state` 独立保留、不参与 token 池竞争；其余历史共享一个**单总池**，按 budget 从新到老回放最近 raw turn 与 episode 摘要。
 
-| 层 | 语义 | 典型内容 |
-| --- | --- | --- |
-| Pinned State | 会话级固定信息，写入后只改不丢 | 用户画像、固化偏好、当前任务主线 |
-| Episodic Memory | 摘要化的历史片段 | 过往轮次的浓缩总结 |
-| Working Memory | 近期轮次的结构化视图 | 最近若干轮的可直接喂给 LLM 的表示 |
-| Raw Transcript | 原始事件流 | 审计/回放用的完整日志 |
+| 层 | 语义 | 是否计入 budget | 典型内容 |
+| --- | --- | --- | --- |
+| Pinned State | 会话级反幻觉锚点，写入后增量更新 | 否（独立路径） | `current_goal` / `confirmed_subjects` / `user_constraints` / `open_questions`，典型 < 200 tokens |
+| 单总池 | 历史回放预算池 | 是 | 最近 N 轮 raw turn（强制保留下限）+ 更老 raw turn（按预算回放）+ episode summaries（剩余预算填充） |
+| Raw Transcript | 原始事件流（独立物理存储） | — | 审计/回放用的完整日志，永不删除 |
+
+**预算公式**：
+```
+budget = clamp(max_context_tokens * memory_token_budget_ratio,
+               memory_token_budget_floor,
+               memory_token_budget_cap)
+```
+
+`recent_turns_floor` 是反退化下限——即使 budget 算下来为 0，也强制保留最近 N 轮 raw turn 不让追问彻底断链；它**不计入 budget**。极端单轮溢出由 `_build_minimum_preserved_turn_view` 兜底（user_text 全保、assistant 降级裁剪）。
 
 ### 10.1 Raw Transcript 的分区策略
 
 Raw transcript 是一个按时间递增的 turn 列表，通过会话级字段 **`compacted_turn_count`** 把列表划分成两个区：
 
-- **已压缩区**：下标 `< compacted_turn_count` 的 turn，语义上"已被摘要进 episodic memory"，**不再参与**后续 working memory 选择与消息拼装（防止 episode 摘要与原文双发，制造冗余与矛盾）。
-- **未压缩尾区**：下标 `>= compacted_turn_count` 的 turn，是 working memory 的候选池；同时也是下一次 compaction 的输入来源。
+- **已压缩区**：下标 `< compacted_turn_count` 的 turn，语义上"已被摘要进 episode summaries"，**不再参与**后续单总池消费（防止 episode 摘要与原文双发，制造冗余与矛盾）。
+- **未压缩尾区**：下标 `>= compacted_turn_count` 的 turn，是单总池中 raw turn 部分的候选池；同时也是下一次 compaction 的输入来源。
 
 `compacted_turn_count` 只由 compaction 成功写入时**单调推进**，杜绝"压缩后再回放原文"。
 
-### 10.2 Working Memory 选择策略
+### 10.2 单总池消费顺序
 
-Working memory 的构造过程是**从未压缩尾区的最新一轮向前回溯**，直到触发任一边界为止：
+单总池消费按**从新到老**优先级，对未压缩尾区与 episode summaries 联合裁切：
 
-- **轮数上限**：保证消息列表"人类可读规模"不膨胀；
-- **Token 预算**：保证最终消息列表在模型窗口与 Host 留白之内。
+1. **最近 N 轮 raw turn 强制保留**（`raw_tail[-recent_turns_floor:]`）：不计入 budget，单轮极长走 minimum_preserve 兜底，不丢追问连续性。
+2. **更老 raw turn 按 budget 从新到老回放**：每轮估算 token，能装下就加入并扣减 budget，装不下就 break（更早历史已被 compaction 压成 episode 摘要）。
+3. **Episode summaries 用剩余 budget 从新到老填充**：装不下就 break。
 
-两条边界**都要满足**（取先触发者），这是"双重预算"约束——单维度约束会在长 turn / 多轮小 turn 两种极端下任一失控。
-
-**最新一轮整轮超预算时的降级顺序**（稳定契约，保证"最新用户意图永远不丢"）：
+**最近一轮整轮超预算时的降级顺序**（稳定契约，保证"最新用户意图永远不丢"）：
 
 1. 保留 user_text；
 2. 保留完整的 assistant_final；
@@ -371,28 +378,36 @@ Working memory 的构造过程是**从未压缩尾区的最新一轮向前回溯
 
 降级顺序是契约：任何实现不得颠倒"先丢工具后截最终答复"的优先级。
 
+**单轮溢出阈值**：`max_context_tokens / max(2, actual_forced_count + 1)`。除数取**当前实际 forced 轮数**而非 `recent_turns_floor` 配置值——避免新会话/刚 compaction 后只剩 1-2 轮 raw turn 时，配置高 floor 把单轮上限错误压低。
+
 ### 10.3 Compaction 触发策略
 
-Compaction 何时发生由两个维度联合判定（策略级，具体阈值属实现调参）：
+触发判定**仅按"占模型窗口百分比"单维度**（轮数触发器已废）：
 
-- **未压缩轮数**超过策略阈值；**或**
-- **未压缩 token 量**超过 working memory 预算的若干倍。
+```
+window_used = system_prompt + pinned_state
+            + actual_episodic_in_prompt
+            + uncompressed_raw_turns + current_user_text
+should_compact = window_used > max_context_tokens * compaction_trigger_context_ratio
+```
 
-同时**始终保留尾部若干轮不参与压缩**，以保护当前对话的连续性与用户体感——最近几轮必须以原文形式继续回放，不能被摘要抹平。
+`actual_episodic_in_prompt` **复用 `_build_memory_block` 的真实裁切结果**，与渲染 prompt 的口径完全一致，避免触发器与渲染器漂移导致 thrashing 或漏触发。
+
+同时**始终保留 `compaction_tail_preserve_turns` 轮不参与压缩**，保护当前对话的连续性与用户体感。
 
 ### 10.4 Compaction 的输入/输出语义
 
 **输入**（给 LLM 的压缩上下文）语义上包括：
 
 - 固定的压缩任务指令；
-- 当前 pinned state（让 LLM 知道会话主线与稳定偏好）；
-- 最近若干已有 episode 摘要（维持"摘要风格的延续感"，避免每轮重写）；
+- 当前 pinned_state（让 LLM 知道会话主线与稳定偏好）；
+- `compaction_context_episode_window` 个最近已有 episode 摘要（维持"摘要风格的延续感"，避免每轮重写）；
 - 本次待压缩的 turns（来自未压缩区但保留尾部以外的那一段）。
 
-**输出**语义上包括两件事：
+**输出**两件事：
 
-- **`episode_summary`**：对本段对话的结构化摘要，追加进 episodic memory；
-- **`pinned_state_patch`**：对 pinned state 的**增量补丁**。合并语义（`apply_to`）是"只覆盖明确给出的字段、缺省字段沿用旧值"，保证 LLM 每次不需要重述整个 pinned state，也不会因为漏输出某字段而把旧值清空。
+- **`episode_summary`**：对本段对话的结构化摘要，追加进 episode summaries；包含 `confirmed_facts` 字段——财报场景反幻觉刚需，永远完整保留不参与 token 截断。
+- **`pinned_state_patch`**：对 pinned_state 的**增量补丁**。合并语义（`apply_to`）是"只覆盖明确给出的字段、缺省字段沿用旧值"——保证 LLM 每次不需要重述整个 pinned_state，也不会因为漏输出某字段而把旧值清空。
 
 "先得到结果、再按乐观锁写回"是语义分离点：得到 patch 不等于已落库。
 
@@ -401,8 +416,8 @@ Compaction 何时发生由两个维度联合判定（策略级，具体阈值属
 每轮发给 LLM 的消息列表按以下**固定顺序**拼接，顺序是契约：
 
 1. **System Prompt**：角色与任务描述；
-2. **Conversation Memory 段**：pinned state + episode 摘要，统一以一条 system 级消息承载，给模型"这是背景而不是对话"的信号；
-3. **Working Memory 段**：§10.2 选中的若干轮，按 user/assistant 原始交替回放；
+2. **Conversation Memory 段**：pinned_state + episode 摘要，统一以一条 system 级消息承载，给模型"这是背景而不是对话"的信号；
+3. **Working Memory 段**：§10.2 选中的若干轮 raw turn，按 user/assistant 原始交替回放；
 4. **当前轮 user message**：最新用户输入。
 
 这一顺序保证：背景信息在对话之前、历史对话保真回放、当前意图在最末尾（减少 LLM 忽略当前指令的概率）。
@@ -411,10 +426,10 @@ Compaction 何时发生由两个维度联合判定（策略级，具体阈值属
 
 Compaction 有两条触发路径，职责分离：
 
-- **同步 compaction**：**在本轮开始前**，如果未压缩区已越过硬阈值（消息列表若不压缩就会超预算），同步执行压缩，确保本轮能立即开跑。这条路径是"必做功"，以保证可用性。
-- **后台 compaction**：**在上一轮结束后**，如果越过软阈值，异步调度。用于"用户感觉不到延迟地缩小 raw 区"。
+- **同步 compaction**（`prepare_transcript`）：**在本轮开始前**，如果未压缩区已越过阈值（消息列表若不压缩就会超预算），同步执行压缩，确保本轮能立即开跑。这条路径**显式接收 `user_text`** 作为入参——本轮用户消息尚未持久化，必须显式传入参与 `window_used` 估算。
+- **后台 compaction**（`schedule_compaction`）：**在上一轮结束后**，越过阈值则异步调度。这条路径**不接收 `user_text`** 入参——调用时机在 `persist_turn` 之后，用户消息已写入 `transcript.turns` 末位，自然出现在 `uncompressed_raw_turns` 中，再传 `user_text` 会双计。
 
-两条路径共享同一套输入/输出语义（§10.4），差异只在调度时机。
+两条路径共享同一套输入/输出语义（§10.4），差异只在调度时机与是否显式传 `user_text`。
 
 **乐观锁并发冲突策略**：compaction 的写回以会话级 **revision** 作为乐观锁——读入时记录 revision，写回前比对；若不一致（说明期间已有其它 compactor/会话写入），**直接丢弃本次摘要结果，不覆盖**。这与"后来者胜"相反：在"继续跑"与"保持一致"之间选择一致。丢弃的代价是下次重算，可接受。
 
@@ -422,9 +437,47 @@ Compaction 有两条触发路径，职责分离：
 
 - **Pinned 永不被 compaction 挤掉**，只由显式 API 或 compaction 的 `pinned_state_patch` 改写；其它层都可以在预算压力下被重塑。
 - **Episode 只能追加**，不支持回改；若 episode 本身需要再浓缩（episode-of-episodes），属于演进方向，不在当前契约内。
+- **`confirmed_facts` 永远完整保留**，不参与 token 截断（财报场景反幻觉核心依赖）。
 - **Raw Transcript 永不被 compaction 物理删除**，只通过 `compacted_turn_count` 标记为"已摘要"；审计/回放总能拿到全量原文。
 
-具体的 token 预算数值、默认窗口大小、触发阈值倍数属于实现调参，不在本文档范围；以 `dayu/host/conversation_*.py` 与 `dayu/config/` 为准。
+### 10.8 默认配置与跨档自适应
+
+`default` 一份打天下，不分档配置；通过 `clamp(window * ratio, floor, cap)` 自动伸缩：
+
+| 字段 | 默认 | 说明 |
+| --- | --- | --- |
+| `memory_token_budget_ratio` | `0.10` | 池大小占模型窗口比例；按当前 floor/cap 在 ~40K–600K 窗口范围内真实生效 |
+| `memory_token_budget_floor` | `4000` | 总池下限保底（短窗口模型用） |
+| `memory_token_budget_cap` | `60000` | 总池上限封顶（1M 档被截到此值） |
+| `recent_turns_floor` | `2` | 最近 N 轮强制保留下限，反退化兜底 |
+| `compaction_trigger_context_ratio` | `0.70` | 占模型窗口百分比触发阈值 |
+| `compaction_tail_preserve_turns` | `4` | 压缩时保留尾部不压的轮数 |
+| `compaction_context_episode_window` | `2` | 给 LLM 的近邻 episode 数 |
+| `compaction_scene_name` | `"conversation_compaction"` | 压缩用专用 scene |
+
+**各档实际 budget**：
+
+| 模型窗口 | `window * 0.10` | clamp 后 budget | 触发阈值 |
+| --- | --- | --- | --- |
+| 1M | 100K | **60K**（cap 截断） | 700K |
+| 256K | 25.6K | **25.6K**（区间内） | 179K |
+| 128K | 12.8K | **12.8K**（区间内） | 89.6K |
+| 32K | 3.2K | **4K**（floor 兜底） | 22.4K |
+
+#### 10.8.1 128K 档使用注意事项
+
+128K 档自适应**功能上完全成立**，但相比 256K/1M 档对"材料 headroom"更敏感：
+
+- **Compaction 阈值 89.6K**，扣除 system_prompt + pinned + 12.8K 总池后，留给"当前轮工具结果 + 财报材料"的有效空间约 **38K**——比 256K 档的 154K 小一个量级。
+- 若单轮工具一次取出多块 XBRL fact + 长财报段落 > 38K，会出现"每轮都触发 compaction"的抖动现象。
+- **调参方向**（按抖动现象选）：
+  - 抖动严重：`memory_token_budget_cap` 下调（如 8000）把池让给材料；或 `compaction_trigger_context_ratio` 上调（如 0.80）延后触发。
+  - 追问频繁忘上一轮：保持 cap，调高 `recent_turns_floor` 到 3。
+- **单轮溢出阈值 ≈ 128K / 3 ≈ 42K**（floor=2、actual_forced=2 时），财报追问中 user_text 几百字 + assistant 摘要几千字远低于此值，正常对话不会触发 minimum_preserve。
+- **不需要在 `llm_models.json` 写 `runtime_hints.conversation_memory` 覆盖**——`default` 已自适应；如确需档位特化，建议先按上述抖动信号调参，验证默认行为不够再考虑覆盖。
+- **当前 `dayu/config/llm_models.json` 仅注册 1M / 256K 档**，128K 档需通过 `dayu-cli init` 添加自定义模型进入；上线前建议跑一次 `interactive` 8+ 轮实测，观察 trace 里的 budget/compaction 日志确认行为符合预期。
+
+具体的 token 预算数值、触发阈值倍数定义在 `dayu/config/run.json`、`dayu/contracts/execution_options.py::ConversationMemorySettings` 与 `dayu/host/conversation_memory.py`，三处默认值通过单元测试 `test_default_conversation_memory_settings_match_runtime_default` 保持一致。详细字段说明见 [config/README.md §5.8](../config/README.md)。
 
 ---
 
@@ -618,7 +671,7 @@ Service 单测写"如何调 Host"时：
 5. `dayu/host/reply_outbox_store.py` — delivery 幂等与 stale 回退；
 6. `dayu/host/executor.py` / `host_execution.py` — 执行路径与 `should_delete_pending_turn_after_terminal_run` 真值表；
 7. `dayu/host/concurrency.py` — lane 合并与 `acquire_many`；
-8. `dayu/host/conversation_*.py` — 分层记忆与 compaction；
+8. `dayu/host/conversation_*.py` — 两层记忆与 compaction；
 9. `dayu/host/startup_preparation.py` — 配置规范化与默认值；
 10. `dayu/host/host_cleanup.py` — 启动恢复的编排。
 

--- a/dayu/host/conversation_memory.py
+++ b/dayu/host/conversation_memory.py
@@ -137,60 +137,35 @@ def _estimate_turn_tokens(turn: ConversationTurnRecord) -> int:
     return sum(_estimate_tokens(piece) for piece in pieces)
 
 
-def _resolve_working_memory_token_budget(
+def _resolve_memory_total_budget(
     *,
     settings: ConversationMemorySettings,
     max_context_tokens: int,
 ) -> int:
-    """解析 working memory 的 token 预算。
+    """解析单总池的 token 预算。
+
+    单总池供"更老 raw turn + episode summaries"共同消费；最近 N 轮 raw turn 由
+    ``recent_turns_floor`` 强制保留，不计入此预算。
 
     Args:
         settings: 分层记忆配置。
         max_context_tokens: 当前模型最大上下文 token。
 
     Returns:
-        working memory token 预算。
+        单总池 token 预算。
 
     Raises:
         无。
     """
 
     if max_context_tokens <= 0:
-        return settings.working_memory_token_budget_cap
-    computed = int(max_context_tokens * settings.working_memory_token_budget_ratio)
+        return settings.memory_token_budget_cap
+    computed = int(max_context_tokens * settings.memory_token_budget_ratio)
     bounded = max(
-        settings.working_memory_token_budget_floor,
-        min(settings.working_memory_token_budget_cap, computed),
+        settings.memory_token_budget_floor,
+        min(settings.memory_token_budget_cap, computed),
     )
     return max(1, min(max_context_tokens, bounded))
-
-
-def _resolve_episodic_memory_token_budget(
-    *,
-    settings: ConversationMemorySettings,
-    max_context_tokens: int,
-) -> int:
-    """解析 episodic memory 的 token 预算。
-
-    Args:
-        settings: 分层记忆配置。
-        max_context_tokens: 当前模型最大上下文 token。
-
-    Returns:
-        episodic memory token 预算。
-
-    Raises:
-        无。
-    """
-
-    if max_context_tokens <= 0:
-        return settings.episodic_memory_token_budget_cap
-    computed = int(max_context_tokens * settings.episodic_memory_token_budget_ratio)
-    bounded = max(
-        settings.episodic_memory_token_budget_floor,
-        min(settings.episodic_memory_token_budget_cap, computed),
-    )
-    return max(0, min(max_context_tokens, bounded))
 
 
 def _resolve_prepared_scene_max_context_tokens(
@@ -518,6 +493,7 @@ class WorkingMemoryPolicyProtocol(Protocol):
         transcript: ConversationTranscript,
         *,
         settings: ConversationMemorySettings,
+        available_token_budget: int,
         max_context_tokens: int,
     ) -> tuple[WorkingMemoryTurnView, ...]:
         """选择需要作为 working memory 回放的 raw turns。"""
@@ -572,6 +548,8 @@ class ConversationMemoryManagerProtocol(Protocol):
         session_id: str,
         prepared_scene: ConversationPreparedSceneProtocol,
         transcript: ConversationTranscript,
+        system_prompt: str,
+        user_text: str,
     ) -> ConversationTranscript:
         """在当前轮开始前补齐必要的同步压缩。"""
         ...
@@ -597,6 +575,7 @@ class ConversationMemoryManagerProtocol(Protocol):
         session_id: str,
         prepared_scene: ConversationPreparedSceneProtocol,
         transcript: ConversationTranscript,
+        system_prompt: str,
     ) -> None:
         """基于最新 transcript 调度后台压缩。"""
         ...
@@ -679,24 +658,35 @@ class NullConversationRetrievalIndex:
 
 
 class DefaultWorkingMemoryPolicy:
-    """基于预算的默认 working memory 策略。"""
+    """基于单总池预算的默认 working memory 策略。
+
+    回放策略：
+    - **强制保留** 最近 ``recent_turns_floor`` 轮 raw turn（不消耗 budget）；
+      若最新一轮单轮即超出预算，走 ``_build_minimum_preserved_turn_view`` 兜底。
+    - **按预算回放** 更老的 raw turn：从新到老消费 ``available_token_budget``，
+      预算耗尽即停（更早历史已由 compaction 压缩为 episode summary）。
+    """
 
     def select_turns(
         self,
         transcript: ConversationTranscript,
         *,
         settings: ConversationMemorySettings,
+        available_token_budget: int,
         max_context_tokens: int,
     ) -> tuple[WorkingMemoryTurnView, ...]:
-        """选择当前轮要回放的高保真 raw turns。
+        """选择当前轮要回放的 raw turns。
 
         Args:
             transcript: 当前 transcript。
             settings: 分层记忆配置。
-            max_context_tokens: 当前模型最大上下文 token。
+            available_token_budget: 单总池中分配给 raw turn 回放的剩余预算
+                （pinned_state 与 recent_turns_floor 不计入此值）。
+            max_context_tokens: 当前模型最大上下文 token；用于派生
+                ``recent_turns_floor`` 的单轮溢出兜底阈值。
 
         Returns:
-            选中的 working memory turn 视图。
+            选中的 working memory turn 视图，按时间从旧到新排列。
 
         Raises:
             无。
@@ -705,53 +695,89 @@ class DefaultWorkingMemoryPolicy:
         raw_tail = transcript.turns[transcript.compacted_turn_count :]
         if not raw_tail:
             return ()
-        token_budget = self._resolve_token_budget(settings=settings, max_context_tokens=max_context_tokens)
-        selected: list[WorkingMemoryTurnView] = []
-        used_tokens = 0
-        for turn in reversed(raw_tail):
-            if len(selected) >= settings.working_memory_max_turns:
-                break
-            full_turn_view = _build_full_working_turn_view(turn)
-            full_turn_tokens = _estimate_working_turn_view_tokens(full_turn_view)
-            if used_tokens + full_turn_tokens <= token_budget:
-                selected.append(full_turn_view)
-                used_tokens += full_turn_tokens
-                continue
-            if selected:
-                break
-            selected.append(
-                _build_minimum_preserved_turn_view(
-                    turn,
-                    token_budget=max(1, token_budget),
-                )
-            )
-            break
-        selected.reverse()
-        return tuple(selected)
 
-    def _resolve_token_budget(
+        recent_floor = max(0, settings.recent_turns_floor)
+        if recent_floor > 0:
+            forced_turns = raw_tail[-recent_floor:]
+            older_turns = raw_tail[:-recent_floor]
+        else:
+            forced_turns = ()
+            older_turns = raw_tail
+
+        forced_views = self._render_forced_turns(
+            forced_turns,
+            settings=settings,
+            max_context_tokens=max_context_tokens,
+            actual_forced_count=len(forced_turns),
+        )
+
+        extra_pool = max(0, available_token_budget)
+        extra_views: list[WorkingMemoryTurnView] = []
+        for turn in reversed(older_turns):
+            full_view = _build_full_working_turn_view(turn)
+            cost = _estimate_working_turn_view_tokens(full_view)
+            if cost > extra_pool:
+                break
+            extra_views.append(full_view)
+            extra_pool -= cost
+        extra_views.reverse()
+        return tuple([*extra_views, *forced_views])
+
+    def _render_forced_turns(
         self,
+        forced_turns: tuple[ConversationTurnRecord, ...],
         *,
         settings: ConversationMemorySettings,
         max_context_tokens: int,
-    ) -> int:
-        """解析当前轮 working memory 的 token 预算。
+        actual_forced_count: int,
+    ) -> tuple[WorkingMemoryTurnView, ...]:
+        """渲染强制保留的最近 N 轮 raw turn。
+
+        默认走完整视图（forced floor 不计入 budget）；只有当**单轮 token 量超过
+        模型当前窗口派生的兜底阈值** 这种极端情况才退到
+        ``_build_minimum_preserved_turn_view`` 兜底，避免上下文窗口被一轮极长输入
+        撑爆。阈值与 ``memory_token_budget_cap`` **解耦**：必须基于当前模型
+        ``max_context_tokens`` 推导，否则在小窗口模型上可能出现"单轮 < cap 但
+        > 当前窗口"被原样回放、撑爆 prompt 的失败模式。
+
+        阈值公式：``max_context_tokens / max(2, actual_forced_count + 1)``。
+        除数取**当前实际 forced 轮数**而不是 ``settings.recent_turns_floor``：新会话或
+        刚 compaction 后只剩 1-2 轮 raw turn 时，若仍按配置 floor=4/5 计算会把单轮上限
+        压得过低，触发不必要的 minimum_preserve 裁剪。语义上为"模型窗口给单轮
+        forced turn 的上限"，按实际轮数+1 平摊，使 forced 队列加 system/pinned/当前
+        user 共用窗口时单轮不会独吞。
 
         Args:
-            settings: 分层记忆配置。
-            max_context_tokens: 当前模型最大上下文 token。
+            forced_turns: 最近 N 轮强制保留的原始 turn。
+            settings: 分层记忆配置；提供 ``memory_token_budget_cap`` 作为窗口未知
+                时的兜底阈值。
+            max_context_tokens: 当前模型最大上下文 token。``<= 0`` 时回落
+                到 ``settings.memory_token_budget_cap`` 作为最后兜底。
+            actual_forced_count: 当前实际 forced turn 数量，用于派生溢出阈值。
 
         Returns:
-            token 预算。
+            渲染后的视图，按时间从旧到新。
 
         Raises:
             无。
         """
 
-        return _resolve_working_memory_token_budget(
-            settings=settings,
-            max_context_tokens=max_context_tokens,
-        )
+        if max_context_tokens > 0:
+            divisor = max(2, actual_forced_count + 1)
+            overflow_threshold = max(1, max_context_tokens // divisor)
+        else:
+            # 防御性兜底：模型窗口未知时回到 cap，保持旧行为不破坏。
+            overflow_threshold = max(1, settings.memory_token_budget_cap)
+        rendered: list[WorkingMemoryTurnView] = []
+        for turn in forced_turns:
+            full_view = _build_full_working_turn_view(turn)
+            if _estimate_working_turn_view_tokens(full_view) <= overflow_threshold:
+                rendered.append(full_view)
+            else:
+                rendered.append(
+                    _build_minimum_preserved_turn_view(turn, token_budget=overflow_threshold)
+                )
+        return tuple(rendered)
 
 
 class DefaultEpisodicMemoryCompressor:
@@ -1125,6 +1151,8 @@ class DefaultConversationMemoryManager:
         session_id: str,
         prepared_scene: ConversationPreparedSceneProtocol,
         transcript: ConversationTranscript,
+        system_prompt: str,
+        user_text: str,
     ) -> ConversationTranscript:
         """在当前轮开始前补齐必要的同步压缩。
 
@@ -1132,6 +1160,8 @@ class DefaultConversationMemoryManager:
             session_id: 会话 ID。
             prepared_scene: 当前轮静态 scene 计划。
             transcript: 当前已落盘 transcript。
+            system_prompt: 当前轮 system prompt，用于触发公式估算 token。
+            user_text: 当前轮用户输入，用于触发公式估算 token。
 
         Returns:
             已补齐同步压缩后的 transcript。
@@ -1144,11 +1174,15 @@ class DefaultConversationMemoryManager:
         current = transcript
         settings = prepared_scene.conversation_memory_settings
         max_context_tokens = _resolve_prepared_scene_max_context_tokens(prepared_scene)
+        system_prompt_tokens = _estimate_tokens(str(system_prompt or ""))
+        user_text_tokens = _estimate_tokens(str(user_text or ""))
         while True:
             candidate_turns = self._select_compaction_candidate(
                 transcript=current,
                 settings=settings,
                 max_context_tokens=max_context_tokens,
+                system_prompt_tokens=system_prompt_tokens,
+                user_text_tokens=user_text_tokens,
             )
             if not candidate_turns:
                 return current
@@ -1205,20 +1239,27 @@ class DefaultConversationMemoryManager:
 
         settings = prepared_scene.conversation_memory_settings
         max_context_tokens = _resolve_prepared_scene_max_context_tokens(prepared_scene)
+        total_budget = _resolve_memory_total_budget(
+            settings=settings,
+            max_context_tokens=max_context_tokens,
+        )
+        # 单总池消费顺序：先扣 episode summaries，再把剩余预算交给"更老 raw turn"。
+        # pinned_state / 最近 N 轮 raw turn 永远独立、不计入此预算。
+        memory_block, episodic_used_tokens = self._build_memory_block(
+            transcript=transcript,
+            total_budget=total_budget,
+        )
+        remaining_for_working = max(0, total_budget - episodic_used_tokens)
         raw_turns = self._working_memory_policy.select_turns(
             transcript,
             settings=settings,
+            available_token_budget=remaining_for_working,
             max_context_tokens=max_context_tokens,
         )
         messages: list[AgentMessage] = []
         normalized_system_prompt = str(system_prompt or "").strip()
         if normalized_system_prompt:
             messages.append(build_system_chat_message(normalized_system_prompt))
-        memory_block = self._build_memory_block(
-            transcript=transcript,
-            settings=settings,
-            max_context_tokens=max_context_tokens,
-        )
         if memory_block:
             messages.append(build_system_chat_message(memory_block))
         messages.extend(self._compile_raw_turns(raw_turns))
@@ -1246,13 +1287,20 @@ class DefaultConversationMemoryManager:
         session_id: str,
         prepared_scene: ConversationPreparedSceneProtocol,
         transcript: ConversationTranscript,
+        system_prompt: str,
     ) -> None:
         """基于最新 transcript 调度后台压缩。
+
+        本入口在 ``persist_turn`` 之后被调用，当前轮 ``user_text`` 已经写进
+        ``transcript.turns`` 最末位、自然出现在 ``uncompressed_tokens`` 中，
+        因此**不接收** ``user_text`` 参数避免重复计数。开局尚未 persist 的同步压缩
+        判定走 ``prepare_transcript``，由它显式传 ``user_text``。
 
         Args:
             session_id: 会话 ID。
             prepared_scene: 当前轮静态 scene 计划。
-            transcript: 最新 transcript。
+            transcript: 最新 transcript（已包含本轮 user/assistant）。
+            system_prompt: 当前轮 system prompt，用于触发公式估算 token。
 
         Returns:
             无。
@@ -1267,6 +1315,8 @@ class DefaultConversationMemoryManager:
             transcript=transcript,
             settings=settings,
             max_context_tokens=max_context_tokens,
+            system_prompt_tokens=_estimate_tokens(str(system_prompt or "")),
+            user_text_tokens=0,
         )
         self._retrieval_index.index_transcript(transcript)
         if not candidate_turns:
@@ -1306,18 +1356,21 @@ class DefaultConversationMemoryManager:
         self,
         *,
         transcript: ConversationTranscript,
-        settings: ConversationMemorySettings,
-        max_context_tokens: int,
-    ) -> str:
-        """构建 `[Conversation Memory]` system block。
+        total_budget: int,
+    ) -> tuple[str, int]:
+        """构建 ``[Conversation Memory]`` system block。
+
+        ``pinned_state`` 永远完整渲染、不消耗 ``total_budget``；``episode summaries``
+        从最新到最旧消费 ``total_budget``，预算耗尽即停。
 
         Args:
             transcript: 当前 transcript。
-            settings: 分层记忆配置。
-            max_context_tokens: 当前模型最大上下文 token。
+            total_budget: 单总池预算（pinned_state 与最近 N 轮 raw turn 不在此池）。
 
         Returns:
-            memory block；无内容时返回空字符串。
+            ``(memory_block, episodic_used_tokens)``：渲染后的 block；以及 episode
+            summaries 实际占用的 token 数（用于把剩余预算让给 raw turn 回放）。
+            block 无内容时返回 ``("", 0)``。
 
         Raises:
             无。
@@ -1327,25 +1380,29 @@ class DefaultConversationMemoryManager:
         pinned_block = _render_pinned_state_block(transcript.pinned_state)
         if pinned_block:
             pieces.append(pinned_block)
-        used_tokens = sum(_estimate_tokens(piece) for piece in pieces)
-        episodic_budget = _resolve_episodic_memory_token_budget(
-            settings=settings,
-            max_context_tokens=max_context_tokens,
-        )
+
+        episodic_used_tokens = 0
         episode_pieces: list[str] = []
+        budget_remaining = max(0, total_budget)
         for episode in reversed(transcript.episodes):
             rendered = _render_episode_summary(episode)
             rendered_tokens = _estimate_tokens(rendered)
-            if episode_pieces and used_tokens + rendered_tokens > episodic_budget:
+            if rendered_tokens > budget_remaining:
+                if not episode_pieces:
+                    # 单条 episode 即超预算时仍保留至少一条最新 episode，避免 episodic
+                    # 层完全失效；token 仍按真实占用记账供调用方核账。
+                    episode_pieces.append(rendered)
+                    episodic_used_tokens += rendered_tokens
                 break
             episode_pieces.append(rendered)
-            used_tokens += rendered_tokens
+            episodic_used_tokens += rendered_tokens
+            budget_remaining -= rendered_tokens
         if episode_pieces:
             episode_pieces.reverse()
             pieces.append("Episode Summaries:\n" + "\n\n".join(episode_pieces))
         if not pieces:
-            return ""
-        return "[Conversation Memory]\n" + "\n\n".join(pieces)
+            return "", 0
+        return "[Conversation Memory]\n" + "\n\n".join(pieces), episodic_used_tokens
 
     def _compile_raw_turns(self, turns: tuple[WorkingMemoryTurnView, ...]) -> list[AgentMessage]:
         """将 working memory raw turns 编译为消息列表。
@@ -1372,13 +1429,31 @@ class DefaultConversationMemoryManager:
         transcript: ConversationTranscript,
         settings: ConversationMemorySettings,
         max_context_tokens: int,
+        system_prompt_tokens: int = 0,
+        user_text_tokens: int = 0,
     ) -> tuple[ConversationTurnRecord, ...]:
         """选择本次可压缩的 raw turn 片段。
+
+        触发公式（占模型窗口百分比，跨档位自动伸缩）::
+
+            window_used = system_prompt + pinned_state
+                         + actual_episodic_in_prompt
+                         + uncompressed_raw_turns + current_user_text
+            should_compact = window_used > max_context_tokens
+                             * compaction_trigger_context_ratio
+
+        说明：``actual_episodic_in_prompt`` 通过复用 ``_build_memory_block`` 的渲染逻辑
+        在当前 ``total_budget`` 下计算"本轮会真正送进 prompt 的 episode token"，从而：
+        - 既避免把全量 ``transcript.episodes`` 计入触发公式带来的抖动（fix #2 原意）；
+        - 也避免无视 ``_build_memory_block`` 的"最新 episode 即使超 budget 也保留一条"
+          兜底分支造成的真实 prompt 体积低估（round2 review #1）。
 
         Args:
             transcript: 当前 transcript。
             settings: 分层记忆配置。
-            max_context_tokens: 当前模型最大上下文 token。
+            max_context_tokens: 当前模型最大上下文 token；``<= 0`` 时跳过 token 触发。
+            system_prompt_tokens: 当前轮 system prompt 估算 token 数。
+            user_text_tokens: 当前轮用户输入估算 token 数。
 
         Returns:
             待压缩 turn 元组；不满足阈值时返回空元组。
@@ -1390,45 +1465,39 @@ class DefaultConversationMemoryManager:
         uncompressed_turns = transcript.turns[transcript.compacted_turn_count :]
         if len(uncompressed_turns) <= settings.compaction_tail_preserve_turns:
             return ()
-        working_budget = self._resolve_working_budget(
+        if max_context_tokens <= 0:
+            # 模型窗口未知时无法判定占比，直接放弃 token 触发；防御性兜底。
+            return ()
+
+        pinned_tokens = _estimate_tokens(_render_pinned_state_block(transcript.pinned_state))
+        uncompressed_tokens = sum(_estimate_turn_tokens(turn) for turn in uncompressed_turns)
+
+        # 用 build_messages 同款逻辑估算本轮实际会送的 episode token：
+        # 复用 _build_memory_block，使触发判定与真实 prompt 体积保持一致。
+        total_budget = _resolve_memory_total_budget(
             settings=settings,
             max_context_tokens=max_context_tokens,
         )
-        uncompressed_tokens = sum(_estimate_turn_tokens(turn) for turn in uncompressed_turns)
-        should_compact = (
-            len(uncompressed_turns) > settings.compaction_trigger_turn_count
-            or uncompressed_tokens > int(working_budget * settings.compaction_trigger_token_ratio)
+        _, episodic_in_prompt_tokens = self._build_memory_block(
+            transcript=transcript,
+            total_budget=total_budget,
         )
-        if not should_compact:
+
+        window_used = (
+            max(0, system_prompt_tokens)
+            + pinned_tokens
+            + episodic_in_prompt_tokens
+            + uncompressed_tokens
+            + max(0, user_text_tokens)
+        )
+        threshold = int(max_context_tokens * settings.compaction_trigger_context_ratio)
+        if window_used <= threshold:
             return ()
+
         cutoff = len(uncompressed_turns) - settings.compaction_tail_preserve_turns
         if cutoff <= 0:
             return ()
         return tuple(uncompressed_turns[:cutoff])
-
-    def _resolve_working_budget(
-        self,
-        *,
-        settings: ConversationMemorySettings,
-        max_context_tokens: int,
-    ) -> int:
-        """解析 compaction 判定使用的 working memory 预算。
-
-        Args:
-            settings: 分层记忆配置。
-            max_context_tokens: 当前模型最大上下文 token。
-
-        Returns:
-            working memory 预算。
-
-        Raises:
-            无。
-        """
-
-        return _resolve_working_memory_token_budget(
-            settings=settings,
-            max_context_tokens=max_context_tokens,
-        )
 
     async def _run_compaction(
         self,

--- a/dayu/host/scene_preparer.py
+++ b/dayu/host/scene_preparer.py
@@ -190,6 +190,7 @@ class ConversationSessionState:
     memory_manager: DefaultConversationMemoryManager
     prepared_scene: PreparedSceneState
     user_message: str
+    system_prompt: str
 
     def persist_turn(
         self,
@@ -218,6 +219,7 @@ class ConversationSessionState:
             session_id=self.session_id,
             prepared_scene=self.prepared_scene,
             transcript=persisted,
+            system_prompt=self.system_prompt,
         )
 
 
@@ -403,6 +405,8 @@ class DefaultScenePreparer(ScenePreparationProtocol):
                 session_id=session_key,
                 prepared_scene=prepared_scene,
                 transcript=transcript,
+                system_prompt=system_prompt,
+                user_text=user_message,
             )
             messages = self._memory_manager.build_messages(
                 prepared_scene=prepared_scene,
@@ -418,6 +422,7 @@ class DefaultScenePreparer(ScenePreparationProtocol):
                 memory_manager=self._memory_manager,
                 prepared_scene=prepared_scene,
                 user_message=user_message,
+                system_prompt=system_prompt,
             )
         else:
             messages = _build_single_turn_messages(system_prompt=system_prompt, user_message=user_message)
@@ -475,6 +480,7 @@ class DefaultScenePreparer(ScenePreparationProtocol):
                 memory_manager=self._memory_manager,
                 prepared_scene=prepared_scene,
                 user_message=session_snapshot.user_message,
+                system_prompt=prepared_turn.system_prompt,
             )
         return AgentInput(
             system_prompt=prepared_turn.system_prompt,

--- a/docs/conversation_memory_optimization.md
+++ b/docs/conversation_memory_optimization.md
@@ -1,221 +1,232 @@
-# `conversation_memory` 优化建议
+## 背景
 
-面向 `dayu/host/conversation_memory.py` 与 `dayu/config/llm_models.json` / `dayu/config/run.json` 的多轮会话记忆子系统。仅对 `conversation.enabled = true` 的 scene 生效，当前即 `interactive / wechat / prompt_mt` 三个 scene；write pipeline 全程走单轮路径，不受此文档任何建议影响。
+`dayu/host/conversation_memory.py` 的多轮记忆 baseline 已跑通，跨模型档位对齐完成（1M 档 13 个模型、256K 档 3 个模型）。静态分析暴露 4 个结构性问题，本 issue 一次性按全新 schema 重构，**硬切换、不留兼容**。范围限定 `conversation.enabled = true` 的 scene（`interactive / wechat / prompt_mt`）。
 
-## 1. 背景与边界
+## 已识别的结构性问题
 
-### 1.1 算法事实
-
-当前送模消息由 `DefaultConversationMemoryManager.build_messages` 组装，分层策略如下：
-
-- `working memory`：最近 raw turns，预算：
-  `working_budget = clamp(max_context_tokens * ratio_w, floor_w, cap_w)`
-  进一步受 `working_memory_max_turns` 轮数上限约束。
-- `episodic memory`：结构化 episode summary，预算：
-  `episodic_budget = clamp(max_context_tokens * ratio_e, floor_e, cap_e)`
-- `compaction` 触发条件：
-  `len(uncompressed) > compaction_trigger_turn_count`
-  或 `uncompressed_tokens > working_budget * compaction_trigger_token_ratio`。
-  压缩时保留尾部 `compaction_tail_preserve_turns` 轮不压。
-
-默认值（`run.json.conversation_memory.default`）：
-`ratio_w = 0.08, floor_w = 1500, cap_w = 12000,
-ratio_e = 0.02, floor_e = 2000, cap_e = 12000,
-max_turns = 6, trigger_turn_count = 8, trigger_token_ratio = 1.5, tail_preserve = 4`。
-
-模型级覆盖通过 `llm_models.json[model].runtime_hints.conversation_memory` 字段级叠加。
-
-### 1.2 当前配置档位一致性
-
-本轮已完成的对齐：
-
-- **1M 档（13 个模型）**：`working_memory_token_budget_cap = 80000`，episodic 走 default (2000 / 12000)。
-- **256K 档（3 个模型）**：`working_memory_token_budget_cap = 32000`，`episodic_floor = cap = 6000`。
-
-跨模型一致性已满足：用户在多轮 scene 内切换模型，memory 行为仅随客观上下文档位变化，不再受历史遗留差异影响。
-
-### 1.3 本次不是"最优"，只是"现阶段稳定 baseline"
-
-以下四点是静态分析层面可观察到的结构性问题，属于继续优化的切入点。
-
----
-
-## 2. 已识别的结构性问题（按证据同源原则）
-
-### 2.1 `compaction_trigger_token_ratio * working_budget` 是半死代码
-
-- 典型设置 `max_turns = 6`，平均每轮 ~5K tokens，上限约 30K tokens。
-- 1M 档 `working_budget * 1.5 = 120000`，30K 永远触不到。
-- 实际生效的几乎总是 `len(uncompressed) > 8` 这条轮数分支。
-
-token 阈值不是被触发了才会动作的防御线，而是与 working cap 耦合后永远被压在阈下，等于**把 compaction 退化成纯轮数触发器**。
+### 2.1 compaction token 阈值是半死代码
+- `compaction_trigger_token_ratio * working_budget` 在 1M 档 = 120K，实际 session 30K 永远触不到
+- compaction 退化成纯轮数触发器（`len(uncompressed) > 8`）
 
 ### 2.2 `working_memory_token_budget_ratio` 在 1M 档是死代码
+- `1M * 0.08 = 83886 > cap = 80000`，ratio 恒被 cap 截断
+- ratio 字段实际不起作用，只是语义噪音
 
-- `1_048_576 * 0.08 = 83_886`，恒大于 `cap = 80000`，最终恒为 cap。
-- ratio 字段保留的"窗口缩小时自动回退"弹性在实际取值域内没发生。
-
-这说明当前实际起控制作用的是 cap 绝对值，ratio 只是语义噪音。
-
-### 2.3 working / episodic 各自独立预算池，没有总池
-
-- `build_messages` 里 working raw turns 与 episodic summaries 分别从各自预算切片取，彼此不感知。
-- 理论上两池之和可能超出"实际留给 memory 的总量"，尤其 1M 档默认 80000 + 12000 = 92000。
-- 调一个池不会释放另一个池空间，调参必须两个池同步考虑，这是此前复核"策略解释不完整"感觉的根源。
-
-业界 `MemGPT / LangGraph` 方向是**单总池 + 层间消费优先级**，dayu 当前选择是"双独立池"，代价已暴露。
+### 2.3 working / episodic 双独立预算池，没有总池
+- 两池各自独立切片，互不感知，理论和可达 92K
+- 调一个池不会释放另一个池空间，调参必须同步考虑
 
 ### 2.4 `working_memory_max_turns = 6` 全局硬限
-
-- 全局生效，不随档位变化。
-- 1M 档下 6 轮 ~30K，只用 cap(80000) 的约 37%，cap 本身在实际路径上用不满。
-- 决定回放量的主约束是 `max_turns` 而不是 `cap`，配置语义与实际行为错位。
+- 1M 档下 6 轮 ~30K，只用 cap(80000) 的 ~37%，cap 用不满
+- 决定回放量的主约束是 `max_turns` 而不是 `cap`，配置语义与实际行为错位
 
 ---
 
-## 3. 优化方案（按收益 / 风险比排序）
+## 设计原则（财报 agent 第一性原理）
 
-### 3.1 Phase 1：compaction 阈值改"占窗口百分比制"
+财报会话不变量与通用代码 agent 不同，方案直接从这些不变量长出来，**不糅合各家招式**：
 
-**目标**：让 token 阈值语义与 "距离爆窗口还有多远" 直接对齐，消除 2.1 的半死代码。
+| 不变量 | 设计含义 |
+|---|---|
+| **目标稳定**：用户开会话是为搞清某公司某财务问题，目标收敛 | `pinned_state` 是会话灵魂，必须永远在、不参与池竞争 |
+| **工具结果即事实**：财报数字 / 章节定位 / XBRL facts 不能被 LLM 二次摘要丢精度 | 项目已只存 `ConversationToolUseSummary.result_summary`，无需额外 prune；compaction 阶段 episode summary 通过 `confirmed_facts` 字段保留 |
+| **追问连续性是刚需**：最常见是"上一轮说 X，再展开/换口径" | 最近 N 轮 raw turn 强制保留、**不计入** token 预算 — `recent_turns_floor` 语义从"上限"反转为"下限保底" |
+| **跨轮一致性 > 上下文丰富度** | episode summary `confirmed_facts` + `pinned_state` 是反幻觉核心 |
+| **memory 应克制**（项目自身工程信条）："长上下文优先留给财报材料、检索结果和当前章节上下文，memory 只建议小步上调" | 1M 档总池 cap 设到 60K（不向 200K 走），把窗口让给财报材料 |
 
-**改动点**：
-
-- `ConversationMemorySettings` 新增 `compaction_trigger_context_ratio: float`，默认 `0.75`。
-- `_select_compaction_candidate` 的 token 分支改为：
-  `uncompressed_tokens + working_tokens_estimated > max_context_tokens * compaction_trigger_context_ratio`
-- 废弃 `compaction_trigger_token_ratio` 或降级为 legacy fallback（若外部 workspace 已有自定义值）。
-
-**收益**：
-
-- 阈值语义清晰、跨档位自动伸缩。
-- 不再受 working_cap 调整的传递影响。
-- 消除半死代码，减轻未来 reviewer 理解成本。
-
-**风险 / 影响面**：
-
-- `_select_compaction_candidate` 行为变更，需补测试。
-- `options.py` 的 `_build_conversation_memory_settings` / `_validate_conversation_memory_settings` 需相应扩展。
-- `config/README.md §5.7` 需更新字段列表与示意。
-- `run.json` 默认值需补 `compaction_trigger_context_ratio`。
-
-**测试覆盖建议**：
-
-- 新增 1M / 256K 两档下，uncompressed 逐步增长直至触发阈值的单测。
-- 原 `trigger_token_ratio` 的测试迁移到新字段。
+**非目标**（明确不做）：
+- 不引入 OpenCode `prune_tool_outputs`（项目已 prune，重复造轮子）
+- 不引入 OpenCode `reserved_token_buffer`（system_prompt + tool schema 是常量，调小 ratio/cap 即可）
+- 不引入 Codex `tokensUsed/tokensRemaining` 显式可观测（trace_infrastructure 已覆盖）
+- 不向 1M 档总池 200K 扩张（违反"memory 克制"信条）
 
 ---
 
-### 3.2 Phase 2：合并为单总池
+## 概念澄清
 
-**目标**：对齐业界 `MemGPT / LangGraph` 主流做法，消除 2.3 的双池独立问题。
+### `pinned_state` 是什么 + 怎么产生
 
-**改动点**：
+**结构定义**（`dayu/host/conversation_store.py:229-237`），4 字段：
 
-- 新增 `memory_total_token_budget_ratio: float`，默认 `0.20`；废弃 `working_*` 与 `episodic_*` 两组 ratio/floor/cap 字段。
-- `build_messages` 先按 working 消费规则填充，溢出部分才给 episodic summary 列表。
-- 模型档位覆盖从 2 个字段压缩为 1 个。
-
-**收益**：
-
-- 配置面从 6 个字段压到 1 个，档位表更清爽。
-- 两池争抢空间的设计歧义消失，README 能用单一原则讲清。
-
-**风险 / 影响面**：
-
-- 较大：影响 `build_messages`、`_build_memory_block`、`_select_compaction_candidate`。
-- schema 变更属于硬兼容断点；按项目约束"按全新 schema 起库处理、不保留兼容读取"的规则，此 Phase 必须一次切断干净。
-- 测试、README、所有 workspace 样例配置都需同步更新。
-
-**前置条件**：
-
-- Phase 1 已落地，且稳定运行一段时间。
-- 有生产 session 长度分布数据，能验证 0.20 默认值是否合理。
-
----
-
-### 3.3 Phase 3：`max_turns` 处理
-
-两种可选方向：
-
-**方向 A：分档化**
-
-- 移入 `runtime_hints.conversation_memory.working_memory_max_turns`。
-- 1M 档建议 10~12，256K 档保持 6~8。
-
-**方向 B：彻底移除**
-
-- 让 token 预算作为唯一回放约束。
-- 对齐 MemGPT / LangGraph 主流做法。
-
-**推荐**：B。当前全局 6 导致 cap 在 1M 档永远用不满，已是"约束错位"的症状。
-
-**风险 / 影响面**：
-
-- 小：仅改 `DefaultWorkingMemoryPolicy.select_turns`。
-- 测试仅需调整 working policy 相关用例。
-
----
-
-### 3.4 Phase 0.5（可选小修）：档位原则写进 README
-
-**目标**：把当前"同档同配"的原则固化为规则，防止未来个案特例重新污染。
-
-**改动点**：`dayu/config/README.md §5.7` 开头补：
-
-1. 前置声明：本节仅作用于 `conversation.enabled = true` 的 scene（当前为 `interactive / wechat / prompt_mt`）。write pipeline 不走 memory manager，本节字段对其无效。
-2. 档位一致性原则：`runtime_hints.conversation_memory` 的配置以**跨模型一致性**为第一优先级，单模型调参必须整档一起动，不允许同档内个体特例。
-
-**收益**：
-
-- 消除读者"write pipeline 也被 memory 配置影响"的误解。
-- 明确规则后，未来新增模型或调参都有硬标尺。
-
-**风险**：极低，仅文档改动。
-
----
-
-## 4. 实施顺序建议
-
-| 阶段 | 动作 | 前置 | 风险 |
+| 字段 | 类型 | 财报场景含义 | 例子 |
 |---|---|---|---|
-| 0 | 本次已完成的档位对齐（deepseek / qwen3:30b） | — | 已落地 |
-| 0.5 | README 档位原则前置声明 | — | 低 |
-| 1 | compaction 阈值改百分比制 | — | 中 |
-| 2 | 单总池合并 | Phase 1 稳定 + 生产数据 | 较大 |
-| 3 | `max_turns` 去除或分档 | Phase 2 已落地 | 小 |
+| `current_goal` | `str` | 当前主任务 | "分析贵州茅台 2024 H1 营收增长结构" |
+| `confirmed_subjects` | `tuple[str, ...]` | 已确认对象（公司 / 报告期 / 报告类型） | `("贵州茅台 600519.SH", "2024 半年报")` |
+| `user_constraints` | `tuple[str, ...]` | 用户口径约束 | `("用 IFRS 口径", "数字以百万元计")` |
+| `open_questions` | `tuple[str, ...]` | 未决问题 | `("毛利率下滑原因待解释",)` |
+
+**怎么产生**（已有链路，本次不动）：
+
+```
+1. 用户发起对话 → 初始 pinned_state = ConversationPinnedState() 全空
+
+2. 对话累积 N 轮 raw turn → 不动 pinned_state
+
+3. compaction 触发（按 compaction_trigger_context_ratio）
+   ↓
+   ConversationCompactionCoordinator 调度 LLM 跑 conversation_compaction scene
+   （prompts/scenes/conversation_compaction.md，无工具、严格 JSON）
+   ↓
+   _build_user_payload 把 pinned_state、近 episodes、待压缩 turns 拼 JSON 喂给 LLM
+   ↓
+   LLM 输出：
+     - episode_summary（append 到 transcript.episodes）
+     - pinned_state_patch（增量修改 pinned_state）
+
+4. ConversationPinnedStatePatch.apply_to → 字段级合并
+   - patch 字段为 None 表示"本次不动"，不是"清空"
+   - 因此 pinned_state 从 N 次 compaction 中单调演进
+```
+
+要点：
+- pinned_state **不是规则提取**，是 LLM 在 compaction 时顺便产出的结构化抽取
+- 渲染由 `_render_pinned_state_block` 输出 `[Conversation Memory]` 系统块开头
+- token 量典型 < 200，永远全量渲染、不参与池竞争
+
+### "最近 N 轮 raw turn"是上限还是下限？
+
+**这是相比旧设计的关键反转**：
+
+| 旧设计 `working_memory_max_turns = 6` | 新设计 `recent_turns_floor = 2` |
+|---|---|
+| **上限**："最多放 6 轮" | **下限**："至少保 2 轮" |
+| 回放轮数 = `min(6, budget 允许的轮数)` | 回放轮数 = `max(2, budget 允许的轮数)` |
+| 1M 档 cap=80K 算下来可放 ~16 轮，被 6 卡死 → cap 永远用不满 | 没有任何上限，budget 允许 20 轮就放 20 轮 |
+| 6 轮被 cap 80K 包住，6 是真主约束（§2.4 原文） | 2 轮是反退化保底，绝大多数情况下被 budget 自然超过 |
+
+简言之：**旧字段是天花板，新字段是地板，方向相反**。如果 budget 充足，可能回放 15 轮，N=2 完全不限制它。它只在极端情况兜底（单轮 user_text 巨长 > budget 时不让追问断链，走 `_build_minimum_preserved_turn_view`）。
 
 ---
 
-## 5. 生产数据需求（决定 Phase 2 / 3 最优值的前置）
+## 最终方案
 
-以下数据缺一项就无法把 Phase 2 / 3 的默认值从"估算"升级为"实测"：
+### 两层结构
 
-- `interactive / wechat / prompt_mt` 三个 scene 各自的 session 长度分布（turn 数 p50 / p90 / p99）。
-- 每轮平均消息 token 量（含工具调用）。
-- compaction 实际触发率（按 turn 触发 vs 按 token 触发）。
-- 触发后的摘要质量回归（是否丢 pinned_state / open_questions）。
+```
+[Conversation Memory]
+├── pinned_state                          ← 永远全量、不计入 token 池
+└── 历史单总池（budget = clamp(window * ratio, floor, cap)）
+    ├── 最近 N 轮 raw turn                ← recent_turns_floor 强制保留，不计入 budget
+    │   （单轮溢出由 _build_minimum_preserved_turn_view 兜底）
+    ├── 更老 raw turn（按预算从新到老回放）
+    └── episode summaries（按剩余预算从新到老填充）
+```
 
-在没有这些数据前，Phase 1 是相对安全的改造（语义清理为主，数值可以保守取 `0.75`）；Phase 2 / 3 应先收数据再动。
+### 配置面（8 字段，旧字段全删）
 
----
+```json
+"conversation_memory": {
+  "default": {
+    "memory_token_budget_ratio": 0.10,
+    "memory_token_budget_floor": 4000,
+    "memory_token_budget_cap": 60000,
+    "recent_turns_floor": 2,
+    "compaction_trigger_context_ratio": 0.70,
+    "compaction_tail_preserve_turns": 4,
+    "compaction_context_episode_window": 2,
+    "compaction_scene_name": "conversation_compaction"
+  }
+}
+```
 
-## 6. 业界参考（知识性总结，非实时核对）
+### 字段说明
 
-| 系统 | 分层 | compaction 触发 | 预算度量 |
+`conversation_memory` 与模型 `max_context_tokens` **仍然强相关**，ratio / 触发阈值都是相对窗口的百分比，不是绝对值。差别在：旧设计 ratio 被 cap 截成死代码（§2.2），新设计接受现实，cap 是真主约束、ratio 在小窗口模型生效。
+
+| # | 字段 | 默认 | 与 `max_context_tokens` 关系 | 作用 | 调参信号 |
+|---|---|---|---|---|---|
+| 1 | `memory_token_budget_ratio` | `0.10` | **池大小 = window * ratio**（再被 floor/cap 截断） | 控制总池占模型窗口百分比 | 通常不动；按当前默认（floor=4000、cap=60000）在 ~40K–600K 窗口范围内真实生效，超出区间被 floor/cap 咬合 |
+| 2 | `memory_token_budget_floor` | `4000` | 与 window 无关 | 总池下限保底 | 短窗口模型一轮都放不下 → 上调 |
+| 3 | `memory_token_budget_cap` | `60000` | 与 window 无关 | 总池上限封顶。1M 档算出 100K 被 cap 截到 60K | 追问频繁忘上一轮 → 小步上调（每次 +8K） |
+| 4 | `recent_turns_floor` | `2` | 无关 | 最近 N 轮强制保留（不计入 budget），反退化下限 | 单轮极长导致追问断链 → 调到 3 |
+| 5 | `compaction_trigger_context_ratio` | `0.70` | **触发阈值 = window * ratio** | `system + pinned + actual_episodic_in_prompt + uncompressed_raw_turns + 当前 user_text > window * 0.70` 时压缩；`actual_episodic_in_prompt` 复用 `_build_memory_block` 的真实裁切结果，与渲染口径一致 | 频繁触发拖慢响应 → 0.80；从不触发 → 0.60 |
+| 6 | `compaction_tail_preserve_turns` | `4` | 无关 | 压缩时保留最近 4 轮 raw 不压 | 现状不变 |
+| 7 | `compaction_context_episode_window` | `2` | 无关 | 生成新 episode summary 时喂给 LLM 多少个最近 episode 作邻近上下文 | 现状不变 |
+| 8 | `compaction_scene_name` | `"conversation_compaction"` | 无关 | 压缩用专用 scene（无工具、严格 JSON） | 不动 |
+
+字段 1 + 5 与 window 强耦合，共同保证 1M / 256K / 8K 档自适应，不用为每档手写绝对阈值。
+
+### 跨档配置策略：default 一份打天下
+
+**不分档配置。** 各档实际 budget 自然落位：
+
+| 模型窗口 | `window * 0.10` | clamp(floor=4000, cap=60000) | 实际 budget |
 |---|---|---|---|
-| Claude Code | 单层滚动 + auto-compact | 占 context window 百分比（常见 80%~90%） | 相对百分比 |
-| MemGPT / Letta | main / recall / archival 三层 + tool-callable memory | main context 满时 LLM 主动搬迁 | 每层绝对值 |
-| LangGraph `ConversationSummaryBufferMemory` | buffer + running summary | buffer 超 token 即 summary | 单层 token 阈值 |
-| AutoGen | 每 agent rolling + summary | turn 或 token 阈值 | 单层 |
-| dayu（当前） | working raw + episodic structured | `turns > N` 或 `tokens > working * 1.5` | 双层独立 ratio/floor/cap |
+| 1M | 100K | 截到 cap | **60K** |
+| 256K | 25.6K | 在区间内 | **25.6K** |
+| 128K | 12.8K | 在区间内 | 12.8K |
+| 32K | 3.2K | 兜到 floor | 4K |
 
-dayu 在"双层结构 + 异步后台 compaction + revision 乐观并发"这三项工程质量上高于主流开源实现；在"阈值语义 + 单池 vs 双池"两项上略落后。Phase 1 / 2 即朝着前者收敛。
+理由：
+1. 1M 档自然被 cap 截到 60K（default cap 就是为它设的）
+2. 256K 档自然落到 25.6K（比 1M 档少 22%，与"窗口越大 memory 越小份额"信条一致）
+3. 财报 agent interactive 不服务 < 128K 模型
+4. 极致表达"同档同配"——连档都不分
+
+**两个迁移点**：
+
+1. **`dayu/config/llm_models.json`**：删除全部 19 处 `runtime_hints.conversation_memory` 块（不再需要，default 接管）
+2. **`dayu/cli/commands/init.py`**：删除 `_build_conversation_memory_overrides`（行 78-103）整个函数，及其在 `init.py:1056 / 1187` 两处调用。`dayu-cli init` 添加 ollama / OpenAI 兼容模型时不再写入 `conversation_memory` 覆盖到 `workspace/config/llm_models.json`，按 default 走
+
+`workspace/config/llm_models.json` 用户已生成的旧 entry **不需要迁移**：按项目硬约束"全新 schema 起库处理"，旧 workspace 由 `workspace_migrations` 在 `dayu-cli init` 流程处理；本次只保证新 init 不再写覆盖、官方 default 干净。
+
+### 移除字段（硬切换）
+
+- `working_memory_max_turns`（→ `recent_turns_floor` 语义反转）
+- `working_memory_token_budget_ratio` / `_floor` / `_cap`（→ `memory_token_budget_*` 单总池）
+- `episodic_memory_token_budget_ratio` / `_floor` / `_cap`（→ 同上）
+- `compaction_trigger_turn_count`（轮数触发器去除，token 占比唯一约束）
+- `compaction_trigger_token_ratio`（→ `compaction_trigger_context_ratio`）
+
+### 触发与消费算法
+
+**Compaction 触发**：
+```
+window_used = system_prompt + pinned_state
+            + actual_episodic_in_prompt
+            + uncompressed_raw_turns + current_user_text
+should_compact = window_used > max_context_tokens * compaction_trigger_context_ratio
+```
+
+`actual_episodic_in_prompt` 复用 `_build_memory_block` 的真实裁切结果，**与 prompt 渲染口径完全一致**，避免触发器与渲染器漂移。`schedule_compaction`（持久化后路径）入参不接 `user_text`：用户消息已写入 transcript，再传会与 `uncompressed_raw_turns` 双计；`prepare_transcript`（持久化前路径）保留 `user_text` 形参。两条路径语义分离。
+
+**总池消费（`build_messages` 新流程）**：
+```python
+budget = clamp(window * ratio, floor, cap)
+
+# 1. pinned_state 独立路径，不动 budget
+# 2. 最近 N 轮 raw turn 强制保留（不计 budget）
+forced = raw_tail[-recent_turns_floor:]
+# 3. 更老 raw turn 按 budget 从新到老回放
+extra_pool = budget
+for turn in reversed(raw_tail[:-recent_turns_floor]):
+    if estimate(turn) <= extra_pool: 加入；扣 extra_pool
+    else: break
+# 4. episode summaries 用剩余 budget 从新到老填充
+for episode in reversed(transcript.episodes):
+    if estimate(episode) <= extra_pool: 加入；扣 extra_pool
+    else: break
+```
+
+`recent_turns_floor` 不计入 budget 的理由：它是反退化硬保底。即使 budget=0、cap=0、配置全错，也保最近 N 轮在不让追问彻底断链。极端单轮溢出由既有 `_build_minimum_preserved_turn_view` 路径处理（user_text 全保、assistant 降级裁剪）。
+
+### 4 个结构性问题对照
+
+| Issue 问题 | 解 |
+|---|---|
+| 2.1 token 阈值半死 | 改占模型窗口百分比 0.70，跨档位自动伸缩 |
+| 2.2 ratio 死代码 | 单总池 cap 主导（接受现实），ratio 仅在小窗口模型生效 |
+| 2.3 双独立池 | 合并单总池；pinned_state 单独不参与竞争 |
+| 2.4 max_turns 全局硬限 | 反转为 `recent_turns_floor`，从"上限"改"下限"（保追问连续性） |
 
 ---
 
-## 7. 不打算做的事
+## 风险与说明
 
-- **不回滚 1M 档 working_cap 到 20000~32000**：会破坏"跨模型一致性"这条第一优先级原则。若真要下调，必须整档统一动。
-- **不再给单个模型特例化 memory 配置**：档位原则一旦写进 README，应作硬规则。
-- **不在没有生产数据前随意提高 episodic cap**：当前 12000 是否过薄属于"理论可能"，但提高前需数据支撑。
+- **1M 档 cap 设到 60000**：基于"memory 克制"信条的工程判断；现有 1M 档用户若依赖更大 working 池追问，可小步上调；项目信条明确"长上下文留给财报材料"，方向一致。
+- **不再等生产数据**：参数化配置可调，先落地机制；后续按生产观察小步调参。
+- **schema 硬切换**：按项目硬约束"全新 schema 起库处理"，旧库迁移作为 `workspace_migrations` 插件进入 `dayu-cli init` 流程。
+
+---
+
+> 业界参考（仅作设计校核，不照搬）：Claude Code（百分比触发 auto-compact）、OpenAI Codex（单池 tokenBudget）、OpenCode（auto/prune/reserved 三件套）、MemGPT/Letta（分层 + 工具可调）。最终方案不是糅合，而是从财报 agent 不变量长出来。

--- a/docs/conversation_memory_test.md
+++ b/docs/conversation_memory_test.md
@@ -1,0 +1,147 @@
+# Interactive Scene 多轮会话记忆实测 Prompt 集
+
+## 目标
+
+实测验证 issue #48 优化后的两层记忆结构在真实财报对话中的表现。重点观察四件事：
+
+1. **pinned_state 是否单调演进**（公司/期间/口径不漂移）。
+2. **compaction 何时触发**（约在 `0.70 * max_context_tokens` 处）。
+3. **追问连续性**（最近 N 轮 raw turn 强制保留的反退化保底是否生效）。
+4. **confirmed_facts 是否在 compaction 后仍可被引用**（跨轮反幻觉）。
+
+启动方式：
+
+```bash
+source .venv/bin/activate
+python -m dayu.cli interactive --scene interactive
+```
+
+每组测试结束后，建议结合 `output/tool_call_traces/` 与日志中 `compaction` 关键字交叉确认。
+
+---
+
+## 测试组 A：pinned_state 演进与抗漂移
+
+**目的**：确认 `current_goal` / `confirmed_subjects` / `user_constraints` 在多轮中只被增量补丁修改，不被覆盖丢失。
+
+观察项：
+- 第 5 轮回答里是否还知道"贵州茅台 600519.SH"是当前主体。
+- 第 6 轮换公司时，pinned_state 是被替换还是被混淆。
+
+```text
+1. 我想看看贵州茅台 2024 年半年报的营收增长结构。
+2. 用百万元口径展示，按产品系列拆分。
+3. 茅台酒和系列酒分别同比增长多少？
+4. 毛利率有变化吗？
+5. 把刚才提到的产品系列对应的销量也一起列出来。
+6. 切换到五粮液 2024 半年报，做同样口径的产品系列拆分。
+7. 回到茅台，刚才你给的茅台酒系列酒同比增速我再确认一遍。
+```
+
+**预期**：第 7 轮"回到茅台"时仍能拿出与第 3 轮一致的同比增速，不能给出新数字。第 5 轮已是触发 compaction 的临界点，第 7 轮压缩后的 episode summary 应记录"茅台 2024H1 营收口径已确认 / 用户要求百万元"。
+
+---
+
+## 测试组 B：追问连续性（最近 N 轮 raw 强制保留）
+
+**目的**：验证 `recent_turns_floor=2` 在 budget 紧张时仍能保住"上一轮 + 上上轮"完整文本。
+
+观察项：
+- 第 3 轮和第 5 轮的"那这个"指代是否能正确解析为上一轮的具体表述。
+
+```text
+1. 拉一下宁德时代 2024 年报里现金流量表的关键数据。
+2. 经营性现金流净额是多少？
+3. 这个数和净利润比，差异在哪个项目最大？
+4. 投资活动的支出主要花在什么上？
+5. 那这部分支出和扩产计划匹配吗？
+6. 如果按 IFRS 口径重看一次，关键数据有差别吗？
+```
+
+**预期**：第 3、5 轮代词解析无错。第 6 轮触发 `user_constraints` 增加"IFRS 口径"，pinned_state 从此带这条约束。
+
+---
+
+## 测试组 C：单轮极长输入的 minimum_preserve 兜底
+
+**目的**：测试单轮 user_text 远超预算时，`_build_minimum_preserved_turn_view` 是否兜底保留 user_text、降级 assistant。
+
+观察项：
+- 第 2 轮粘贴长披露文本后，第 3 轮的追问是否仍能基于第 2 轮的内容连贯回答。
+
+```text
+1. 我准备分析比亚迪 2024 半年报的毛利率结构变化。
+2. （粘贴一份 8000-15000 字的官方披露原文片段，比如 MD&A 中关于毛利率影响因素的整段描述）
+   基于以上原文，给我提炼影响毛利率的三个最重要因素，按重要性排序。
+3. 第二个因素能再展开讲讲吗？
+4. 这三个因素和你之前给我的拆分口径一致吗？
+5. 把这次讨论的毛利率结论和测试组 A 里茅台的毛利率对比一下。
+```
+
+**预期**：第 3 轮"第二个因素"的指代能正确还原。第 5 轮可以发现两家公司毛利率口径已经在不同 pinned_state 中分别保存（如果是新开 session）或被 confirmed_facts 同时记录。
+
+---
+
+## 测试组 D：compaction 触发与 confirmed_facts 跨轮一致性
+
+**目的**：验证 compaction 触发后，关键事实通过 episode_summary.confirmed_facts 跨轮保留，新轮不重复检索。
+
+观察项：
+- 在第 8-10 轮会观察到日志中 `准备同步压缩 transcript` / `检测到 compaction 候选`；
+- 第 12 轮再问"刚才确认过的数据"时，模型应基于 episode summary 而非重新调用工具。
+
+```text
+1. 帮我看看招商银行 2024 半年报的息差数据。
+2. 净息差是多少？
+3. 同比变化幅度多少？
+4. 生息资产收益率分项给我列一下。
+5. 计息负债成本率呢？
+6. 资产端的零售贷款占比变化怎么样？
+7. 负债端定期存款占比呢？
+8. 把这些数据按"资产 / 负债 / 息差"分三组重新组织一下。
+9. 哪一组对净息差下行贡献最大？
+10. 给个一句话结论。
+11. 我换个问题：招行的不良率怎么样？
+12. 回到刚才息差讨论，净息差的具体数值再确认一次。
+13. 这次确认的数和第 2 轮一致吗？
+```
+
+**预期**：
+- 第 8-10 轮时上下文用量逼近 `0.70 * max_context_tokens`，触发 compaction。
+- 第 12 轮回答应直接基于 episode summary 的 confirmed_facts，**不再重新工具调用**。
+- 第 13 轮答案应与第 2 轮完全一致——这是反幻觉核心校验点。
+
+---
+
+## 测试组 E：长会话稳定性（连续 20+ 轮）
+
+**目的**：观察 budget 长期稳定性，验证 episode 数量增长后 budget 路径是否仍能正常裁剪。
+
+操作：选定一家公司（推荐美的集团 000333.SZ 或宁德时代 300750.SZ），围绕其 2024 半年报，按"营收 → 毛利 → 费用 → 利润 → 资产 → 负债 → 现金流 → 估值 → 同行对比"的展开顺序，每个主题问 2-3 个具体问题。目标 25-30 轮。
+
+观察项：
+- 每隔 5-7 轮触发一次 compaction，episode 数稳定增长。
+- pinned_state 中 `confirmed_subjects` 不重复添加同一公司，`user_constraints` 不丢失。
+- 第 25 轮提问"我们这次对话定下了哪些口径约束？"时，模型应能列全 user_constraints。
+
+---
+
+## 验证清单（每组测试结束后核对）
+
+- [ ] `output/tool_call_traces/` 中查到本次 session 的 trace。
+- [ ] 日志中至少出现一次 `准备同步压缩 transcript` 或 `开始后台 compaction`。
+- [ ] 用 sqlite3 打开 `.dayu/host/dayu_host.db`，查 `conversation_transcripts` 表中本 session 的 `pinned_state` JSON，确认 `current_goal` / `confirmed_subjects` / `user_constraints` 不为空且单调演进。
+- [ ] 测试组 D 第 13 轮答案与第 2 轮严格一致（数值不漂）。
+- [ ] 测试组 A 第 7 轮答案与第 3 轮严格一致。
+
+## 调参信号判读
+
+实测中如果观察到以下现象，对应调整方向：
+
+| 现象 | 调整 |
+|---|---|
+| 追问频繁忘上一轮（最近 1-2 轮内容丢失） | `memory_token_budget_cap` 小步上调（每次 +8K），或确认 `recent_turns_floor` 仍为 2 |
+| compaction 频繁触发拖慢响应 | `compaction_trigger_context_ratio` 0.70 → 0.80 |
+| 当前问题被旧内容淹没 | `compaction_trigger_context_ratio` 调到 0.60，提早压缩旧轮 |
+| confirmed_facts 数据跨轮不一致 | 检查 `prompts/scenes/conversation_compaction.md` 抽取约束，而非动 budget |
+| 单轮极长输入后追问断链 | 检查 minimum_preserve 路径，必要时把 `recent_turns_floor` 升到 3（仅在极端用例） |

--- a/tests/application/test_scene_execution.py
+++ b/tests/application/test_scene_execution.py
@@ -1282,7 +1282,7 @@ def test_scene_preparer_helper_functions_cover_single_turn_and_execution_option_
             fins_tool_limits=FinsToolLimits(),
             web_tools_config=WebToolsConfig(provider="off"),
             trace_settings=TraceSettings(enabled=False, output_dir=tmp_path / "trace-accepted"),
-            conversation_memory_settings=ConversationMemorySettings(compaction_trigger_turn_count=6),
+            conversation_memory_settings=ConversationMemorySettings(recent_turns_floor=3),
         ),
         prompt_contributions={},
         user_message="hello",
@@ -1368,8 +1368,8 @@ def test_scene_preparer_conversation_session_state_persist_turn_saves_and_schedu
         persisted.extend([next_transcript, expected_revision])
         return next_transcript
 
-    def _schedule_compaction(*, session_id, prepared_scene, transcript):
-        scheduled.extend([session_id, prepared_scene, transcript])
+    def _schedule_compaction(*, session_id, prepared_scene, transcript, system_prompt):
+        scheduled.extend([session_id, prepared_scene, transcript, system_prompt])
 
     session_state = scene_preparer_module.ConversationSessionState(
         session_id="session-1",
@@ -1379,6 +1379,7 @@ def test_scene_preparer_conversation_session_state_persist_turn_saves_and_schedu
         memory_manager=cast(scene_preparer_module.DefaultConversationMemoryManager, SimpleNamespace(schedule_compaction=_schedule_compaction)),
         prepared_scene=prepared_scene,
         user_message="hello",
+        system_prompt="SYS",
     )
 
     session_state.persist_turn(
@@ -1452,7 +1453,7 @@ async def test_scene_preparer_prepare_restore_and_host_owned_state_helpers(
             fins_tool_limits=FinsToolLimits(),
             web_tools_config=WebToolsConfig(provider="off"),
             trace_settings=TraceSettings(enabled=False, output_dir=tmp_path / "trace"),
-            conversation_memory_settings=ConversationMemorySettings(compaction_trigger_turn_count=5),
+            conversation_memory_settings=ConversationMemorySettings(recent_turns_floor=2),
         ),
         prompt_contributions={},
         user_message="hello",
@@ -1495,7 +1496,7 @@ async def test_scene_preparer_prepare_restore_and_host_owned_state_helpers(
         ),
         toolset_configs=(ToolsetConfigSnapshot(toolset_name="doc", payload={"list_files_max": 9}),),
         trace_settings=TraceSettings(enabled=False, output_dir=tmp_path / "trace-restored"),
-        conversation_memory_settings=ConversationMemorySettings(compaction_trigger_turn_count=4),
+        conversation_memory_settings=ConversationMemorySettings(recent_turns_floor=4),
         trace_identity=scene_preparer_module.AgentTraceIdentity(
             agent_name="prompt_agent",
             agent_kind="scene_agent",

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -11,21 +11,16 @@ from unittest.mock import patch
 import pytest
 
 from dayu.cli.commands.init import (
-    _build_conversation_memory_overrides,
-    _CONTEXT_TOKENS_LARGE_THRESHOLD,
     _CUSTOM_CATALOG_KEY,
     _CUSTOM_OPENAI_DEFAULT_MAX_CONTEXT_TOKENS,
     _CustomOpenAIConfig,
     _HF_MIRROR_URL,
     _INIT_ROLE_KEY,
-    _LARGE_CONTEXT_WORKING_MEMORY_CAP,
     _OLLAMA_CATALOG_KEY,
     _OLLAMA_DEFAULT_MAX_CONTEXT_TOKENS,
     _OLLAMA_DEFAULT_ENDPOINT,
     _OLLAMA_DEFAULT_WRITE_CHAPTER_LANE,
     _OllamaConfig,
-    _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
-    _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
     _build_ollama_catalog_entry,
     _set_write_chapter_lane,
     _PROVIDER_OPTION_CUSTOM_OPENAI,
@@ -732,7 +727,7 @@ class TestBuildOllamaCatalogEntry:
         runtime_hints = entry["runtime_hints"]
         assert isinstance(runtime_hints, dict)
         assert "temperature_profiles" in runtime_hints
-        assert "conversation_memory" in runtime_hints
+        assert "conversation_memory" not in runtime_hints
 
 
 class TestWriteOllamaCatalogEntries:
@@ -2364,43 +2359,6 @@ class TestInitPrewarm:
 
 
 # --------------------------------------------------------------------------- #
-#  _build_conversation_memory_overrides
-# --------------------------------------------------------------------------- #
-
-
-class TestBuildConversationMemoryOverrides:
-    """conversation_memory 动态构建测试。"""
-
-    def test_large_context_returns_working_memory_cap(self) -> None:
-        """max_context_tokens >= 100 万时返回 working_memory_token_budget_cap。"""
-        result = _build_conversation_memory_overrides(1_000_000)
-        assert result == {"working_memory_token_budget_cap": _LARGE_CONTEXT_WORKING_MEMORY_CAP}
-
-    def test_large_context_above_threshold(self) -> None:
-        """远超阈值时仍返回 working_memory_token_budget_cap。"""
-        result = _build_conversation_memory_overrides(2_000_000)
-        assert result == {"working_memory_token_budget_cap": _LARGE_CONTEXT_WORKING_MEMORY_CAP}
-
-    def test_small_context_returns_episodic_memory(self) -> None:
-        """max_context_tokens < 100 万时返回 episodic_memory 覆盖。"""
-        result = _build_conversation_memory_overrides(262144)
-        assert result == {
-            "episodic_memory_token_budget_floor": _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR,
-            "episodic_memory_token_budget_cap": _SMALL_CONTEXT_EPISODIC_MEMORY_CAP,
-        }
-
-    def test_threshold_boundary(self) -> None:
-        """恰好等于阈值时走大上下文分支。"""
-        result = _build_conversation_memory_overrides(_CONTEXT_TOKENS_LARGE_THRESHOLD)
-        assert "working_memory_token_budget_cap" in result
-
-    def test_just_below_threshold(self) -> None:
-        """阈值减 1 时走小上下文分支。"""
-        result = _build_conversation_memory_overrides(_CONTEXT_TOKENS_LARGE_THRESHOLD - 1)
-        assert "episodic_memory_token_budget_cap" in result
-
-
-# --------------------------------------------------------------------------- #
 #  _override_ollama_write_chapter_lane
 # --------------------------------------------------------------------------- #
 
@@ -2508,7 +2466,7 @@ class TestInitConversationMemoryAndLane:
     """init 流程中 conversation_memory 和 write_chapter lane 集成验证。"""
 
     def test_ollama_small_context_conversation_memory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Ollama 小上下文模型应写入 episodic_memory 覆盖。"""
+        """Ollama 小上下文模型 runtime_hints 不再写入 conversation_memory 覆盖。"""
         src = tmp_path / "pkg_config"
         src.mkdir()
         (src / "run.json").write_text(
@@ -2554,10 +2512,9 @@ class TestInitConversationMemoryAndLane:
         assert exit_code == 0
 
         llm_models = json.loads((base / "config" / "llm_models.json").read_text(encoding="utf-8"))
-        cm = llm_models[_OLLAMA_CATALOG_KEY]["runtime_hints"]["conversation_memory"]
-        assert cm["episodic_memory_token_budget_floor"] == _SMALL_CONTEXT_EPISODIC_MEMORY_FLOOR
-        assert cm["episodic_memory_token_budget_cap"] == _SMALL_CONTEXT_EPISODIC_MEMORY_CAP
-        assert "working_memory_token_budget_cap" not in cm
+        runtime_hints = llm_models[_OLLAMA_CATALOG_KEY]["runtime_hints"]
+        # default 一份打天下：runtime_hints 不再写入 conversation_memory 覆盖
+        assert "conversation_memory" not in runtime_hints
 
         # 验证 write_chapter lane 从 5 覆盖为 2
         run_data = json.loads((base / "config" / "run.json").read_text(encoding="utf-8"))
@@ -2566,7 +2523,7 @@ class TestInitConversationMemoryAndLane:
     def test_custom_openai_large_context_conversation_memory(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Custom OpenAI 大上下文模型应写入 working_memory_token_budget_cap。"""
+        """Custom OpenAI 大上下文模型 runtime_hints 不再写入 conversation_memory 覆盖。"""
         src = tmp_path / "pkg_config"
         src.mkdir()
         (src / "run.json").write_text("{}", encoding="utf-8")
@@ -2610,6 +2567,6 @@ class TestInitConversationMemoryAndLane:
         assert exit_code == 0
 
         llm_models = json.loads((base / "config" / "llm_models.json").read_text(encoding="utf-8"))
-        cm = llm_models[_CUSTOM_CATALOG_KEY]["runtime_hints"]["conversation_memory"]
-        assert cm["working_memory_token_budget_cap"] == _LARGE_CONTEXT_WORKING_MEMORY_CAP
-        assert "episodic_memory_token_budget_cap" not in cm
+        runtime_hints = llm_models[_CUSTOM_CATALOG_KEY]["runtime_hints"]
+        # default 一份打天下：runtime_hints 不再写入 conversation_memory 覆盖
+        assert "conversation_memory" not in runtime_hints

--- a/tests/engine/test_conversation_memory.py
+++ b/tests/engine/test_conversation_memory.py
@@ -317,17 +317,19 @@ def test_build_base_execution_options_keeps_default_conversation_memory_settings
         run_config={
             "conversation_memory": {
                 "default": {
-                    "working_memory_token_budget_cap": 7000,
-                    "episodic_memory_token_budget_floor": 2100,
-                    "episodic_memory_token_budget_cap": 2100,
+                    "memory_token_budget_ratio": 0.10,
+                    "memory_token_budget_floor": 4000,
+                    "memory_token_budget_cap": 7000,
+                    "recent_turns_floor": 2,
+                    "compaction_trigger_context_ratio": 0.60,
                 },
             }
         },
     )
 
-    assert base_options.conversation_memory_settings.working_memory_token_budget_cap == 7000
-    assert base_options.conversation_memory_config.default.episodic_memory_token_budget_floor == 2100
-    assert base_options.conversation_memory_config.default.episodic_memory_token_budget_cap == 2100
+    assert base_options.conversation_memory_settings.memory_token_budget_cap == 7000
+    assert base_options.conversation_memory_config.default.memory_token_budget_floor == 4000
+    assert base_options.conversation_memory_config.default.memory_token_budget_cap == 7000
 
 
 @pytest.mark.unit
@@ -341,8 +343,8 @@ def test_build_base_execution_options_keeps_typed_default_run_config_values(tmp_
 
     assert cast(OpenAIRunnerRuntimeConfig, base_options.runner_running_config).tool_timeout_seconds == 90.0
     assert base_options.agent_running_config.max_iterations == 16
-    assert base_options.conversation_memory_settings.working_memory_token_budget_cap == 12000
-    assert base_options.conversation_memory_settings.episodic_memory_token_budget_cap == 12000
+    assert base_options.conversation_memory_settings.memory_token_budget_cap == 60000
+    assert base_options.conversation_memory_settings.memory_token_budget_floor == 4000
 
 
 @pytest.mark.unit
@@ -356,9 +358,11 @@ def test_merge_execution_options_keeps_default_conversation_memory_settings(
         run_config={
             "conversation_memory": {
                 "default": {
-                    "working_memory_token_budget_cap": 6500,
-                    "episodic_memory_token_budget_floor": 2600,
-                    "episodic_memory_token_budget_cap": 2600,
+                    "memory_token_budget_ratio": 0.10,
+                    "memory_token_budget_floor": 4000,
+                    "memory_token_budget_cap": 6500,
+                    "recent_turns_floor": 2,
+                    "compaction_trigger_context_ratio": 0.60,
                 },
             }
         },
@@ -371,9 +375,8 @@ def test_merge_execution_options_keeps_default_conversation_memory_settings(
     )
 
     assert resolved.model_name == "deepseek-v4-flash-thinking"
-    assert resolved.conversation_memory_settings.working_memory_token_budget_cap == 6500
-    assert resolved.conversation_memory_settings.episodic_memory_token_budget_floor == 2600
-    assert resolved.conversation_memory_settings.episodic_memory_token_budget_cap == 2600
+    assert resolved.conversation_memory_settings.memory_token_budget_cap == 6500
+    assert resolved.conversation_memory_settings.memory_token_budget_floor == 4000
 
 
 @pytest.mark.unit
@@ -385,9 +388,11 @@ def test_build_base_execution_options_uses_default_when_model_has_no_runtime_hin
         run_config={
             "conversation_memory": {
                 "default": {
-                    "working_memory_token_budget_cap": 9000,
-                    "episodic_memory_token_budget_floor": 2600,
-                    "episodic_memory_token_budget_cap": 2600,
+                    "memory_token_budget_ratio": 0.10,
+                    "memory_token_budget_floor": 4000,
+                    "memory_token_budget_cap": 9000,
+                    "recent_turns_floor": 2,
+                    "compaction_trigger_context_ratio": 0.60,
                 },
             }
         },
@@ -400,9 +405,7 @@ def test_build_base_execution_options_uses_default_when_model_has_no_runtime_hin
     )
 
     assert resolved.model_name == "qwen-plus-thinking"
-    assert resolved.conversation_memory_settings.working_memory_token_budget_cap == 9000
-    assert resolved.conversation_memory_settings.episodic_memory_token_budget_floor == 2600
-    assert resolved.conversation_memory_settings.episodic_memory_token_budget_cap == 2600
+    assert resolved.conversation_memory_settings.memory_token_budget_cap == 9000
 
 
 @pytest.mark.unit
@@ -414,9 +417,11 @@ def test_resolve_conversation_memory_settings_merges_model_runtime_hints(tmp_pat
         run_config={
             "conversation_memory": {
                 "default": {
-                    "working_memory_token_budget_cap": 9000,
-                    "episodic_memory_token_budget_floor": 2600,
-                    "episodic_memory_token_budget_cap": 2600,
+                    "memory_token_budget_ratio": 0.10,
+                    "memory_token_budget_floor": 4000,
+                    "memory_token_budget_cap": 9000,
+                    "recent_turns_floor": 2,
+                    "compaction_trigger_context_ratio": 0.60,
                 }
             }
         },
@@ -427,22 +432,20 @@ def test_resolve_conversation_memory_settings_merges_model_runtime_hints(tmp_pat
         model_config={
             "runtime_hints": {
                 "conversation_memory": {
-                    "working_memory_token_budget_cap": 20000,
-                    "episodic_memory_token_budget_floor": 4200,
-                    "episodic_memory_token_budget_cap": 4200,
+                    "memory_token_budget_cap": 20000,
+                    "recent_turns_floor": 3,
                 }
             }
         },
     )
 
-    assert settings.working_memory_token_budget_cap == 20000
-    assert settings.episodic_memory_token_budget_floor == 4200
-    assert settings.episodic_memory_token_budget_cap == 4200
+    assert settings.memory_token_budget_cap == 20000
+    assert settings.recent_turns_floor == 3
 
 
 @pytest.mark.unit
 def test_working_memory_policy_uses_uncompacted_tail_and_budget() -> None:
-    """验证 working memory 只从未压缩 tail 中按预算选 turn。"""
+    """验证 working memory 强制保留最近 N 轮，并按预算回放更老 raw turn。"""
 
     policy = DefaultWorkingMemoryPolicy()
     transcript = ConversationTranscript.create_empty("sess_1")
@@ -454,13 +457,14 @@ def test_working_memory_policy_uses_uncompacted_tail_and_budget() -> None:
         compacted_turn_count=3,
     )
     settings = ConversationMemorySettings(
-        working_memory_max_turns=2,
-        working_memory_token_budget_ratio=0.01,
-        working_memory_token_budget_floor=120,
-        working_memory_token_budget_cap=120,
+        memory_token_budget_ratio=0.01,
+        memory_token_budget_floor=120,
+        memory_token_budget_cap=120,
+        recent_turns_floor=2,
     )
 
-    selected = policy.select_turns(transcript, settings=settings, max_context_tokens=1000)
+    # 总预算 120 tokens 仅够最近 2 轮 forced 保留，更老 raw 不进。
+    selected = policy.select_turns(transcript, settings=settings, available_token_budget=0, max_context_tokens=200_000)
 
     assert tuple(turn.turn_id for turn in selected) == ("turn_6", "turn_7")
 
@@ -479,7 +483,12 @@ def test_working_memory_policy_does_not_overrun_small_context_budget() -> None:
         )
     )
 
-    selected = policy.select_turns(transcript, settings=ConversationMemorySettings(), max_context_tokens=1024)
+    selected = policy.select_turns(
+        transcript,
+        settings=ConversationMemorySettings(),
+        available_token_budget=1024,
+        max_context_tokens=200_000,
+    )
 
     assert len(selected) == 1
     assert selected[0].turn_id == "turn_1"
@@ -489,7 +498,7 @@ def test_working_memory_policy_does_not_overrun_small_context_budget() -> None:
 
 @pytest.mark.unit
 def test_working_memory_policy_keeps_latest_turn_as_truncated_view_when_single_turn_exceeds_budget() -> None:
-    """验证最新 turn 即使超预算也会以裁剪视图保留，而不是整轮消失。"""
+    """验证最新 turn 即使超 cap 也会以裁剪视图保留，而不是整轮消失。"""
 
     policy = DefaultWorkingMemoryPolicy()
     transcript = ConversationTranscript.create_empty("sess_1").append_turn(
@@ -511,13 +520,13 @@ def test_working_memory_policy_keeps_latest_turn_as_truncated_view_when_single_t
         )
     )
     settings = ConversationMemorySettings(
-        working_memory_max_turns=6,
-        working_memory_token_budget_ratio=0.01,
-        working_memory_token_budget_floor=120,
-        working_memory_token_budget_cap=120,
+        memory_token_budget_ratio=0.01,
+        memory_token_budget_floor=120,
+        memory_token_budget_cap=120,
+        recent_turns_floor=1,
     )
 
-    selected = policy.select_turns(transcript, settings=settings, max_context_tokens=1000)
+    selected = policy.select_turns(transcript, settings=settings, available_token_budget=0, max_context_tokens=240)
 
     assert len(selected) == 1
     assert selected[0].turn_id == "turn_1"
@@ -532,10 +541,10 @@ def test_default_conversation_memory_manager_builds_memory_block_and_raw_tail(tm
     """验证 memory manager 会把 pinned state、episodes 和 raw tail 一起编译进消息。"""
 
     settings = ConversationMemorySettings(
-        episodic_memory_token_budget_ratio=0.0,
-        episodic_memory_token_budget_floor=400,
-        episodic_memory_token_budget_cap=400,
-        working_memory_max_turns=2,
+        memory_token_budget_ratio=0.0,
+        memory_token_budget_floor=400,
+        memory_token_budget_cap=400,
+        recent_turns_floor=2,
     )
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
@@ -717,7 +726,10 @@ def test_default_episodic_memory_compressor_rejects_empty_summary_title() -> Non
 def test_conversation_memory_manager_compacts_in_background_and_replans(tmp_path: Path) -> None:
     """验证后台 compaction 会取消旧任务并按最新 transcript 重排。"""
 
-    settings = ConversationMemorySettings(compaction_trigger_turn_count=2, compaction_tail_preserve_turns=1)
+    settings = ConversationMemorySettings(
+        compaction_trigger_context_ratio=0.001,
+        compaction_tail_preserve_turns=1,
+    )
     store = FileConversationStore(tmp_path / "conversations")
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     compressor = _FakeCompressor(delay=0.02)
@@ -736,6 +748,7 @@ def test_conversation_memory_manager_compacts_in_background_and_replans(tmp_path
             session_id="sess_1",
             prepared_scene=_build_prepared_scene(settings=settings),
             transcript=transcript,
+            system_prompt="sys",
         )
         await asyncio.sleep(0)
         current = store.load("sess_1")
@@ -747,6 +760,7 @@ def test_conversation_memory_manager_compacts_in_background_and_replans(tmp_path
             session_id="sess_1",
             prepared_scene=_build_prepared_scene(settings=settings),
             transcript=updated,
+            system_prompt="sys",
         )
         await manager.wait_for_session("sess_1")
 
@@ -791,6 +805,8 @@ def test_prepare_transcript_compacts_persisted_tail_before_resumed_turn(tmp_path
             session_id="sess_1",
             prepared_scene=_build_prepared_scene(settings=settings, max_context_tokens=2048),
             transcript=transcript,
+            system_prompt="sys",
+            user_text="hi",
         )
     )
 
@@ -838,12 +854,15 @@ def test_conversation_memory_emits_compaction_logs(tmp_path: Path, monkeypatch: 
             session_id="sess_log",
             prepared_scene=_build_prepared_scene(settings=settings, max_context_tokens=2048),
             transcript=transcript,
+            system_prompt="sys",
+            user_text="hi",
         )
     )
     manager.schedule_compaction(
         session_id="sess_log",
         prepared_scene=_build_prepared_scene(settings=settings, max_context_tokens=100000),
         transcript=prepared,
+        system_prompt="sys",
     )
 
     verbose_messages = [call.args[0] for call in verbose_mock.call_args_list]
@@ -852,3 +871,356 @@ def test_conversation_memory_emits_compaction_logs(tmp_path: Path, monkeypatch: 
     assert any("准备同步压缩 transcript" in message for message in verbose_messages)
     assert any("同步压缩写回 transcript" in message for message in verbose_messages)
     assert any("无需调度 compaction" in message for message in debug_messages)
+
+
+@pytest.mark.unit
+def test_resolve_memory_total_budget_clamped_by_floor_and_cap() -> None:
+    """验证总池预算公式 ``clamp(window * ratio, floor, cap)`` 在跨档位都生效。"""
+
+    from dayu.host.conversation_memory import _resolve_memory_total_budget
+
+    settings = ConversationMemorySettings(
+        memory_token_budget_ratio=0.10,
+        memory_token_budget_floor=4000,
+        memory_token_budget_cap=32000,
+    )
+    # 1M 档：100K 算出被 cap 截到 32K
+    assert _resolve_memory_total_budget(settings=settings, max_context_tokens=1_000_000) == 32000
+    # 256K 档：自然落到 25.6K
+    assert _resolve_memory_total_budget(settings=settings, max_context_tokens=256_000) == 25_600
+    # 8K 档：800 太小被 floor 兜底
+    assert _resolve_memory_total_budget(settings=settings, max_context_tokens=8_000) == 4000
+
+
+@pytest.mark.unit
+def test_recent_turns_floor_forced_preserved_when_budget_zero() -> None:
+    """``recent_turns_floor`` 在 budget=0 时仍强制保留最近 N 轮。"""
+
+    policy = DefaultWorkingMemoryPolicy()
+    transcript = ConversationTranscript.create_empty("sess_floor")
+    for index in range(1, 6):
+        transcript = transcript.append_turn(_build_turn(index))
+    settings = ConversationMemorySettings(
+        memory_token_budget_ratio=0.10,
+        memory_token_budget_floor=4000,
+        memory_token_budget_cap=32000,
+        recent_turns_floor=2,
+    )
+
+    selected = policy.select_turns(transcript, settings=settings, available_token_budget=0, max_context_tokens=200_000)
+
+    assert tuple(t.turn_id for t in selected) == ("turn_4", "turn_5")
+
+
+@pytest.mark.unit
+def test_compaction_triggered_by_window_ratio(tmp_path: Path) -> None:
+    """当 window_used 超过 ``max_context_tokens * trigger_context_ratio`` 时触发 compaction。"""
+
+    settings = ConversationMemorySettings(
+        compaction_trigger_context_ratio=0.50,
+        compaction_tail_preserve_turns=1,
+    )
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        conversation_store=FileConversationStore(tmp_path / "conversations"),
+    )
+    transcript = ConversationTranscript.create_empty("sess_trig")
+    for index in range(1, 5):
+        transcript = transcript.append_turn(
+            ConversationTurnRecord(
+                turn_id=f"turn_{index}",
+                scene_name="interactive",
+                user_text="x" * 800,
+                assistant_final="",
+            )
+        )
+
+    candidates = manager._select_compaction_candidate(
+        transcript=transcript,
+        settings=settings,
+        max_context_tokens=2048,
+    )
+    assert len(candidates) > 0
+
+
+@pytest.mark.unit
+def test_compaction_not_triggered_below_ratio(tmp_path: Path) -> None:
+    """当 window_used 远小于阈值时不触发 compaction。"""
+
+    settings = ConversationMemorySettings(
+        compaction_trigger_context_ratio=0.99,
+        compaction_tail_preserve_turns=1,
+    )
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        conversation_store=FileConversationStore(tmp_path / "conversations"),
+    )
+    transcript = ConversationTranscript.create_empty("sess_low")
+    for index in range(1, 4):
+        transcript = transcript.append_turn(_build_turn(index))
+
+    candidates = manager._select_compaction_candidate(
+        transcript=transcript,
+        settings=settings,
+        max_context_tokens=1_000_000,
+    )
+    assert candidates == ()
+
+
+@pytest.mark.unit
+def test_forced_turn_overflow_threshold_decoupled_from_cap() -> None:
+    """Fix #1：单轮兜底阈值由 ``max_context_tokens`` 派生，与 ``memory_token_budget_cap`` 解耦。
+
+    构造场景：单轮 token 数 < cap 但 > 当前模型窗口。旧逻辑会按 cap 兜底，
+    把整轮原样回放从而撑爆窗口；新逻辑必须走 ``_build_minimum_preserved_turn_view``。
+    """
+
+    policy = DefaultWorkingMemoryPolicy()
+    transcript = ConversationTranscript.create_empty("sess_decouple").append_turn(
+        ConversationTurnRecord(
+            turn_id="turn_1",
+            scene_name="interactive",
+            user_text="问题",
+            assistant_final="x" * 4000,  # ~1000 tokens 远小于 cap=60000
+        )
+    )
+    settings = ConversationMemorySettings(
+        memory_token_budget_cap=60000,  # 故意调高 cap
+        recent_turns_floor=1,
+    )
+    # 模型窗口仅 200，单轮就超出窗口；阈值应由 max_context_tokens 派生，触发 minimum_preserve。
+    selected = policy.select_turns(
+        transcript,
+        settings=settings,
+        available_token_budget=0,
+        max_context_tokens=200,
+    )
+    assert len(selected) == 1
+    assert selected[0].assistant_text.endswith("...<truncated>")
+
+
+@pytest.mark.unit
+def test_forced_turn_overflow_threshold_uses_actual_forced_count() -> None:
+    """Round3 #1：单轮兜底阈值除数取**当前实际 forced 轮数**而非 ``settings.recent_turns_floor``。
+
+    场景：``recent_turns_floor=5`` 但当前 transcript 仅 1 轮 raw turn，``max_context_tokens=300``。
+    旧实现按 ``floor + 1 = 6`` 派生阈值 ``300/6 = 50``，单轮（约 75 tokens）会被错误判定溢出
+    走 minimum_preserve；新实现按 ``actual_forced_count + 1 = 2`` 派生阈值 ``300/2 = 150``，
+    单轮可完整保留。
+    """
+
+    policy = DefaultWorkingMemoryPolicy()
+    transcript = ConversationTranscript.create_empty("sess_actual_floor").append_turn(
+        ConversationTurnRecord(
+            turn_id="turn_only",
+            scene_name="interactive",
+            user_text="新对话第一轮",
+            assistant_final="x" * 200,  # ~50 tokens
+        )
+    )
+    settings = ConversationMemorySettings(
+        memory_token_budget_cap=60000,
+        recent_turns_floor=5,  # 配置高 floor，但实际只有 1 轮
+    )
+    selected = policy.select_turns(
+        transcript,
+        settings=settings,
+        available_token_budget=0,
+        max_context_tokens=300,
+    )
+    assert len(selected) == 1
+    # 实际 forced=1，阈值=300/2=150，单轮 ~50 tokens 完整保留，不应被截断。
+    assert not selected[0].assistant_text.endswith("...<truncated>")
+
+
+@pytest.mark.unit
+def test_compaction_trigger_does_not_count_episodes(tmp_path: Path) -> None:
+    """Round 1 Fix #2 + Round 2 #1：``transcript.episodes`` 仅按 ``_build_memory_block``
+    裁切后真实进入 prompt 的部分计入 ``window_used``；超大 episode 在剩余预算放不下时
+    应被丢弃，不计入触发判定，避免压缩抖动。"""
+
+    settings = ConversationMemorySettings(
+        compaction_trigger_context_ratio=0.50,
+        compaction_tail_preserve_turns=1,
+    )
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        conversation_store=FileConversationStore(tmp_path / "conversations"),
+    )
+    transcript = ConversationTranscript.create_empty("sess_no_eps")
+    transcript = transcript.append_turn(_build_turn(1))
+    transcript = transcript.append_turn(_build_turn(2))
+    # 注入一个超大 episode；若错误计入 window_used，会无谓触发压缩。
+    huge_episode = ConversationEpisodeSummary(
+        episode_id="ep_huge",
+        start_turn_id="turn_1",
+        end_turn_id="turn_1",
+        title="历史摘要",
+        goal="x" * 50_000,
+        confirmed_facts=(),
+    )
+    transcript = transcript.replace_memory(
+        pinned_state=transcript.pinned_state,
+        episodes=(huge_episode,),
+        compacted_turn_count=transcript.compacted_turn_count,
+    )
+
+    # raw turn 体量很小，加 system/user 远不到 1M*0.5=500K 阈值；episode 不应让公式越线。
+    candidates = manager._select_compaction_candidate(
+        transcript=transcript,
+        settings=settings,
+        max_context_tokens=1_000_000,
+        system_prompt_tokens=200,
+        user_text_tokens=50,
+    )
+    assert candidates == ()
+
+
+@pytest.mark.unit
+def test_schedule_compaction_passes_system_prompt_token_estimate(tmp_path: Path) -> None:
+    """``schedule_compaction`` 必须把 system_prompt 估算 token 接到触发公式。
+
+    Round2 #2：``schedule_compaction`` 在 ``persist_turn`` 之后调用，当前轮 user_text
+    已落入 ``transcript.turns`` 最末位，自然出现在 ``uncompressed_tokens`` 中，
+    本入口不再接收 ``user_text`` 避免重复计数。``prepare_transcript`` 仍显式传
+    ``user_text``（开局尚未 persist）。
+    """
+
+    settings = ConversationMemorySettings(
+        compaction_trigger_context_ratio=0.50,
+        compaction_tail_preserve_turns=1,
+    )
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        conversation_store=FileConversationStore(tmp_path / "conversations"),
+    )
+    transcript = ConversationTranscript.create_empty("sess_wired")
+    for index in range(1, 4):
+        transcript = transcript.append_turn(
+            ConversationTurnRecord(
+                turn_id=f"turn_{index}",
+                scene_name="interactive",
+                user_text="x" * 100,
+                assistant_final="",
+            )
+        )
+
+    captured: dict[str, int] = {}
+    original = manager._select_compaction_candidate
+
+    def _spy(
+        *,
+        transcript: ConversationTranscript,
+        settings: ConversationMemorySettings,
+        max_context_tokens: int,
+        system_prompt_tokens: int = 0,
+        user_text_tokens: int = 0,
+    ) -> tuple[ConversationTurnRecord, ...]:
+        captured["system_prompt_tokens"] = system_prompt_tokens
+        captured["user_text_tokens"] = user_text_tokens
+        return original(
+            transcript=transcript,
+            settings=settings,
+            max_context_tokens=max_context_tokens,
+            system_prompt_tokens=system_prompt_tokens,
+            user_text_tokens=user_text_tokens,
+        )
+
+    manager._select_compaction_candidate = _spy  # type: ignore[method-assign]
+
+    manager.schedule_compaction(
+        session_id="sess_wired",
+        prepared_scene=_build_prepared_scene(settings=settings),
+        transcript=transcript,
+        system_prompt="SYS:" + "y" * 1000,
+    )
+
+    assert captured["system_prompt_tokens"] > 100
+    # Round2 #2 回归：schedule_compaction 不再把 user_text 重复计入触发公式。
+    assert captured["user_text_tokens"] == 0
+
+
+@pytest.mark.unit
+def test_compaction_trigger_counts_actual_episode_in_prompt(tmp_path: Path) -> None:
+    """Round2 #1：触发公式必须计入 ``_build_memory_block`` 的兜底分支保留的 episode。
+
+    场景：单条 episode 远大于 ``total_budget``。``_build_memory_block`` 仍会保留这条
+    最新 episode（避免 episodic 层完全失效）。如果 ``_select_compaction_candidate``
+    把 ``transcript.episodes`` 完全踢出 ``window_used``，会低估真实 prompt 体积、
+    在该压缩时不压缩。
+    """
+
+    settings = ConversationMemorySettings(
+        memory_token_budget_ratio=0.10,
+        memory_token_budget_floor=2000,
+        memory_token_budget_cap=2000,  # 把 budget 锁到 2000，让大 episode 必然超 budget
+        compaction_trigger_context_ratio=0.50,
+        compaction_tail_preserve_turns=1,
+    )
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        conversation_store=FileConversationStore(tmp_path / "conversations"),
+    )
+    transcript = ConversationTranscript.create_empty("sess_round2_1")
+    # raw turns 体量很小，单独不会触发。
+    transcript = transcript.append_turn(_build_turn(1))
+    transcript = transcript.append_turn(_build_turn(2))
+    huge_summary = "x" * 100_000  # ~25K tokens，远超 budget 2000
+    transcript = transcript.replace_memory(
+        pinned_state=transcript.pinned_state,
+        episodes=(
+            ConversationEpisodeSummary(
+                episode_id="ep_huge",
+                start_turn_id="turn_0",
+                end_turn_id="turn_0",
+                title="历史摘要",
+                goal=huge_summary,
+            ),
+        ),
+        compacted_turn_count=transcript.compacted_turn_count,
+    )
+
+    # 模型窗口 30K，阈值 = 30K * 0.5 = 15K。raw + system + user 单独 < 15K，
+    # 但 _build_memory_block 兜底保留的大 episode 会让 actual_episodic > 15K，触发公式必须包含。
+    candidates = manager._select_compaction_candidate(
+        transcript=transcript,
+        settings=settings,
+        max_context_tokens=30_000,
+        system_prompt_tokens=200,
+        user_text_tokens=50,
+    )
+    assert len(candidates) > 0
+
+
+@pytest.mark.unit
+def test_default_conversation_memory_settings_match_runtime_default() -> None:
+    """Round2 #3：``ConversationMemorySettings()`` dataclass 默认值必须与 run.json
+    / ``options.py`` 运行时默认一致，避免快照恢复 / dataclass 直构 / run.json
+    三条路径得到不同 memory policy。"""
+
+    from dayu.execution.options import _DEFAULT_RUN_CONFIG  # type: ignore[attr-defined]
+
+    runtime_default = _DEFAULT_RUN_CONFIG.conversation_memory.default
+    dataclass_default = ConversationMemorySettings()
+    assert dataclass_default.memory_token_budget_ratio == runtime_default.memory_token_budget_ratio
+    assert dataclass_default.memory_token_budget_floor == runtime_default.memory_token_budget_floor
+    assert dataclass_default.memory_token_budget_cap == runtime_default.memory_token_budget_cap
+    assert dataclass_default.recent_turns_floor == runtime_default.recent_turns_floor
+    assert (
+        dataclass_default.compaction_trigger_context_ratio
+        == runtime_default.compaction_trigger_context_ratio
+    )
+    assert (
+        dataclass_default.compaction_tail_preserve_turns
+        == runtime_default.compaction_tail_preserve_turns
+    )
+    assert (
+        dataclass_default.compaction_context_episode_window
+        == runtime_default.compaction_context_episode_window
+    )
+    assert dataclass_default.compaction_scene_name == runtime_default.compaction_scene_name


### PR DESCRIPTION
- 弃用 working/episodic 双独立预算池，改为 pinned_state 独立 + 单总池（最近 N 轮 raw + 老 raw + episode summaries）
- compaction 触发改为占模型窗口百分比单维度判定，复用 _build_memory_block 计算 actual_episodic_in_prompt 与渲染口径对齐
- recent_turns_floor 语义反转为反退化下限（不计入 budget）；单轮溢出阈值按实际 forced 轮数派生，与 cap 解耦
- 双路径语义分离：prepare_transcript 显式接 user_text、schedule_compaction 不接（避免 post-persist 双计）
- default 一份打天下，删除 llm_models.json 19 处 runtime_hints 覆盖与 init.py 写覆盖逻辑
- 同步更新 config/README §5.8、host/README §10、dayu/README §8 与 docs/conversation_memory_optimization.md，标注 128K 档使用注意事项

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>
