### PR TITLE
code review low 风险 finding 全量修复（批 1–15）

### DIFF
--- a/dayu/cli/main.py
+++ b/dayu/cli/main.py
@@ -67,7 +67,10 @@ def main() -> int:
             from dayu.cli.commands.write import run_write_command
 
             return run_write_command(args)
-        return 0
+        # argparse subparsers 已声明 dest="command", required=True，未匹配
+        # 任何已注册命令时会在 parse_arguments() 阶段直接退出，因此本处
+        # 不再出现"未命中分支"的运行时分支。
+        raise AssertionError(f"未识别的 CLI 命令: {args.command!r}")
     except KeyboardInterrupt:
         # 信号 handler（sync_signals._handler）在收到 SIGINT 时先执行
         # `coordinator.settle_active_runs(trigger="signal:SIGINT")`

--- a/dayu/engine/README.md
+++ b/dayu/engine/README.md
@@ -258,8 +258,10 @@ PrepareIteration
 预算治理当前由 `AsyncAgent` 编排，并由 `dayu.engine.context_budget` 承载其中的预算原语，主要包括：
 - 软上限触发的主动压缩
 - 硬上限触发的压缩重试
-- 工具结果预测性截断（只作用于“已序列化、待注入下一轮消息”的工具结果，不替代 ToolRegistry 的 schema 驱动截断）
+- 工具结果预测性截断（只作用于“已序列化、待注入下一轮消息”的工具结果，不替代 ToolRegistry 的 schema 驱动截断；当前采用宽字符感知的保守 token 估算，避免中文/财报文本被明显低估）
 - 截断续写
+
+压缩摘要不会尝试保留完整历史，而是保留 system、首条 user、最近 tail，并把中段工具结果压成结构化 highlights；对 `dict/list` 结果优先保留顶层字段语义，而不是简单截 JSON 前缀。
 
 预算参数的最终真源在 `AgentCreateArgs`，不是 Runner 自己去读模型配置文件。
 

--- a/dayu/engine/async_agent.py
+++ b/dayu/engine/async_agent.py
@@ -102,6 +102,16 @@ DEFAULT_COMPACTION_SUMMARY_INSTRUCTION = (
     "Continue reasoning based on recent context. "
     "Avoid repeating tool calls that have already been completed."
 )
+_TERMINATION_REASON_CONTEXT_OVERFLOW_RETRIED = "context_overflow_retried"
+_TERMINATION_REASON_CONTEXT_OVERFLOW_EXHAUSTED = "context_overflow_exhausted"
+_TERMINATION_REASON_TOOL_CALLS_MISSING = "tool_calls_missing"
+_TERMINATION_REASON_TOOL_CALLS_CONTINUED = "tool_calls_continued"
+_TERMINATION_REASON_TOOL_CALLS_BATCH_MISSING = "tool_calls_batch_missing"
+_TERMINATION_REASON_TOOL_CALL_EARLY_EXIT = "tool_call_early_exit"
+_TERMINATION_REASON_CONTINUATION = "continuation"
+_TERMINATION_REASON_FINAL_ANSWER = "final_answer"
+_TERMINATION_REASON_MAX_ITERATIONS = "max_iterations"
+_TERMINATION_REASON_ERROR = "error"
 
 # 压缩中保留的最近 message 条数（system 和首条 user 单独保留）
 _COMPACT_RECENT_KEEP = 6
@@ -910,7 +920,15 @@ class AsyncAgent:
                     yield self._annotate_event(event, run_id=run_id, iteration_id=iteration_id)
                     if not error_data.get("recoverable", False):
                         if trace_recorder is not None:
-                            trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                            trace_recorder.finish_iteration(
+                                iteration_id=iteration_id,
+                                iteration_index=iteration,
+                                termination_reason=(
+                                    _TERMINATION_REASON_CONTEXT_OVERFLOW_EXHAUSTED
+                                    if overflow_exhausted
+                                    else str(err_type).strip() or _TERMINATION_REASON_ERROR
+                                ),
+                            )
                         return
                 
                 else:
@@ -920,7 +938,11 @@ class AsyncAgent:
             # context_overflow 压缩后重试：不计入迭代次数（但 iteration_counter 已递增，保证下一轮 iteration_id 唯一）
             if context_overflow_handled:
                 if trace_recorder is not None:
-                    trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration_counter)
+                    trace_recorder.finish_iteration(
+                        iteration_id=iteration_id,
+                        iteration_index=iteration_counter,
+                        termination_reason=_TERMINATION_REASON_CONTEXT_OVERFLOW_RETRIED,
+                    )
                 iteration -= 1
                 continue
 
@@ -941,7 +963,11 @@ class AsyncAgent:
                     )
                     yield self._annotate_event(error, run_id=run_id, iteration_id=iteration_id)
                     if trace_recorder is not None:
-                        trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                        trace_recorder.finish_iteration(
+                            iteration_id=iteration_id,
+                            iteration_index=iteration,
+                            termination_reason=_TERMINATION_REASON_TOOL_CALLS_MISSING,
+                        )
                     return
 
                 if any(is_tool_success(tc.get("result")) for tc in ordered_tool_calls):
@@ -1027,7 +1053,7 @@ class AsyncAgent:
                     )
                     yield self._annotate_event(duplicate_warning, run_id=run_id, iteration_id=iteration_id)
                     messages.append(
-                        build_user_chat_message(
+                        build_system_chat_message(
                             self._build_duplicate_tool_hint_prompt(duplicate_hint_tool_name)
                         )
                     )
@@ -1054,12 +1080,26 @@ class AsyncAgent:
                         )
                         yield self._annotate_event(error, run_id=run_id, iteration_id=iteration_id)
                         if trace_recorder is not None:
-                            trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                            trace_recorder.finish_iteration(
+                                iteration_id=iteration_id,
+                                iteration_index=iteration,
+                                termination_reason=(
+                                    early_exit_error_type
+                                    or _TERMINATION_REASON_TOOL_CALL_EARLY_EXIT
+                                ),
+                            )
                         return
 
                     if self.fallback_mode == "force_answer":
                         if trace_recorder is not None:
-                            trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                            trace_recorder.finish_iteration(
+                                iteration_id=iteration_id,
+                                iteration_index=iteration,
+                                termination_reason=(
+                                    early_exit_error_type
+                                    or _TERMINATION_REASON_TOOL_CALL_EARLY_EXIT
+                                ),
+                            )
                         async for fallback_event in self._run_force_answer(
                             messages,
                             stream=stream,
@@ -1075,7 +1115,11 @@ class AsyncAgent:
                         return
 
                 if trace_recorder is not None:
-                    trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                    trace_recorder.finish_iteration(
+                        iteration_id=iteration_id,
+                        iteration_index=iteration,
+                        termination_reason=_TERMINATION_REASON_TOOL_CALLS_CONTINUED,
+                    )
                 continue
 
             if tool_calls_data and not tool_calls_batch_done_seen:
@@ -1087,7 +1131,11 @@ class AsyncAgent:
                 )
                 yield self._annotate_event(error, run_id=run_id, iteration_id=iteration_id)
                 if trace_recorder is not None:
-                    trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                    trace_recorder.finish_iteration(
+                        iteration_id=iteration_id,
+                        iteration_index=iteration,
+                        termination_reason=_TERMINATION_REASON_TOOL_CALLS_BATCH_MISSING,
+                    )
                 return
 
             if (content_complete_seen or done_event_seen) and not tool_calls_data:
@@ -1146,7 +1194,11 @@ class AsyncAgent:
                             )
                             Log.warn(f"[{iteration_id}] {cont_compact_msg}", module=MODULE)
                     if trace_recorder is not None:
-                        trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                        trace_recorder.finish_iteration(
+                            iteration_id=iteration_id,
+                            iteration_index=iteration,
+                            termination_reason=_TERMINATION_REASON_CONTINUATION,
+                        )
                     continue  # 回到 while 循环进行下一轮
 
                 # 拼接所有轮次的内容（续写场景下 accumulated_content_parts 含前序内容）
@@ -1175,7 +1227,11 @@ class AsyncAgent:
                     )
                 yield self._annotate_event(final_event, run_id=run_id, iteration_id=iteration_id)
                 if trace_recorder is not None:
-                    trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                    trace_recorder.finish_iteration(
+                        iteration_id=iteration_id,
+                        iteration_index=iteration,
+                        termination_reason=_TERMINATION_REASON_FINAL_ANSWER,
+                    )
                 return
             
         if iteration >= self.running_config.max_iterations:
@@ -1191,12 +1247,20 @@ class AsyncAgent:
                 )
                 yield self._annotate_event(error, run_id=run_id, iteration_id=iteration_id)
                 if trace_recorder is not None:
-                    trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                    trace_recorder.finish_iteration(
+                        iteration_id=iteration_id,
+                        iteration_index=iteration,
+                        termination_reason=_TERMINATION_REASON_MAX_ITERATIONS,
+                    )
                 return
 
             if self.fallback_mode == "force_answer":
                 if trace_recorder is not None:
-                    trace_recorder.finish_iteration(iteration_id=iteration_id, iteration_index=iteration)
+                    trace_recorder.finish_iteration(
+                        iteration_id=iteration_id,
+                        iteration_index=iteration,
+                        termination_reason=_TERMINATION_REASON_MAX_ITERATIONS,
+                    )
                 async for fallback_event in self._run_force_answer(
                     messages,
                     stream=stream,
@@ -1587,7 +1651,7 @@ def _compact_messages(
             header=summary_header,
             instruction=summary_instruction,
         )
-        result.append(build_user_chat_message(summary))
+        result.append(build_system_chat_message(summary))
 
     # 保留最近 recent_keep 条消息
     result.extend(messages[recent_start:])

--- a/dayu/engine/async_agent.py
+++ b/dayu/engine/async_agent.py
@@ -116,8 +116,11 @@ _TERMINATION_REASON_ERROR = "error"
 # 压缩中保留的最近 message 条数（system 和首条 user 单独保留）
 _COMPACT_RECENT_KEEP = 6
 _COMPACTION_TOOL_RESULT_MAX_LINES = 4
-_COMPACTION_VALUE_SUMMARY_MAX_CHARS = 160
+_COMPACTION_VALUE_SUMMARY_MAX_CHARS = 320
 _COMPACTION_ERROR_SUMMARY_MAX_CHARS = 120
+_COMPACTION_VALUE_SUMMARY_MAX_ITEMS = 6
+_COMPACTION_SEQUENCE_SUMMARY_MAX_ITEMS = 4
+_COMPACTION_INLINE_VALUE_MAX_CHARS = 80
 
 
 def _extract_sse_protocol_error_trace_payload(
@@ -340,7 +343,10 @@ def _compute_predictive_budget_stats(
     """
 
     total_result_chars = sum(len(s) for _, s in serialized_pairs)
-    estimated_injection_tokens = ToolResultBudgetCapper.estimate_chars_to_tokens(total_result_chars)
+    estimated_injection_tokens = sum(
+        ToolResultBudgetCapper.estimate_text_to_tokens(result_str)
+        for _, result_str in serialized_pairs
+    )
     projected_tokens = (
         budget_state.current_prompt_tokens
         + budget_state.latest_completion_tokens
@@ -1850,6 +1856,168 @@ def _build_compaction_tool_status_parts(parsed_payload: object) -> list[str]:
     return status_parts
 
 
+def _truncate_compaction_summary_text(text: str, max_chars: int) -> str:
+    """将摘要文本裁剪到给定长度。
+
+    Args:
+        text: 原始摘要文本。
+        max_chars: 最大允许字符数。
+
+    Returns:
+        截断后的摘要文本。
+
+    Raises:
+        无。
+    """
+
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3] + "..."
+
+
+def _normalize_compaction_scalar_text(value: object) -> str | None:
+    """把标量值规范化为单行文本。
+
+    Args:
+        value: 待规范化的标量值。
+
+    Returns:
+        规范化后的单行文本；若为空则返回 `None`。
+
+    Raises:
+        无。
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        normalized = " ".join(value.split())
+    else:
+        serialized = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        normalized = " ".join(serialized.split())
+    return normalized or None
+
+
+def _summarize_compaction_mapping(
+    value: dict[object, object],
+    *,
+    max_chars: int,
+    depth: int,
+) -> str | None:
+    """为字典值构建更保真的紧凑摘要。
+
+    Args:
+        value: 待摘要的字典。
+        max_chars: 最大允许字符数。
+        depth: 当前递归深度。
+
+    Returns:
+        结构化摘要文本；无法提炼时返回 `None`。
+
+    Raises:
+        无。
+    """
+
+    fragments: list[str] = []
+    total_items = len(value)
+    for raw_key, raw_value in value.items():
+        key_text = str(raw_key).strip()
+        if not key_text:
+            continue
+        value_text = _summarize_compaction_value(
+            raw_value,
+            max_chars=_COMPACTION_INLINE_VALUE_MAX_CHARS,
+            depth=depth + 1,
+        )
+        if value_text is None:
+            continue
+        fragments.append(f"{key_text}={value_text}")
+        if len(fragments) >= _COMPACTION_VALUE_SUMMARY_MAX_ITEMS:
+            break
+    if not fragments:
+        fallback_text = _normalize_compaction_scalar_text(value)
+        if fallback_text is None:
+            return None
+        return _truncate_compaction_summary_text(fallback_text, max_chars)
+    summary = "; ".join(fragments)
+    if total_items > len(fragments):
+        summary = f"{summary}; ... ({total_items} keys)"
+    return _truncate_compaction_summary_text(summary, max_chars)
+
+
+def _summarize_compaction_sequence(
+    value: list[object] | tuple[object, ...],
+    *,
+    max_chars: int,
+    depth: int,
+) -> str | None:
+    """为序列值构建更保真的紧凑摘要。
+
+    Args:
+        value: 待摘要的序列。
+        max_chars: 最大允许字符数。
+        depth: 当前递归深度。
+
+    Returns:
+        紧凑摘要文本；无法提炼时返回 `None`。
+
+    Raises:
+        无。
+    """
+
+    item_summaries: list[str] = []
+    for item in value[:_COMPACTION_SEQUENCE_SUMMARY_MAX_ITEMS]:
+        item_summary = _summarize_compaction_value(
+            item,
+            max_chars=_COMPACTION_INLINE_VALUE_MAX_CHARS,
+            depth=depth + 1,
+        )
+        if item_summary is None:
+            continue
+        item_summaries.append(item_summary)
+    if not item_summaries:
+        fallback_text = _normalize_compaction_scalar_text(value)
+        if fallback_text is None:
+            return None
+        return _truncate_compaction_summary_text(fallback_text, max_chars)
+    summary = ", ".join(item_summaries)
+    if len(value) > len(item_summaries):
+        summary = f"{summary}, ... ({len(value)} items)"
+    return _truncate_compaction_summary_text(summary, max_chars)
+
+
+def _summarize_compaction_value(
+    value: object,
+    *,
+    max_chars: int,
+    depth: int,
+) -> str | None:
+    """按值类型生成保真的工具结果摘要。
+
+    Args:
+        value: 待摘要的值。
+        max_chars: 最大允许字符数。
+        depth: 当前递归深度。
+
+    Returns:
+        紧凑摘要文本；若值为空则返回 `None`。
+
+    Raises:
+        无。
+    """
+
+    if value is None:
+        return None
+    if depth <= 1 and isinstance(value, dict):
+        return _summarize_compaction_mapping(value, max_chars=max_chars, depth=depth)
+    if depth <= 1 and isinstance(value, (list, tuple)):
+        return _summarize_compaction_sequence(value, max_chars=max_chars, depth=depth)
+    normalized = _normalize_compaction_scalar_text(value)
+    if normalized is None:
+        return None
+    return _truncate_compaction_summary_text(normalized, max_chars)
+
+
 def _summarize_compaction_scalar_value(
     value: object,
     *,
@@ -1868,18 +2036,7 @@ def _summarize_compaction_scalar_value(
         无。
     """
 
-    if value is None:
-        return None
-    if isinstance(value, str):
-        normalized = " ".join(value.split())
-    else:
-        serialized = json.dumps(value, ensure_ascii=False, sort_keys=True)
-        normalized = " ".join(serialized.split())
-    if not normalized:
-        return None
-    if len(normalized) <= max_chars:
-        return normalized
-    return normalized[: max_chars - 3] + "..."
+    return _summarize_compaction_value(value, max_chars=max_chars, depth=0)
 
 
 class AgentResult:

--- a/dayu/engine/context_budget.py
+++ b/dayu/engine/context_budget.py
@@ -12,10 +12,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
+import math
 from typing import Mapping
-
-CHARS_PER_TOKEN = 4
-"""字符到 token 的保守换算比例。"""
+import unicodedata
 
 MIN_RESULT_CHARS = 4000
 """预测性预算裁剪后，单个工具结果最少保留的字符数。
@@ -31,6 +31,20 @@ PREDICTIVE_OVERHEAD_TOKENS = 4096
 tokenizer 对中文/特殊字符的膨胀余量（实测结构开销在 2k-3k token，
 取 4096 留出安全裕度）。
 """
+
+_HALF_WIDTH_TOKEN_UNITS = 1
+"""半角字符对应的 token 估算单位。"""
+
+_FULL_WIDTH_TOKEN_UNITS = 2
+"""全角/宽字符对应的 token 估算单位。"""
+
+_TOKEN_UNITS_PER_ESTIMATED_TOKEN = 2
+"""token 估算单位到保守 token 数的换算基数。"""
+
+MIN_RESULT_TOKENS = math.ceil(
+    (MIN_RESULT_CHARS * _HALF_WIDTH_TOKEN_UNITS) / _TOKEN_UNITS_PER_ESTIMATED_TOKEN
+)
+"""预测性预算裁剪后，单个工具结果最少保留的估算 token 数。"""
 
 
 def _coerce_usage_token_count(raw_value: object) -> int:
@@ -60,6 +74,87 @@ def _coerce_usage_token_count(raw_value: object) -> int:
             return 0
         return int(normalized_value)
     return 0
+
+
+@lru_cache(maxsize=256)
+def _token_units_for_char(char: str) -> int:
+    """返回单个字符对应的 token 估算单位。
+
+    Args:
+        char: 单个字符。
+
+    Returns:
+        宽字符返回 ``2``，其余字符返回 ``1``。
+
+    Raises:
+        无。
+    """
+
+    if unicodedata.east_asian_width(char) in {"W", "F"}:
+        return _FULL_WIDTH_TOKEN_UNITS
+    return _HALF_WIDTH_TOKEN_UNITS
+
+
+def _estimate_token_units(text: str) -> int:
+    """估算文本对应的原始 token 单位数。
+
+    Args:
+        text: 原始文本。
+
+    Returns:
+        估算得到的 token 单位总数。
+
+    Raises:
+        无。
+    """
+
+    return sum(_token_units_for_char(char) for char in text)
+
+
+def _token_units_to_estimated_tokens(token_units: int) -> int:
+    """将 token 单位数转换为保守 token 估算值。
+
+    Args:
+        token_units: token 单位总数。
+
+    Returns:
+        保守 token 估算值。
+
+    Raises:
+        无。
+    """
+
+    if token_units <= 0:
+        return 0
+    return max(1, math.ceil(token_units / _TOKEN_UNITS_PER_ESTIMATED_TOKEN))
+
+
+def _find_text_prefix_within_token_budget(text: str, max_tokens: int) -> str:
+    """返回满足 token 预算的最长文本前缀。
+
+    Args:
+        text: 原始文本。
+        max_tokens: 最大允许的估算 token 数。
+
+    Returns:
+        不超过预算的最长前缀；预算不足时返回空字符串。
+
+    Raises:
+        无。
+    """
+
+    if max_tokens <= 0 or not text:
+        return ""
+    max_units = max_tokens * _TOKEN_UNITS_PER_ESTIMATED_TOKEN
+    consumed_units = 0
+    end_index = 0
+    for index, char in enumerate(text):
+        next_units = _token_units_for_char(char)
+        if consumed_units + next_units > max_units:
+            break
+        consumed_units += next_units
+        end_index = index + 1
+    return text[:end_index]
 
 
 @dataclass
@@ -210,11 +305,11 @@ class ToolResultBudgetCapper:
     """
 
     @staticmethod
-    def estimate_chars_to_tokens(chars: int) -> int:
-        """将字符数转换为 token 数的保守估计。
+    def estimate_text_to_tokens(text: str) -> int:
+        """将文本转换为 token 数的保守估计。
 
         Args:
-            chars: 字符数。
+            text: 原始文本。
 
         Returns:
             估计 token 数。
@@ -223,7 +318,10 @@ class ToolResultBudgetCapper:
             无。
         """
 
-        return chars // CHARS_PER_TOKEN
+        normalized = str(text or "")
+        if not normalized:
+            return 0
+        return _token_units_to_estimated_tokens(_estimate_token_units(normalized))
 
     @staticmethod
     def truncate_result_str(result_str: str, max_chars: int) -> str:
@@ -252,6 +350,33 @@ class ToolResultBudgetCapper:
         return truncated + note
 
     @classmethod
+    def truncate_result_str_to_token_budget(cls, result_str: str, max_tokens: int) -> str:
+        """按 token 预算截断单个过大的工具结果字符串。
+
+        Args:
+            result_str: 原始结果字符串。
+            max_tokens: 最大允许保留的估算 token 数。
+
+        Returns:
+            截断后的字符串；若未超限则原样返回。
+
+        Raises:
+            无。
+        """
+
+        if cls.estimate_text_to_tokens(result_str) <= max_tokens:
+            return result_str
+        original_len = len(result_str)
+        truncated = _find_text_prefix_within_token_budget(result_str, max_tokens)
+        kept_chars = len(truncated)
+        note = (
+            f"\n\n[CONTEXT_BUDGET_TRUNCATED: "
+            f"original={original_len} chars, kept={kept_chars} chars. "
+            f"Please narrow your query scope or request a smaller result set.]"
+        )
+        return truncated + note
+
+    @classmethod
     def cap_results_for_budget(
         cls,
         serialized_pairs: list[tuple[dict[str, object], str]],
@@ -276,43 +401,43 @@ class ToolResultBudgetCapper:
             - budget_state.current_prompt_tokens
             - budget_state.latest_completion_tokens,
         )
-        available_chars = available_tokens * CHARS_PER_TOKEN
-
         indexed_sizes: list[tuple[int, int]] = [
-            (index, len(result_str))
+            (index, cls.estimate_text_to_tokens(result_str))
             for index, (_, result_str) in enumerate(serialized_pairs)
             if result_str
         ]
-        total_chars = sum(size for _, size in indexed_sizes)
-        if total_chars <= available_chars:
+        total_tokens = sum(size for _, size in indexed_sizes)
+        if total_tokens <= available_tokens:
             return serialized_pairs, False
 
         indexed_sizes.sort(key=lambda item: item[1])
         caps: dict[int, int] = {}
-        remaining_budget = available_chars
+        remaining_budget_tokens = available_tokens
         remaining_count = len(indexed_sizes)
         for index, size in indexed_sizes:
-            # 这里采用升序公平分配：小结果优先完整保留，剩余预算让给大结果，
-            # 这样比平均裁剪更能保住整体信息量。
-            fair_share = max(MIN_RESULT_CHARS, remaining_budget // max(1, remaining_count))
-            actual = min(size, fair_share)
+            # 这里采用升序公平分配：小结果优先完整保留，剩余预算让给大结果。
+            fair_share_tokens = max(
+                MIN_RESULT_TOKENS,
+                remaining_budget_tokens // max(1, remaining_count),
+            )
+            actual = min(size, fair_share_tokens)
             caps[index] = actual
-            remaining_budget = max(0, remaining_budget - actual)
+            remaining_budget_tokens = max(0, remaining_budget_tokens - actual)
             remaining_count -= 1
 
         capped = False
         new_pairs: list[tuple[dict[str, object], str]] = []
         for index, (tool_call, result_str) in enumerate(serialized_pairs):
-            if index in caps and len(result_str) > caps[index]:
-                result_str = cls.truncate_result_str(result_str, caps[index])
+            if index in caps and cls.estimate_text_to_tokens(result_str) > caps[index]:
+                result_str = cls.truncate_result_str_to_token_budget(result_str, caps[index])
                 capped = True
             new_pairs.append((tool_call, result_str))
         return new_pairs, capped
 
 
 __all__ = [
-    "CHARS_PER_TOKEN",
     "MIN_RESULT_CHARS",
+    "MIN_RESULT_TOKENS",
     "PREDICTIVE_OVERHEAD_TOKENS",
     "ContextBudgetState",
     "ToolResultBudgetCapper",

--- a/dayu/engine/tool_registry.py
+++ b/dayu/engine/tool_registry.py
@@ -62,7 +62,7 @@ class ToolRegistry:
     内部组合了 ArgumentValidator（参数校验）和 TruncationManager（截断分页）。
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         初始化工具注册表
 
@@ -74,7 +74,7 @@ class ToolRegistry:
                 Path("output/logs/app.log")
             ])
         """
-        self.tools: Dict[str, Callable] = {}
+        self.tools: Dict[str, Callable[..., object]] = {}
         self.schemas: Dict[str, Dict[str, Any]] = {}
         self.tool_schemas: Dict[str, ToolSchema] = {}
         self.tool_descriptors: Dict[str, ToolDescriptor] = {}
@@ -117,7 +117,7 @@ class ToolRegistry:
     def register(
         self,
         name: str,
-        func: Callable,
+        func: Callable[..., object],
         schema: Any,
     ) -> None:
         """
@@ -235,7 +235,7 @@ class ToolRegistry:
                 "schema.function.parameters.additionalProperties 必须是布尔值",
             )
     
-    def get_schemas(self) -> list:
+    def get_schemas(self) -> list[dict[str, Any]]:
         """获取所有工具的 schema 列表（用于传递给 LLM）"""
         return list(self.schemas.values())
     

--- a/dayu/engine/tools/__init__.py
+++ b/dayu/engine/tools/__init__.py
@@ -23,51 +23,23 @@ from ..tool_contracts import ToolSchema, ToolFunctionSchema, ToolTruncateSpec
 from .base import tool, build_tool_schema
 from .web_tools import register_web_tools
 from dayu.contracts.tool_configs import WebToolsConfig
-from .web_recovery import (
-    RECOVERY_CONTRACT_VERSION,
-    ALLOWED_NEXT_ACTIONS,
-    ALLOWED_REASONS,
-    NEXT_ACTION_CHANGE_SOURCE,
-    NEXT_ACTION_CONTINUE_WITHOUT_WEB,
-    NEXT_ACTION_RETRY,
-    REASON_BLOCKED_BY_SITE_POLICY,
-    REASON_CONTENT_CONVERSION_FAILED,
-    REASON_EMPTY_CONTENT,
-    REASON_HTTP_ERROR,
-    REASON_REDIRECT_CHAIN_TOO_LONG,
-    REASON_REQUEST_TIMEOUT,
-    build_hint,
-    normalize_next_action,
-    normalize_reason,
-)
 
 # 不在这里导入 doc_tools 和 utils_tools，避免循环依赖
 # 它们依赖 ToolRegistry，而 ToolRegistry 又导入 tools.__init__
+#
+# web_recovery 内部常量（RECOVERY_CONTRACT_VERSION / ALLOWED_NEXT_ACTIONS / ... 等）
+# 是 web 工具内部的重试策略实现细节，不暴露为 dayu.engine.tools 顶层稳定契约；
+# 需要这些常量的调用方请直接 `from dayu.engine.tools.web_recovery import ...`。
 
 __all__ = [
     # 类型定义
     "ToolSchema",
     "ToolFunctionSchema",
     "ToolTruncateSpec",
-    
+
     # 工具装饰器
     "tool",
     "build_tool_schema",
     "register_web_tools",
     "WebToolsConfig",
-    "RECOVERY_CONTRACT_VERSION",
-    "ALLOWED_NEXT_ACTIONS",
-    "ALLOWED_REASONS",
-    "NEXT_ACTION_CHANGE_SOURCE",
-    "NEXT_ACTION_CONTINUE_WITHOUT_WEB",
-    "NEXT_ACTION_RETRY",
-    "REASON_BLOCKED_BY_SITE_POLICY",
-    "REASON_CONTENT_CONVERSION_FAILED",
-    "REASON_EMPTY_CONTENT",
-    "REASON_HTTP_ERROR",
-    "REASON_REDIRECT_CHAIN_TOO_LONG",
-    "REASON_REQUEST_TIMEOUT",
-    "build_hint",
-    "normalize_next_action",
-    "normalize_reason",
 ]

--- a/dayu/fins/processors/def14a_processor.py
+++ b/dayu/fins/processors/def14a_processor.py
@@ -6,15 +6,9 @@ from typing import Optional
 
 from dayu.engine.processors.source import Source
 
-from .def14a_form_common import (  # noqa: F401  re-export for backward compat
-    _DEF14A_ANNEX_PATTERN,
-    _DEF14A_APPENDIX_PATTERN,
+from .def14a_form_common import (
     _DEF14A_FORMS,
-    _DEF14A_PROPOSAL_PATTERN,
-    _DEF14A_SECTION_MARKERS,
     _build_def14a_markers,
-    _find_proposal_position_after,
-    _select_def14a_proposal_markers,
 )
 from .sec_report_form_common import _BaseSecReportFormProcessor
 

--- a/dayu/fins/processors/eight_k_processor.py
+++ b/dayu/fins/processors/eight_k_processor.py
@@ -7,9 +7,8 @@ from typing import Optional
 from dayu.engine.processors.source import Source
 from dayu.fins.processors.sec_report_form_common import _BaseSecReportFormProcessor
 
-from .eight_k_form_common import (  # noqa: F401  re-export for backward compat
+from .eight_k_form_common import (
     _EIGHT_K_FORMS,
-    _EIGHT_K_ITEM_PATTERN,
     _build_eight_k_markers,
 )
 

--- a/dayu/fins/processors/html_financial_statement_common.py
+++ b/dayu/fins/processors/html_financial_statement_common.py
@@ -1384,6 +1384,13 @@ def _resolve_period_end_from_fiscal_period(
 ) -> Optional[dt.date]:
     """根据财期标签推断 period_end 日期。
 
+    限制：本函数仅作为 HTML 表头/OCR 路径无法直接解析具体日期时的粗粒度兜底，
+    Q4/FY 一律按公历 12-31 推断，不感知公司实际财年结束月日（例如 Apple 9 月财年）。
+    **禁止**把本函数当作 filing 级权威 period_end 的来源；filing 级 period_end
+    必须使用 SEC EDGAR 提供的 ``report_date``（见 ``filing_manifest.json``），
+    XBRL fact 筛选也以 manifest report_date 为准。后续 code review 若再次质疑
+    硬编码 12-31，请先确认是否真有调用方把本函数输出当作权威值使用，没有则维持现状。
+
     Args:
         fiscal_period: 财期标签。
         fiscal_year: 财年。
@@ -1392,7 +1399,7 @@ def _resolve_period_end_from_fiscal_period(
         对应的期末日期；无法映射时返回 `None`。
 
     Raises:
-        RuntimeError: 推断失败时抛出。
+        无。
     """
 
     mapping: dict[str, tuple[int, int]] = {

--- a/dayu/fins/processors/sc13_processor.py
+++ b/dayu/fins/processors/sc13_processor.py
@@ -7,13 +7,10 @@ from typing import Optional
 from dayu.engine.processors.source import Source
 from dayu.fins.processors.sec_report_form_common import _BaseSecReportFormProcessor
 
-from .sc13_form_common import (  # noqa: F401  re-export for backward compat
+from .sc13_form_common import (
     _SC13_FORMS,
-    _SC13_ITEM_PATTERN,
     _build_sc13_markers,
-    _find_item_position_after,
     _has_sufficient_sc13_markers,
-    _select_sc13_item_markers,
 )
 from .sec_form_section_common import (
     _is_table_placeholder_dominant_text,

--- a/dayu/fins/processors/sec_xbrl_query.py
+++ b/dayu/fins/processors/sec_xbrl_query.py
@@ -56,6 +56,27 @@ _DECIMALS_SCALE_MAP: dict[int, str] = {
     0: "units",
 }
 
+# 用于 units/scale 推断的主营收入概念候选（按 US-GAAP 实务命中优先级排序）。
+# - ``Revenues``：US-GAAP 2018+ 主流命名。
+# - ``Revenue``：部分 IFRS-aligned filer 与子集成器使用。
+# - ``SalesRevenueNet`` / ``SalesRevenueGoodsNet``：旧规与细分场景。
+_REVENUE_CONCEPT_CANDIDATES: tuple[str, ...] = (
+    "Revenues",
+    "Revenue",
+    "SalesRevenueNet",
+    "SalesRevenueGoodsNet",
+)
+
+# ISO 4217 主要货币代码（覆盖 SEC 主要外国发行人语种），用于从 units
+# 字符串中识别货币代码。未命中时返回 ``None``，避免把诸如 ``"shares"``
+# 之类的非货币单位误当作货币代码传给下游。
+_KNOWN_CURRENCY_CODES: frozenset[str] = frozenset(
+    {
+        "USD", "EUR", "GBP", "JPY", "CNY", "HKD", "TWD", "KRW", "INR",
+        "CAD", "AUD", "CHF", "BRL", "MXN", "SGD", "ZAR",
+    }
+)
+
 
 def _normalize_optional_string(value: Any) -> Optional[str]:
     """将任意值转为可选字符串，额外处理 pandas NaN/NaT。
@@ -667,6 +688,9 @@ def _infer_text_content_type(value: str) -> str:
 def _infer_units_from_xbrl_query(xbrl: XBRL) -> Optional[str]:
     """从 XBRL 查询推断单位。
 
+    依次尝试 ``_REVENUE_CONCEPT_CANDIDATES`` 中的概念，命中即返回该 fact
+    的 ``unit`` / ``unit_ref``，扩展对 IFRS-aligned 与旧规命名 filer 的覆盖。
+
     Args:
         xbrl: XBRL 对象。
 
@@ -674,48 +698,55 @@ def _infer_units_from_xbrl_query(xbrl: XBRL) -> Optional[str]:
         单位字符串或 `None`。
 
     Raises:
-        RuntimeError: 推断失败时抛出。
+        无。
     """
 
-    try:
-        rows = xbrl.query().by_concept("Revenue").execute()
-    except Exception:
-        return None
-    for row in rows:
-        if not isinstance(row, dict):
+    for concept in _REVENUE_CONCEPT_CANDIDATES:
+        try:
+            rows = xbrl.query().by_concept(concept).execute()
+        except Exception:
             continue
-        unit = row.get("unit") or row.get("unit_ref")
-        if unit:
-            return str(unit).upper()
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            unit = row.get("unit") or row.get("unit_ref")
+            if unit:
+                return str(unit).upper()
     return None
 
 
 def _infer_currency_from_units(units: Optional[str]) -> Optional[str]:
-    """从单位推断货币类型。
+    """从单位字符串中识别 ISO 4217 货币代码。
+
+    在 ``_KNOWN_CURRENCY_CODES`` 范围内做子串匹配，命中即返回标准代码；
+    未命中返回 ``None``，避免把诸如 ``"shares"`` 这类非货币单位误当作货币
+    代码传给下游。
 
     Args:
         units: 单位字符串。
 
     Returns:
-        货币代码或 `None`。
+        ISO 4217 货币代码或 ``None``。
 
     Raises:
-        RuntimeError: 推断失败时抛出。
+        无。
     """
 
     if not units:
         return None
     upper_units = units.upper()
-    if "USD" in upper_units:
-        return "USD"
-    return units
+    for code in _KNOWN_CURRENCY_CODES:
+        if code in upper_units:
+            return code
+    return None
 
 
 def _infer_scale_from_xbrl_query(xbrl: XBRL) -> Optional[str]:
     """从 XBRL Revenue facts 的 decimals 属性推断数值 scale。
 
-    查询思路：取 Revenue 概念的第一条 fact 的 ``decimals`` 字段，
-    按映射表推断 scale（如 ``-6`` → ``millions``）。
+    依次尝试 ``_REVENUE_CONCEPT_CANDIDATES``，取首条命中 fact 的 ``decimals``
+    字段并按映射表推断 scale（如 ``-6`` → ``millions``）。SEC 实务中单 filing
+    内不同报表 scale 一致，因此使用单一概念探测即可。
 
     Args:
         xbrl: XBRL 对象。
@@ -724,37 +755,38 @@ def _infer_scale_from_xbrl_query(xbrl: XBRL) -> Optional[str]:
         scale 描述字符串或 ``None``。
 
     Raises:
-        RuntimeError: 推断失败时抛出。
+        无。
     """
 
-    try:
-        rows = xbrl.query().by_concept("Revenue").execute()
-    except Exception:
-        return None
-    for row in rows:
-        if not isinstance(row, dict):
+    for concept in _REVENUE_CONCEPT_CANDIDATES:
+        try:
+            rows = xbrl.query().by_concept(concept).execute()
+        except Exception:
             continue
-        raw_decimals = row.get("decimals")
-        if raw_decimals is None:
-            continue
-        # 解析 decimals 值
-        if isinstance(raw_decimals, str):
-            stripped = raw_decimals.strip().upper()
-            if stripped == "INF":
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            raw_decimals = row.get("decimals")
+            if raw_decimals is None:
+                continue
+            # 解析 decimals 值
+            if isinstance(raw_decimals, str):
+                stripped = raw_decimals.strip().upper()
+                if stripped == "INF":
+                    return "units"
+                try:
+                    decimals_int = int(stripped)
+                except ValueError:
+                    continue
+            else:
+                try:
+                    decimals_int = int(raw_decimals)
+                except (TypeError, ValueError):
+                    continue
+            # 查映射表
+            exact = _DECIMALS_SCALE_MAP.get(decimals_int)
+            if exact is not None:
+                return exact
+            if decimals_int > 0:
                 return "units"
-            try:
-                decimals_int = int(stripped)
-            except ValueError:
-                continue
-        else:
-            try:
-                decimals_int = int(raw_decimals)
-            except (TypeError, ValueError):
-                continue
-        # 查映射表
-        exact = _DECIMALS_SCALE_MAP.get(decimals_int)
-        if exact is not None:
-            return exact
-        if decimals_int > 0:
-            return "units"
     return None

--- a/dayu/fins/processors/six_k_form_common.py
+++ b/dayu/fins/processors/six_k_form_common.py
@@ -1642,10 +1642,10 @@ def _parse_ocr_numeric_token(token: str) -> Optional[float]:
         token: 原始数值 token。
 
     Returns:
-        浮点数；横线占位返回 `None`。
+        浮点数；横线占位、空 token 或无法解析为浮点时返回 `None`。
 
     Raises:
-        RuntimeError: 转换失败时抛出。
+        无。
     """
 
     normalized_token = str(token or "").strip()
@@ -1653,9 +1653,15 @@ def _parse_ocr_numeric_token(token: str) -> Optional[float]:
         return None
     is_negative = normalized_token.startswith("(") and normalized_token.endswith(")")
     cleaned = normalized_token.strip("()").replace(",", "")
+    # OCR 文本中括号负数可能含货币符号（如 "($1,234)"），剥离括号后货币符号仍残留，
+    # 必须再次清理，否则 ``float`` 会抛 ``ValueError`` 中断整条 OCR 解析链路。
+    cleaned = re.sub(r"[$€£¥₩₹]", "", cleaned).strip()
     if not cleaned:
         return None
-    value = float(cleaned)
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
     return -value if is_negative else value
 
 

--- a/dayu/fins/processors/ten_k_processor.py
+++ b/dayu/fins/processors/ten_k_processor.py
@@ -12,29 +12,8 @@ from typing import Optional
 
 from dayu.engine.processors.source import Source
 
-from .ten_k_form_common import (  # noqa: F401  re-export for backward compat
-    _TEN_K_HEADING_FALLBACK_PATTERNS,
-    _TEN_K_HEADING_FALLBACK_REQUIRED_ITEMS,
-    _TEN_K_HEADING_FALLBACK_SEARCH_PATTERNS,
-    _TEN_K_ITEM_ORDER,
-    _TEN_K_ITEM_PART_MAP,
-    _TEN_K_ITEM_PATTERN,
-    _TEN_K_NUMBERED_HEADING_KEYWORDS,
-    _TEN_K_PART_PATTERN,
-    _MIN_HEADING_SECTION_SPAN,
-    _TOC_PAGE_LINE_PATTERN,
-    _TOC_PAGE_SNIPPET_PATTERN,
-    _TRAILING_TOC_SPAN_RATIO,
-    _build_part_markers,
+from .ten_k_form_common import (
     _build_ten_k_markers,
-    _correct_part_from_sec_rules,
-    _find_first_pattern_position_after,
-    _find_ten_k_heading_fallback_positions,
-    _looks_like_toc_page_line,
-    _repair_ten_k_key_items_with_heading_fallback,
-    _resolve_part_title,
-    _select_ten_k_heading_fallback_markers,
-    _skip_heading_toc_cluster,
     expand_ten_k_virtual_sections_content,
 )
 from .sec_report_form_common import _BaseSecReportFormProcessor

--- a/dayu/fins/processors/ten_q_processor.py
+++ b/dayu/fins/processors/ten_q_processor.py
@@ -14,34 +14,8 @@ from typing import Optional
 
 from dayu.engine.processors.source import Source
 
-from .ten_q_form_common import (  # noqa: F401  re-export for backward compat
-    _TEN_Q_ITEM_PATTERN,
-    _TEN_Q_PART_I_ITEM_ORDER,
-    _TEN_Q_PART_II_ITEM_ORDER,
-    _html_flexible_word,
-    _PART_I_HEADING_PATTERN,
-    _PART_II_HEADING_PATTERN,
-    _ANCHOR_QUALITY_MIN_SPAN,
-    _ANCHOR_QUALITY_MIN_MEANINGFUL_ITEMS,
-    _PART_II_ANCHOR_MAX_TOC_SPREAD,
-    _TOC_PAGE_LINE_PATTERN,
-    _TOC_PAGE_SNIPPET_PATTERN,
-    _TEN_Q_PART_I_HEADING_FALLBACK_PATTERNS,
-    _TEN_Q_PART_I_EXPECTED_KEYWORDS,
-    _TEN_Q_PART_I_TOC_SUMMARY_PATTERN,
-    _TEN_Q_ITEM_1_STRUCTURED_HEADING_PATTERNS,
-    _MIN_PART_I_KEY_ITEM_GAP_CHARS,
+from .ten_q_form_common import (
     _build_ten_q_markers,
-    _find_all_part_heading_positions,
-    _select_best_part_i_anchor,
-    _anchor_produces_meaningful_items,
-    _repair_part_i_key_items_with_heading_fallback,
-    _repair_item_1_with_structured_heading_fallback,
-    _find_item_1_structured_heading_position,
-    _find_first_pattern_position_in_range,
-    _looks_like_part_i_toc_summary,
-    _matches_part_i_expected_heading,
-    _looks_like_toc_page_line,
     expand_ten_q_virtual_sections_content,
 )
 from .sec_report_form_common import _BaseSecReportFormProcessor

--- a/dayu/fins/processors/twenty_f_processor.py
+++ b/dayu/fins/processors/twenty_f_processor.py
@@ -22,25 +22,10 @@ from typing import Optional
 
 from dayu.engine.processors.source import Source
 
-from .twenty_f_form_common import (  # noqa: F401  re-export for backward compat
-    _TWENTY_F_ITEM_ORDER,
-    _TWENTY_F_ITEM_PATTERN,
-    _TWENTY_F_KEY_ITEM_FALLBACK_PATTERNS,
-    _TWENTY_F_ITEM_5_SUBHEADING_PATTERNS,
-    _TWENTY_F_KEY_ITEMS,
-    _TOC_PAGE_LINE_PATTERN,
-    _TOC_PAGE_SNIPPET_PATTERN,
-    _TWENTY_F_ITEM_PART_MAP,
-    _TWENTY_F_ITEM_DESCRIPTIONS,
+from .twenty_f_form_common import (
     _build_twenty_f_markers,
     _select_preferred_twenty_f_text,
     _trim_twenty_f_source_text,
-    _repair_twenty_f_key_items_with_heading_fallback,
-    _repair_twenty_f_item_5_with_subheading_fallback,
-    _find_next_item_position_after_token,
-    _find_twenty_f_key_heading_positions,
-    _looks_like_toc_page_line,
-    _build_item_title,
 )
 from .sec_report_form_common import (
     _BaseSecReportFormProcessor,

--- a/dayu/fins/tools/fins_tools.py
+++ b/dayu/fins/tools/fins_tools.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from dayu.log import Log
 from dayu.contracts.tool_configs import FinsToolLimits
 from dayu.engine.tool_contracts import ToolTruncateSpec
 from dayu.engine.tool_registry import ToolRegistry
 from dayu.engine.tools.base import tool
+from dayu.fins.ingestion.service import FinsIngestionService
 
 from .ingestion_tools import register_ingestion_tools
 from .result_types import (
@@ -105,7 +106,7 @@ def register_fins_read_tools(
 def register_fins_ingestion_tools(
     registry: ToolRegistry,
     *,
-    service_factory: Any,
+    service_factory: Callable[[str], FinsIngestionService],
     manager_key: str,
     timeout_budget: float | None = None,
 ) -> int:

--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -366,8 +366,10 @@ Raw transcript 是一个按时间递增的 turn 列表，通过会话级字段 *
 单总池消费按**从新到老**优先级，对未压缩尾区与 episode summaries 联合裁切：
 
 1. **最近 N 轮 raw turn 强制保留**（`raw_tail[-recent_turns_floor:]`）：不计入 budget，单轮极长走 minimum_preserve 兜底，不丢追问连续性。
-2. **更老 raw turn 按 budget 从新到老回放**：每轮估算 token，能装下就加入并扣减 budget，装不下就 break（更早历史已被 compaction 压成 episode 摘要）。
-3. **Episode summaries 用剩余 budget 从新到老填充**：装不下就 break。
+2. **Episode summaries 按 budget 从新到老填充**：每条估算 token，能装下就加入并扣减 budget，装不下就 break。
+3. **更老 raw turn 用剩余 budget 从新到老回放**：每轮估算 token，能装下就加入并扣减剩余 budget，装不下就 break（更早历史已被 compaction 压成 episode 摘要）。
+
+> 顺序设计意图：episode summaries 是"老 turn 的结构化摘要"，单位 token 信息密度显著高于 raw turn 长尾；先把预算分给 episodes 能在压缩后稳定保住历史覆盖，再用剩余预算尽可能回放原文细节。
 
 **最近一轮整轮超预算时的降级顺序**（稳定契约，保证"最新用户意图永远不丢"）：
 

--- a/dayu/host/cancellation_bridge.py
+++ b/dayu/host/cancellation_bridge.py
@@ -8,11 +8,18 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING
 
-from dayu.contracts.run import TERMINAL_STATES, RunState
+from dayu.contracts.run import TERMINAL_STATES
 from dayu.contracts.cancellation import CancellationToken
+from dayu.log import Log
 
 if TYPE_CHECKING:
     from dayu.host.protocols import RunRegistryProtocol
+
+
+_MODULE = "HOST.CANCELLATION_BRIDGE"
+
+# 连续轮询失败次数达到该阈值后停止轮询，避免在持续性异常下空转消耗资源。
+_MAX_CONSECUTIVE_POLL_FAILURES = 10
 
 
 class CancellationBridge:
@@ -79,6 +86,7 @@ class CancellationBridge:
     def _poll_loop(self) -> None:
         """后台轮询循环。"""
 
+        consecutive_failures = 0
         while not self._stop_event.is_set():
             try:
                 run = self._run_registry.get_run(self._run_id)
@@ -91,9 +99,26 @@ class CancellationBridge:
                 if run.state in TERMINAL_STATES:
                     # run 已完成（SUCCEEDED/FAILED），无需继续轮询
                     break
-            except Exception:  # noqa: BLE001
-                # 查询失败不中断轮询，下次重试
-                pass
+                consecutive_failures = 0
+            except Exception as exc:  # noqa: BLE001
+                # 查询失败不立即中断轮询，但累计失败次数；持续失败到阈值后退出，
+                # 避免在系统性异常下空转消耗资源。
+                consecutive_failures += 1
+                Log.warn(
+                    "CancellationBridge 轮询失败: "
+                    f"run_id={self._run_id}, "
+                    f"consecutive_failures={consecutive_failures}, "
+                    f"error={exc}",
+                    module=_MODULE,
+                )
+                if consecutive_failures >= _MAX_CONSECUTIVE_POLL_FAILURES:
+                    Log.error(
+                        "CancellationBridge 连续轮询失败已达阈值，停止轮询: "
+                        f"run_id={self._run_id}, "
+                        f"max_consecutive_failures={_MAX_CONSECUTIVE_POLL_FAILURES}",
+                        module=_MODULE,
+                    )
+                    break
             self._stop_event.wait(timeout=self._poll_interval)
 
 

--- a/dayu/host/conversation_memory.py
+++ b/dayu/host/conversation_memory.py
@@ -436,7 +436,18 @@ def _build_minimum_preserved_turn_view(
 
 @dataclass(frozen=True)
 class ConversationPinnedStatePatch:
-    """pinned state 的增量 patch。"""
+    """pinned state 的增量 patch。
+
+    每个字段三态语义（稳定契约）：
+
+    - ``None``：本次不修改该字段，保留 ``base`` 中的旧值。
+    - 空值（``""`` 或 ``()``）：显式清空该字段。
+    - 非空值：覆盖该字段为新值。
+
+    `_parse_result` 通过 ``key in patch_dict`` 区分"LLM 未输出该字段"
+    （映射为 ``None``）与"LLM 显式输出空值"（映射为 ``""`` / ``()``）。
+    LLM 提示词需保证：仅在确实要清空时输出空值，否则省略键。
+    """
 
     current_goal: str | None = None
     confirmed_subjects: tuple[str, ...] | None = None
@@ -445,6 +456,9 @@ class ConversationPinnedStatePatch:
 
     def apply_to(self, base: ConversationPinnedState) -> ConversationPinnedState:
         """将 patch 应用到现有 pinned state。
+
+        按字段三态语义（见类 docstring）逐项合并：``None`` 保留旧值，
+        其它值（含空字符串、空 tuple）一律覆盖。
 
         Args:
             base: 旧状态。
@@ -910,6 +924,11 @@ class DefaultEpisodicMemoryCompressor:
         turns: tuple[ConversationTurnRecord, ...],
     ) -> ConversationCompactionResult | None:
         """解析压缩 scene 返回的 JSON。
+
+        ``pinned_state_patch`` 各字段按 ``ConversationPinnedStatePatch`` 三态契约解析：
+        通过 ``"key" in patch_dict`` 区分"LLM 未输出该字段"（映射为 ``None``，
+        语义=不动）与"LLM 显式输出空值"（映射为 ``""`` 或 ``()``，语义=清空）。
+        非空值原样转换后覆盖。
 
         Args:
             final_answer: 模型最终回答文本。

--- a/dayu/host/executor.py
+++ b/dayu/host/executor.py
@@ -56,6 +56,7 @@ TStreamEvent = TypeVar("TStreamEvent", bound=PublishedRunEventProtocol)
 TSyncResult = TypeVar("TSyncResult")
 MODULE = "HOST.EXECUTOR"
 _DEFAULT_CONCURRENCY_ACQUIRE_TIMEOUT_SECONDS = 300.0
+_MAX_TOOL_RESULT_SUMMARY_CHARS = 2000
 _CONCURRENCY_POLICY_MODE_HOST_DEFAULT: Literal["host_default"] = "host_default"
 _CONCURRENCY_POLICY_MODE_TIMEOUT: Literal["timeout"] = "timeout"
 _CONCURRENCY_POLICY_MODE_UNBOUNDED: Literal["unbounded"] = "unbounded"
@@ -1316,15 +1317,17 @@ class DefaultHostExecutor(HostExecutorProtocol):
         """
 
         token = CancellationToken()
+        if self.run_registry.is_cancel_requested(run_id):
+            token.cancel()
+            self._finalize_cancelled(run_id)
+            raise CancelledError("run 已在启动前收到取消请求")
         bridge = CancellationBridge(self.run_registry, run_id, token)
-        bridge.start()
         deadline_watcher = RunDeadlineWatcher(
             self.run_registry,
             run_id,
             token,
             spec.timeout_ms,
         )
-        deadline_watcher.start()
         # bridge / deadline_watcher 已经启动后台线程或 Timer，若后续步骤抛
         # 异常而调用方拿不到句柄，将造成守护线程持续轮询 SQLite 与 Timer
         # 持续到进程退出。这里在剩余初始化阶段统一兜底，确保异常时立刻
@@ -1337,6 +1340,8 @@ class DefaultHostExecutor(HostExecutorProtocol):
         try:
             self.run_registry.start_run(run_id)
             run_started = True
+            bridge.start()
+            deadline_watcher.start()
             permits: list[ConcurrencyPermit] = []
             if self.concurrency_governor is not None:
                 lanes = _required_lanes_for_spec(spec, include_agent_lane=include_agent_lane)
@@ -1993,10 +1998,10 @@ def _summarize_tool_result(result: Any) -> str:
 
     projected = project_for_llm(result)
     serialized = json.dumps(projected, ensure_ascii=False, sort_keys=True)
-    if len(serialized) <= 2000:
+    if len(serialized) <= _MAX_TOOL_RESULT_SUMMARY_CHARS:
         return serialized
-    suffix = f"...<truncated {len(serialized) - 2000} chars>"
-    keep = max(0, 2000 - len(suffix))
+    suffix = f"...<truncated {len(serialized) - _MAX_TOOL_RESULT_SUMMARY_CHARS} chars>"
+    keep = max(0, _MAX_TOOL_RESULT_SUMMARY_CHARS - len(suffix))
     return serialized[:keep] + suffix
 
 

--- a/dayu/host/pending_turn_store.py
+++ b/dayu/host/pending_turn_store.py
@@ -421,6 +421,13 @@ class InMemoryPendingConversationTurnStore:
             return None
         if existing.state is not PendingConversationTurnState.RESUMING:
             return existing
+        if existing.pre_resume_state is None:
+            Log.warn(
+                "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                f"pending_turn_id={existing.pending_turn_id}, "
+                f"session_id={existing.session_id}",
+                module=MODULE,
+            )
         restored_state = existing.pre_resume_state or PendingConversationTurnState.ACCEPTED_BY_HOST
         updated = PendingConversationTurn(
             pending_turn_id=existing.pending_turn_id,
@@ -521,6 +528,13 @@ class InMemoryPendingConversationTurnStore:
         )
         # 失败路径一并回退 RESUMING lease；非 RESUMING 则仅写错误消息。
         if existing.state is PendingConversationTurnState.RESUMING:
+            if existing.pre_resume_state is None:
+                Log.warn(
+                    "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                    f"pending_turn_id={existing.pending_turn_id}, "
+                    f"session_id={existing.session_id}",
+                    module=MODULE,
+                )
             restored_state = existing.pre_resume_state or PendingConversationTurnState.ACCEPTED_BY_HOST
             new_pre_resume_state: PendingConversationTurnState | None = None
         else:
@@ -978,6 +992,13 @@ class SQLitePendingConversationTurnStore:
                 early_row = row
             else:
                 pre_resume_state_raw = row["pre_resume_state"] if "pre_resume_state" in row.keys() else None
+                if not pre_resume_state_raw:
+                    Log.warn(
+                        "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                        f"pending_turn_id={normalized_pending_turn_id}, "
+                        f"session_id={str(row['session_id'])}",
+                        module=MODULE,
+                    )
                 restored_state_value = (
                     str(pre_resume_state_raw)
                     if pre_resume_state_raw
@@ -1123,6 +1144,13 @@ class SQLitePendingConversationTurnStore:
                 current_state = str(row["state"])
                 if current_state == PendingConversationTurnState.RESUMING.value:
                     pre_resume_state_raw = row["pre_resume_state"] if "pre_resume_state" in row.keys() else None
+                    if not pre_resume_state_raw:
+                        Log.warn(
+                            "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                            f"pending_turn_id={normalized_pending_turn_id}, "
+                            f"session_id={str(row['session_id'])}",
+                            module=MODULE,
+                        )
                     restored_state_value = (
                         str(pre_resume_state_raw)
                         if pre_resume_state_raw

--- a/dayu/services/chat_service.py
+++ b/dayu/services/chat_service.py
@@ -12,6 +12,7 @@ from dayu.contracts.events import AppEvent
 from dayu.contracts.session import SessionSource
 from dayu.host.protocols import ConversationalExecutionGatewayProtocol, PendingTurnSummary
 from dayu.contracts.execution_metadata import normalize_execution_delivery_context
+from dayu.prompting.scene_definition import PromptManifestError
 from dayu.services.concurrency_lanes import resolve_contract_concurrency_lane
 from dayu.services.contract_preparation import prepare_execution_contract
 from dayu.services.contracts import (
@@ -211,6 +212,8 @@ class ChatService(ChatServiceProtocol):
             accepted_scene = self.scene_execution_acceptance_preparer.prepare(scene_name, request.execution_options)
         except FileNotFoundError as exc:
             raise ValueError(f"scene 不存在: {scene_name}") from exc
+        except PromptManifestError as exc:
+            raise ValueError(f"scene manifest 配置损坏: scene={scene_name}, 详情={exc}") from exc
         return _PreparedChatTurnContext(
             scene_name=scene_name,
             user_message=user_message,

--- a/dayu/services/internal/write_pipeline/artifact_store.py
+++ b/dayu/services/internal/write_pipeline/artifact_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import tempfile
 from contextlib import contextmanager
 from dataclasses import asdict
@@ -374,6 +375,25 @@ class ArtifactStore:
 
         self._persist_chapter_artifacts(result)
 
+    def purge_chapter_artifacts(self, task: ChapterTask) -> None:
+        """清除指定章节的全部历史产物（最终正文 + 阶段产物 + 章节子目录）。
+
+        触发时机：
+        - 单章重写（``cli write --chapter``）显式重跑某章前，先把旧产物删除，
+          避免后续 fallback 路径读到陈旧的最终正文或中间稿。
+
+        Args:
+            task: 待清理章节任务。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        self._purge_chapter_artifacts(task)
+
     def load_latest_failed_chapter_content(self, task: ChapterTask) -> str:
         """公开加载章节失败时的最新中间稿。"""
 
@@ -620,6 +640,7 @@ class ArtifactStore:
             if current.signature == signature:
                 return current
             Log.warn("检测到 manifest 签名变更，将重新开始从头写作", module=MODULE)
+            self._purge_stale_run_artifacts()
 
         return RunManifest(
             version="write_manifest_v1",
@@ -628,6 +649,84 @@ class ArtifactStore:
             chapter_results={},
             company_facets=None,
         )
+
+    def _purge_stale_run_artifacts(self) -> None:
+        """清空 chapters/ 目录下的全部历史产物以及 sources_dedup.json。
+
+        当 manifest 签名变更时，旧的章节正文/中间稿/sources 落盘文件不再与
+        新的运行匹配，必须主动清理；否则单章 fallback 与决策章节恢复路径
+        会读到陈旧文件，污染本次报告。
+
+        清理失败被降级为 warning 日志，不阻塞主流程：清理是恢复保证，
+        即便残留也由后续覆盖写入或人工介入处置。
+
+        Args:
+            无。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        try:
+            if self._chapters_dir.exists():
+                for entry in self._chapters_dir.iterdir():
+                    if entry.is_dir():
+                        shutil.rmtree(entry)
+                    else:
+                        entry.unlink(missing_ok=True)
+                Log.info(
+                    f"已清理 chapters 目录下陈旧产物: {self._chapters_dir}",
+                    module=MODULE,
+                )
+        except OSError as exc:
+            Log.warning(
+                f"清理 chapters 目录失败，可能残留陈旧文件: dir={self._chapters_dir} error={exc}",
+                module=MODULE,
+            )
+        sources_path = self._output_dir / "sources_dedup.json"
+        try:
+            if sources_path.exists():
+                sources_path.unlink()
+                Log.info(f"已清理陈旧 sources_dedup.json: {sources_path}", module=MODULE)
+        except OSError as exc:
+            Log.warning(
+                f"清理 sources_dedup.json 失败: path={sources_path} error={exc}",
+                module=MODULE,
+            )
+
+    def _purge_chapter_artifacts(self, task: ChapterTask) -> None:
+        """清除指定章节的最终正文与阶段产物子目录。
+
+        Args:
+            task: 待清理章节任务。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        chapter_path = self._chapter_file_path(task.index, task.title)
+        try:
+            chapter_path.unlink(missing_ok=True)
+        except OSError as exc:
+            Log.warning(
+                f"清理章节最终正文失败: path={chapter_path} error={exc}",
+                module=MODULE,
+            )
+        chapter_dir = chapter_path.parent / chapter_path.stem
+        if chapter_dir.exists():
+            try:
+                shutil.rmtree(chapter_dir)
+            except OSError as exc:
+                Log.warning(
+                    f"清理章节阶段产物目录失败: dir={chapter_dir} error={exc}",
+                    module=MODULE,
+                )
 
     def _persist_manifest(self, *, manifest: RunManifest, chapter_results: dict[str, ChapterResult]) -> None:
         """持久化运行清单。

--- a/dayu/services/internal/write_pipeline/pipeline.py
+++ b/dayu/services/internal/write_pipeline/pipeline.py
@@ -479,7 +479,7 @@ class WritePipelineRunner:
             # 单章模式且目标既不是第0章概览章也不是决策章，跳过 decision + overview + 来源清单 + 报告组装
             single_result = chapter_results.get(chapter_filter)
             Log.info(f"[单章模式] 完成：{chapter_filter}", module=MODULE)
-            return 0 if self._did_chapter_succeed_in_current_mode(single_result) else 4
+            return 0 if self._satisfies_audit_gate_for_current_mode(single_result) else 4
 
         decision_result: ChapterResult | None = None
         decision_chapter = chapters_by_title.get(_DECISION_CHAPTER_TITLE)
@@ -560,7 +560,7 @@ class WritePipelineRunner:
 
         if chapter_filter == _DECISION_CHAPTER_TITLE:
             Log.info(f"[单章模式] 完成：{_DECISION_CHAPTER_TITLE}", module=MODULE)
-            return 0 if self._did_chapter_succeed_in_current_mode(decision_result) else 4
+            return 0 if self._satisfies_audit_gate_for_current_mode(decision_result) else 4
 
         overview_task = ChapterTask(
             index=chapters_by_title[_OVERVIEW_CHAPTER_TITLE].index,
@@ -643,7 +643,7 @@ class WritePipelineRunner:
         if chapter_filter == _OVERVIEW_CHAPTER_TITLE:
             # 单章模式且目标为第0章概览章，跳过来源清单和报告组装
             Log.info(f"[单章模式] 完成：{_OVERVIEW_CHAPTER_TITLE}", module=MODULE)
-            return 0 if self._did_chapter_succeed_in_current_mode(overview_result) else 4
+            return 0 if self._satisfies_audit_gate_for_current_mode(overview_result) else 4
 
         source_chapter_markdown: str | None = None
         if has_source_chapter:
@@ -669,7 +669,7 @@ class WritePipelineRunner:
         summary_payload = self._execution_summary_builder.build_summary(
             chapter_results,
             output_file=output_file,
-            success_predicate=self._did_chapter_succeed_in_current_mode,
+            success_predicate=self._satisfies_audit_gate_for_current_mode,
         )
         (self._output_dir / "run_summary.json").write_text(
             json.dumps(summary_payload, ensure_ascii=False, indent=2),
@@ -1038,21 +1038,6 @@ class WritePipelineRunner:
             return True
         return bool(result.audit_passed)
 
-    def _did_chapter_succeed_in_current_mode(self, result: ChapterResult | None) -> bool:
-        """判断章节在当前运行模式下是否算成功。
-
-        Args:
-            result: 待检查章节结果。
-
-        Returns:
-            当前模式下成功返回 ``True``。
-
-        Raises:
-            无。
-        """
-
-        return self._satisfies_audit_gate_for_current_mode(result)
-
     def _recover_prior_chapter_result_from_artifacts(
         self, task: ChapterTask
     ) -> tuple[ChapterResult | None, str]:
@@ -1122,7 +1107,11 @@ class WritePipelineRunner:
                 return self._write_config.ticker
             resolved_name = str(self._company_name_resolver(self._write_config.ticker) or "").strip()
             return resolved_name or self._write_config.ticker
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            Log.warning(
+                f"company_name 解析失败，回退 ticker: ticker={self._write_config.ticker} error={exc}",
+                module=MODULE,
+            )
             return self._write_config.ticker
 
     def _resolve_company_meta_summary(self) -> dict[str, str]:
@@ -1151,7 +1140,11 @@ class WritePipelineRunner:
             }
             normalized.setdefault("ticker", self._write_config.ticker)
             return normalized
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            Log.warning(
+                f"company_meta_summary 解析失败，回退最小 meta: ticker={self._write_config.ticker} error={exc}",
+                module=MODULE,
+            )
             return {"ticker": self._write_config.ticker}
 
     def _ensure_company_facets(self, *, manifest: RunManifest, company_name: str) -> CompanyFacetProfile | None:
@@ -1237,7 +1230,7 @@ class WritePipelineRunner:
         if existing_result is None:
             return False
         # resume 只跳过在“当前运行门槛”下已完成的章节。
-        return self._did_chapter_succeed_in_current_mode(existing_result)
+        return self._satisfies_audit_gate_for_current_mode(existing_result)
 
     def _merge_historical_chapter_results_for_single_chapter(
         self, chapter_results: dict[str, ChapterResult]

--- a/dayu/services/internal/write_pipeline/pipeline.py
+++ b/dayu/services/internal/write_pipeline/pipeline.py
@@ -439,6 +439,10 @@ class WritePipelineRunner:
                 existing_result = chapter_results.get(task.title)
                 if self._should_skip_with_resume(existing_result):
                     Log.info(f"[单章模式] 显式指定章节，强制重跑: {task.title}", module=MODULE)
+                # 单章重跑必须先清空旧产物，否则后续 fallback 路径
+                # 会读到陈旧的最终正文/中间稿，污染本次重写结果。
+                self._store.purge_chapter_artifacts(task)
+                chapter_results.pop(task.title, None)
                 try:
                     result = self._run_single_chapter(
                         task=task,
@@ -529,6 +533,9 @@ class WritePipelineRunner:
                         Log.info(f"跳过已完成章节: {_DECISION_CHAPTER_TITLE}", module=MODULE)
                         decision_result = existing_decision
                 if decision_result is None:
+                    # 统一原则：章节即将重写时清空旧阶段产物，避免读到陈旧最终正文/中间稿。
+                    self._store.purge_chapter_artifacts(decision_task)
+                    chapter_results.pop(_DECISION_CHAPTER_TITLE, None)
                     self._check_cancellation()
                     try:
                         decision_result = self._run_single_chapter(
@@ -573,10 +580,17 @@ class WritePipelineRunner:
             item_rules=chapters_by_title[_OVERVIEW_CHAPTER_TITLE].item_rules,
         )
         existing_overview = chapter_results.get(_OVERVIEW_CHAPTER_TITLE)
+        if chapter_filter == _OVERVIEW_CHAPTER_TITLE:
+            if self._should_skip_with_resume(existing_overview):
+                Log.info(f"[单章模式] 显式指定章节，强制重跑: {_OVERVIEW_CHAPTER_TITLE}", module=MODULE)
+            existing_overview = None
         if self._should_skip_with_resume(existing_overview):
             Log.info(f"跳过已完成章节: {_OVERVIEW_CHAPTER_TITLE}", module=MODULE)
             overview_result = existing_overview
         else:
+            # 统一原则：章节即将重写时清空旧阶段产物，避免读到陈旧最终正文/中间稿。
+            self._store.purge_chapter_artifacts(overview_task)
+            chapter_results.pop(_OVERVIEW_CHAPTER_TITLE, None)
             overview_dependency_tasks = _build_overview_dependency_tasks(layout)
             if chapter_filter == _OVERVIEW_CHAPTER_TITLE and not self._write_config.force:
                 resolved_overview_results, precheck_errors = self._resolve_overview_single_chapter_prerequisites(
@@ -734,6 +748,9 @@ class WritePipelineRunner:
             if self._should_skip_with_resume(existing_result):
                 Log.info(f"跳过已完成章节: {task.title}", module=MODULE)
                 continue
+            # 统一原则：章节即将重写时清空旧阶段产物，避免读到陈旧最终正文/中间稿。
+            self._store.purge_chapter_artifacts(task)
+            chapter_results.pop(task.title, None)
             pending_tasks.append(task)
         if not pending_tasks:
             return chapter_results

--- a/dayu/services/internal/write_pipeline/report_assembler.py
+++ b/dayu/services/internal/write_pipeline/report_assembler.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from dayu.log import Log
 from dayu.services.internal.write_pipeline.audit_formatting import _strip_evidence_section
 from dayu.services.contracts import WriteRunConfig
 from dayu.services.internal.write_pipeline.models import ChapterResult
@@ -13,6 +14,7 @@ from dayu.services.internal.write_pipeline.template_parser import TemplateLayout
 
 _OVERVIEW_CHAPTER_TITLE = "投资要点概览"
 _SOURCE_CHAPTER_TITLE = "来源清单"
+MODULE = "APP.WRITE_PIPELINE.ASSEMBLER"
 
 
 class ReportAssembler:
@@ -75,6 +77,16 @@ class ReportAssembler:
                 continue
             result = chapter_results.get(chapter.title)
             if result is None or not result.content:
+                if result is None:
+                    Log.warning(
+                        f"章节缺失结果，回退 skeleton: title={chapter.title}",
+                        module=MODULE,
+                    )
+                else:
+                    Log.warning(
+                        f"章节正文为空，回退 skeleton: title={chapter.title} status={result.status}",
+                        module=MODULE,
+                    )
                 ordered_chapters.append(chapter.skeleton)
             elif chapter.title == _OVERVIEW_CHAPTER_TITLE:
                 ordered_chapters.append(_strip_evidence_section(result.content))

--- a/dayu/wechat/ilink_client.py
+++ b/dayu/wechat/ilink_client.py
@@ -22,11 +22,15 @@ from typing import Any, Mapping
 
 import httpx
 
+from dayu.log import Log
+
 DEFAULT_ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 DEFAULT_BOT_TYPE = 3
 DEFAULT_CHANNEL_VERSION = "1.0.2"
 TYPING_STATUS_TYPING = 1
 TYPING_STATUS_CANCEL = 2
+
+MODULE = "WECHAT.ILINK_CLIENT"
 
 
 def build_x_wechat_uin_header() -> str:
@@ -521,6 +525,14 @@ class IlinkApiClient:
             )
         except httpx.TimeoutException:
             if timeout_fallback is not None:
+                # 长轮询的"读超时"是预期路径（服务端无新消息时主动断开），
+                # 但短请求超时可能是异常事件。这里用 debug 级日志记录，
+                # 既能在排查时看到 fallback 命中，也不污染正常运行的日志流。
+                Log.debug(
+                    f"iLink 请求超时命中 fallback: method={method} path={path} "
+                    f"read_timeout_sec={read_timeout_sec}",
+                    module=MODULE,
+                )
                 return dict(timeout_fallback)
             raise
         except httpx.HTTPError as exc:

--- a/dayu/wechat/state_store.py
+++ b/dayu/wechat/state_store.py
@@ -146,13 +146,23 @@ def _write_text_atomic(target: Path, content: str) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, temp_path_str = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
     temp_path = Path(temp_path_str)
+    fd_owned = True
     try:
+        # 把 fd 交给 fdopen 包装；一旦 with 接管，fd 由文件对象在 close 时关闭。
         with os.fdopen(file_descriptor, "w", encoding="utf-8") as temp_file:
+            fd_owned = False
             temp_file.write(content)
             temp_file.flush()
             os.fsync(temp_file.fileno())
         os.replace(temp_path, target)
     except Exception:
+        # fdopen 自身抛出（如内部参数校验失败）时，fd 不会被 with 接管，必须显式关闭，
+        # 否则会泄漏底层文件描述符；正常路径下 fd_owned 在 with 进入后即被置 False。
+        if fd_owned:
+            try:
+                os.close(file_descriptor)
+            except OSError:
+                pass
         if temp_path.exists():
             temp_path.unlink(missing_ok=True)
         raise

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -11,7 +11,7 @@
 - 写入 workspace/code-review-mmdd-HHMM.md （月份日期-小时分钟）。
 - 每发现一项编号后写入一项。输出格式：
 ```text
-### 编号-未修复-[修复风险（低/中/高）]-finding简述
+### 编号-未修复-[严重程度（低/中/高/严重）]-finding简述
 - **入口/函数**: 问题发生在什么执行入口或什么函数
 - **文件(行号)**: 具体位置
 - **输入场景**: 什么输入会触发问题
@@ -21,9 +21,10 @@
 - **直接证据**: 具体判断条件、参数传递路径、返回值或状态更新位置（行号）
 - **影响**: 错误 answer / 错误状态 / 静默失效 / 不可恢复 / 仅局部行为错误
 - **建议改法和验证点**
+- **修复风险（低/中/高**
 - **严重程度（低/中/高/严重）**
 ```
-- review结束给出按严重程度排序等完整列表。
+- review结束给出按修复风险排序等完整列表。
 
 ## 审查要求（极其严格）
 
@@ -428,19 +429,168 @@
   - 若发现执行问题，优先沿 `UI -> Service -> Contract preparation -> Host -> scene preparation -> Agent` 检查责任归属。
   - 只有在证据直接显示 Agent 本身错误时，才把 root cause 定位到 Agent；禁止因为现象出现在 Agent 输出上，就跳过 Host / Service 直接归因给模型或 prompt。
 
-### 6. 金融逻辑分层
+### 6. 多轮会话记忆子系统
+
+本节专门审查 `dayu/host/conversation_*.py` 实现的两层记忆模型（`pinned_state` 独立 + 单总池）、compaction 调度与跨档自适应。设计意图与不变量见 `docs/conversation_memory_optimization.md`、`dayu/host/README.md §10`。
+
+#### 6.1 两层结构边界是否清晰
+
+- **pinned_state 是否独立路径渲染、不计入 token budget**：检查 `_render_pinned_state_block` 输出是否在 `[Conversation Memory]` 系统块开头独立渲染；检查 `_resolve_memory_total_budget` / `build_messages` 链路上是否有任何分支错误地把 `pinned_state` 体积加进单总池消费。
+- **单总池消费顺序是否符合契约**（`forced raw → 老 raw → episode summaries`）：
+  - 强制保留段：`raw_tail[-recent_turns_floor:]` **不计入 budget**；
+  - 更老 raw turn：按 `extra_pool` 从新到老回放，装不下即 break；
+  - episode summaries：用剩余 `extra_pool` 从新到老填充，装不下即 break。
+- **Raw Transcript 是否物理保留**：检查 compaction 写回路径是否仅推进 `compacted_turn_count` 而**不删除** `transcript.turns` 内容；审计/回放是否仍可拿到全量原文。
+- 判定标准：若任一路径让 `pinned_state` 进入 budget 竞争、改变三段消费顺序、或物理删除 raw turn → 报告。
+
+#### 6.2 预算与触发公式是否与渲染口径一致
+
+- **预算公式**：`budget = clamp(max_context_tokens * memory_token_budget_ratio, memory_token_budget_floor, memory_token_budget_cap)`。检查 `_resolve_memory_total_budget` 的实现：
+  - 是否使用了真实的 `prepared_scene` 解析后的 `max_context_tokens`，而非 hardcoded 默认值；
+  - clamp 顺序是否为 `max(floor, min(cap, window*ratio))`；
+  - 当 `max_context_tokens <= 0` / 缺失时是否有明确兜底。
+- **触发公式**：`window_used = system_prompt + pinned + actual_episodic_in_prompt + uncompressed_raw_turns + user_text`。检查 `_select_compaction_candidate`：
+  - `actual_episodic_in_prompt` 是否**复用 `_build_memory_block` 的真实裁切结果**，而不是"求和所有 episodes"或"完全排除 episodes"两种废弃口径；
+  - 触发器与渲染器是否使用**同一份 budget**（不能各自 clamp 一次造成漂移）。
+- 判定标准：触发公式与 prompt 实际渲染口径出现任一项不一致（episode 算法、user_text 是否计入、pinned 是否计入、budget 数值不同）→ 报告。
+
+#### 6.3 双路径语义分离（`prepare_transcript` vs `schedule_compaction`）
+
+两条 compaction 触发入口语义必须严格分离：
+
+| 路径 | 时机 | `user_text` 形参 | 原因 |
+|---|---|---|---|
+| `prepare_transcript` | persist 之前（pre-persist） | **必须显式传入** | 当前轮用户消息尚未写入 transcript，需进入 `window_used` 估算 |
+| `schedule_compaction` | persist 之后（post-persist） | **不接收** | 用户消息已落入 `transcript.turns` 末位，再传会与 `uncompressed_raw_turns` 双计 |
+
+- 检查所有调用点（`scene_preparer.py::ConversationSessionState.persist_turn` / `prepare_transcript`）是否严格遵守上表；
+- 检查 `_select_compaction_candidate` 内部是否会把 `user_text_tokens` 重复加入 `window_used`（应仅在 `prepare_transcript` 链路上传入，且 `schedule_compaction` 链路必须传 0）；
+- 检查 `ConversationMemoryManagerProtocol` 接口定义是否在签名层面强制分离（`schedule_compaction` 不应有 `user_text` 形参，仅靠注释或运行时检查不够）。
+- 判定标准：任一调用点把 `user_text` 在 post-persist 路径再传一次、或接口允许 `schedule_compaction` 接 `user_text` → 报告。
+
+#### 6.4 单轮溢出阈值与 forced 轮数派生
+
+- **阈值公式**：`max_context_tokens / max(2, actual_forced_count + 1)`。检查 `_render_forced_turns`：
+  - 除数是否取**当前实际 forced 轮数 `actual_forced_count`**，而**不是** `settings.recent_turns_floor` 配置值；
+  - 当 `max_context_tokens <= 0` 时是否回落到 `settings.memory_token_budget_cap` 作为最后兜底；
+  - 阈值不应**直接等于** `memory_token_budget_cap`（与窗口解耦的反模式）。
+- **溢出降级顺序契约**（`_build_minimum_preserved_turn_view`，稳定不可颠倒）：
+  1. 保留 `user_text`（最新用户意图永不丢）；
+  2. 保留完整 `assistant_final`；
+  3. 丢弃 tool 调用/结果摘要；
+  4. 仍超预算 → 对 `assistant_final` 做末尾截断 + 显式 `...<truncated>` 标记。
+- 判定标准：若除数取配置 floor 而非实际轮数（导致新会话 1-2 轮时阈值被错误压低）、或降级顺序颠倒（先截最终回复后丢工具）→ 报告。
+
+#### 6.5 `recent_turns_floor` 语义是否为下限保底
+
+- 关键反转：`recent_turns_floor` 是**下限保底**（"至少保 N 轮"），不是上限封顶（"最多放 N 轮"）。
+- 检查 `select_turns` 是否存在任何分支把 `recent_turns_floor` 当上限使用（如 `min(recent_turns_floor, ...)`、轮数硬截断）；
+- 检查"老 raw turn 按 budget 回放"循环是否有错误的轮数上限阻断；budget 充足时应自然回放 15+ 轮、不被任何 floor 截断；
+- 检查 forced 段在 `budget=0`、`cap=0`、配置全错时仍能保最近 N 轮（反退化路径）。
+- 判定标准：若任一代码路径让 `recent_turns_floor` 表现为上限语义 → 报告。
+
+#### 6.6 pinned_state 演进与 compaction LLM 输出处理
+
+- **`ConversationPinnedStatePatch.apply_to` 字段级合并语义**：检查 patch 字段为 `None` 是否**仅表示"本次不动"**，而**非"清空"**（否则 LLM 漏输出某字段会导致旧值丢失）；空字符串/空数组与 `None` 的语义区分是否一致。
+- **`confirmed_facts` 是否永远完整保留**：检查 `_render_episode_summary` 与单总池裁切链路，episode summary 内的 `confirmed_facts` 字段不应参与 token 截断（财报反幻觉核心依赖）。
+- **compaction LLM 输出解析**：检查 `_parse_result` 对非法/缺字段/JSON 错误的输出是否**安全降级**（丢弃本次 patch、不污染 pinned_state），而不是把空值或异常态写回；
+- **`compacted_turn_count` 单调推进**：检查 compaction 写回是否**仅在 LLM 成功输出且乐观锁通过时**才推进；失败/取消/冲突路径下 `compacted_turn_count` 不应被推进。
+- 判定标准：patch 合并把缺省字段当清空、`confirmed_facts` 被裁切、LLM 异常输出污染 pinned_state、或 `compacted_turn_count` 在失败路径被推进 → 报告。
+
+#### 6.7 同步/异步 compaction 调度与乐观锁
+
+- **同步 compaction**（`prepare_transcript`）：本轮开始前，越过阈值则同步执行——确保本轮立即可跑。
+- **后台 compaction**（`schedule_compaction`）：本轮结束后异步调度——不阻塞用户感知。
+- **乐观锁写回**：以会话级 `revision` 为锁，写回前比对——若不一致**直接丢弃本次摘要结果，不覆盖**（"保持一致" > "后来者胜"）。
+- 检查项：
+  - 是否存在同时多个 `ConversationCompactionCoordinator` 实例对同一 session 写回不走乐观锁的路径；
+  - 后台 compaction task 取消/Host 重启时是否有半提交残留（部分写入 `episodes`、未推 `compacted_turn_count`）；
+  - 同步与后台路径是否共享同一套 `_select_compaction_candidate` / `_build_user_payload` 实现，避免双份代码漂移；
+  - compaction scene 调用失败/超时时是否会反复触发自身（无界自调度）。
+- 判定标准：乐观锁缺失/绕过、半提交、双份调度逻辑漂移、或失败后无界重试 → 报告。
+
+#### 6.8 跨档自适应（default 一份打天下）
+
+- **不分档配置原则**：`dayu/config/run.json` 的 `conversation_memory.default` 通过 `clamp(window * ratio, floor, cap)` 自动伸缩，**不应**为 1M / 256K / 128K / 32K 档分别写覆盖。
+- 检查项：
+  - `dayu/config/llm_models.json` 各 model entry 是否仍残留 `runtime_hints.conversation_memory` 块（设计已要求全删 19 处）；
+  - `dayu/cli/commands/init.py` 是否仍残留 `_build_conversation_memory_overrides` 函数或调用点（设计已要求删除整个函数）；
+  - 各档实际 budget 是否符合预期（1M=60K cap 截断 / 256K=25.6K 区间 / 128K=12.8K 区间 / 32K=4K floor 兜底）；
+  - 三处默认值（`run.json` / `ConversationMemorySettings` dataclass / `options.py` 校验）是否一致——若漂移，下次 plan 落地的字段语义会被静默错读。
+- **128K 档 headroom 风险**：检查文档/代码中是否提示——128K 档 compaction 阈值 89.6K 扣除单总池后留给"工具结果 + 财报材料"的有效空间约 38K，单轮材料过大会触发 compaction 抖动；调参方向应先调 `cap` / `compaction_trigger_context_ratio` 而非引入档位特化覆盖。
+- 判定标准：runtime_hints 残留、init 写覆盖残留、三处默认值漂移、或对 128K 档行为缺少有效说明 → 报告。
+
+#### 6.9 移除字段硬切换是否彻底
+
+`docs/conversation_memory_optimization.md §"移除字段（硬切换）"` 列出的旧字段必须**全部清空**：
+
+- `working_memory_max_turns`
+- `working_memory_token_budget_ratio` / `_floor` / `_cap`
+- `episodic_memory_token_budget_ratio` / `_floor` / `_cap`
+- `compaction_trigger_turn_count`
+- `compaction_trigger_token_ratio`
+
+检查项：
+- `grep -rn` 上述字段名在 `dayu/`、`tests/`、`docs/`、`workspace/config/` 应**返回空**；
+- `agent_execution_serialization.py` 的快照反序列化是否**显式拒绝**包含旧字段的快照（而非静默忽略）；
+- `ConversationMemorySettings` dataclass 是否仍保留任何旧字段作为"过渡兼容"（项目硬约束禁止兼容性代码）；
+- 配置 schema 校验（`options.py` 校验段）是否覆盖 4 个新字段：`memory_token_budget_*`（ratio ∈ [0,1] 有限数 / floor>0 / cap≥floor）、`recent_turns_floor≥0`、`compaction_trigger_context_ratio ∈ (0,1]`。
+- 判定标准：任一旧字段在生产代码或 schema 中残留、或新字段校验缺失 → 报告。
+
+#### 6.10 `conversation.enabled` 边界是否被尊重
+
+- 多轮记忆子系统**仅作用于 `conversation.enabled = true` 的 scene**（`interactive / wechat / prompt_mt`）；其它 scene（如 `prompt_st` 单轮）不应触发 transcript / compaction / pinned_state 装配。
+- 检查项：
+  - `scene_preparer.py::ConversationSessionState` 构造是否仅在 `conversation.enabled=true` 路径上执行；
+  - `prepare_transcript` / `schedule_compaction` 调用是否在 `conversation.enabled=false` scene 上被静默跳过（而非误触发空 transcript）；
+  - manifest 关闭多轮的 scene 走 `prompt --label` / `interactive --label` 入口时，CLI 是否直接拒绝执行（不静默退化成伪多轮）。
+- 判定标准：单轮 scene 误触发 conversation memory 装配、或多轮 scene 被本地覆写关闭后仍走 conversation 路径 → 报告。
+
+#### 6.11 估算函数与 token 口径是否一致
+
+- 涉及 token 估算的函数：`_estimate_tokens` / `_estimate_turn_tokens` / `_estimate_working_turn_view_tokens`。
+- 检查项：
+  - 三者是否使用**同一种估算方法**（不应一个按字符数除常数、另一个按 tokenizer 真实切分，造成 budget 计算不可比）；
+  - `_build_full_working_turn_view` 与 `_build_minimum_preserved_turn_view` 输出是否使用同一估算函数纳入 budget；
+  - episode summary 与 raw turn 估算是否口径一致（不能 raw 按 token 估、episode 按字符估）。
+- 判定标准：estimate 路径不一致导致 budget 在不同分支下数值漂移 → 报告。
+
+#### 6.12 测试是否覆盖关键不变量
+
+- 必须存在的回归测试（参见 `tests/engine/test_conversation_memory.py`）：
+  - `test_pinned_state_not_counted_in_budget`：pinned 不消耗 budget；
+  - `test_recent_turns_floor_forced_preserved`：单轮溢出预算时仍保留最近 N 轮；
+  - `test_recent_turns_floor_minimum_preserve_on_extreme_turn`：单轮 user_text 巨长时走 minimum_preserve；
+  - `test_total_pool_priority_recent_then_episodes`:总池消费顺序 working > episodic；
+  - `test_compaction_triggered_by_window_ratio`:占模型窗口 ratio 触发；
+  - `test_short_window_model_uses_floor`:小窗口模型走 floor；
+  - `test_forced_turn_overflow_threshold_decoupled_from_cap`:阈值与 cap 解耦；
+  - `test_forced_turn_overflow_threshold_uses_actual_forced_count`:除数取实际 forced 轮数；
+  - `test_compaction_trigger_does_not_count_episodes`:episodes 仅按 `_build_memory_block` 真实裁切结果计入；
+  - `test_schedule_compaction_passes_system_prompt_token_estimate`:`user_text_tokens == 0` 在 post-persist 路径；
+  - `test_default_conversation_memory_settings_match_runtime_default`:三处默认值一致性。
+- 检查覆盖率应 ≥ 80%（项目硬约束）。
+- 判定标准：上述任一回归测试缺失、或被改写后失去原有保护语义 → 报告。
+
+#### 6.13 产出要求
+
+- 每条问题需指出：违反的不变量（例如"`pinned_state` 不计入 budget"）、具体代码位置、可复现输入、对运行时的影响（错误压缩 / 上下文漏失 / 双计 / 阈值死代码）。
+- 不要把"调参建议"当作问题报告——除非默认值与设计文档/三处一致性测试明确冲突。
+- 引用设计意图时统一指向 `docs/conversation_memory_optimization.md` 与 `dayu/host/README.md §10`，避免与实现细节互相反推。
+
+### 7. 金融逻辑分层
 - 金融逻辑（SEC Item 编号解析、财务指标判断、filing 结构规则等）是否只出现在 `fins` 中。
 - `engine` 中是否混入了金融逻辑。
 - 金融逻辑中是否有规则硬编码（如公司名、固定 ticker）。
 - 同一 Form 的主路由 processor 与 fallback processor 之间是否存在互相 import。
 - 重点审查processor 提取数据的逻辑是否有bug。
 
-### 7. 运行参数传递
+### 8. 运行参数传递
 - config参数是否最终传到Host / Agent。
 - prompt asserts是否最终传到Agent。
 - CLI 参数 是否作为override 最高优先级最终传到Host / Agent。
 
-### 8. 代码质量
+### 9. 代码质量
 - 是否有硬编码 magic string / magic number（出现在生产路径中的）；工具 schema例外，工具 schema必须把字符串写在schema内，禁止使用常量定义。
 - 调用函数，被调用函数的签名是否和调用方期望的一致。
 - 函数是否使用object、any、json等无法进行严格类型检查的参数类型和返回值。
@@ -454,7 +604,7 @@
 - 是否pyright无错误。
 - 是否符合 AGENTS.md 的代码结构要求（函数扁平化、无嵌套类、docstring 等）。
 
-### 9. 性能（静态分析，无需 profiling）
+### 10. 性能（静态分析，无需 profiling）
 仅标记通过代码阅读即可判断的明显性能问题，不做猜测性优化建议。关注以下模式：
 - **循环内重复计算**：循环体内每次调用开销大的函数（如正则编译、文件 I/O、重复 JSON 解析），应提到循环外。
 - **低效数据结构**：用 `list` 做成员查找（`x in list`）而应用 `set`；用字符串拼接替代 `join`。

--- a/docs/code_review_fixer.md
+++ b/docs/code_review_fixer.md
@@ -1,17 +1,17 @@
 ## 中修复风险
-你充当 code review findings的fixer 角色，接下来fix code-review-0423-0936-medium.md 里的findings。
+你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-medium.md 里的findings。
 medium里全部都是评估为中修复风险的finding。为了避免一次性修复太多findings 超出了你能处理的上下文范围，你先过一遍medium里的条目，把所有的findings分成N批，分成多少批，以你有把握稳定修复为准，分批结果写回到medium.md 文件头部。
 修复范式是先判断是不是和bug，是bug才修复；修复一批停下来等review，如果有review意见我会把意见贴给你继续修复，如果没有review意见就把修复结果写回medium，然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入high.md。
 
 
 ## 高修复风险
-你充当 code review findings的fixer 角色，接下来fix code-review-0423-0936-high.md 里的findings。
+你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-high.md 里的findings。
 high里全部都是评估为高修复风险的finding，修复时一定要谨慎，不要引入新bug。
 修复范式是先判断是不是和bug，是bug才修复；修复一个停下来等review，如果有review意见我会把意见贴给你继续修复，如果没有review意见就把修复结果写回medium，然后修复下一个；如果实际修复中发现修复风险过大，进入plan模式，经跟我讨论后再落地实施。
 
 
 ## review uncommited code
 你充当 code reviewer 角色，review的是另外一个Agent对findings的修复。
-代码在 uncommited code 里，finding 可以根据编号在 code-review-0423-0936-high.md 中找到。
+代码在 uncommited code 里，finding 可以根据编号在 code-review-0428-1727-high.md 中找到。
 等我给你另外一个Agent对 findings 的修复报告再开始工作。
 

--- a/docs/code_review_fixer.md
+++ b/docs/code_review_fixer.md
@@ -1,17 +1,18 @@
 ## 中修复风险
 你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-medium.md 里的findings。
 medium里全部都是评估为中修复风险的finding。为了避免一次性修复太多findings 超出了你能处理的上下文范围，你先过一遍medium里的条目，把所有的findings分成N批，分成多少批，以你有把握稳定修复为准，分批结果写回到medium.md 文件头部。
-修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复结果写回medium（若无问题）；然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入medium.md。
+修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；确认后先把诊断写回medium再开始修复，修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复方案和修复结果写回medium（若无问题）；然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入medium.md。
 
 
 ## 高修复风险
 你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-high.md 里的findings。
 high里全部都是评估为高修复风险的finding，修复时一定要深度思考，不要引入新bug。
-修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复结果写回high（若无问题）；然后修复下一批；如果实际修复中发现修复风险过大，进入plan模式，经跟我讨论后再落地实施。
+修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；确认后先把诊断写回high再开始修复，修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复方案和修复结果写回high（若无问题）；然后修复下一批；如果实际修复中发现修复风险过大，进入plan模式，经跟我讨论后再落地实施。
 
 
 ## review uncommited code
-你充当 code reviewer 角色，请帮我 review 当前代码改动，你要review的是另外一个Agent对findings的修复。
+你充当 code reviewer 角色，请帮我 review 当前代码改动。
+你将收到另外一个Agent对 findings 的修复报告，你要review的是另外一个Agent对findings的修复。
 代码在 uncommited code 里，finding 可以根据编号在 code-review-0428-1727-high.md 中找到。
 Review 要求：
 - 采用 code review 模式，优先找真正会影响正确性、稳定性、可维护性的缺陷

--- a/docs/code_review_fixer.md
+++ b/docs/code_review_fixer.md
@@ -1,7 +1,13 @@
+## 低修复风险
+你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-low.md 里的findings。
+medium里全部都是评估为低修复风险的finding。为了避免一次性修复太多findings 超出了你能处理的上下文范围，你先过一遍low里的条目，把所有的findings分成N批，分成多少批，以你有把握稳定修复为准，分批结果写回到low文件头部。
+修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；确认后先把诊断写回low再开始修复，修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复方案和修复结果写回low（若无问题）；然后修复下一批；如果实际修复中发现修复风险大于“低”，停止修复，并把finding写入medium.md。
+
+
 ## 中修复风险
 你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-medium.md 里的findings。
-medium里全部都是评估为中修复风险的finding。为了避免一次性修复太多findings 超出了你能处理的上下文范围，你先过一遍medium里的条目，把所有的findings分成N批，分成多少批，以你有把握稳定修复为准，分批结果写回到medium.md 文件头部。
-修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；确认后先把诊断写回medium再开始修复，修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复方案和修复结果写回medium（若无问题）；然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入medium.md。
+medium里全部都是评估为中修复风险的finding。为了避免一次性修复太多findings 超出了你能处理的上下文范围，你先过一遍medium里的条目，把所有的findings分成N批，分成多少批，以你有把握稳定修复为准，分批结果写回到medium文件头部。
+修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；确认后先把诊断写回medium再开始修复，修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复方案和修复结果写回medium（若无问题）；然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入high.md。
 
 
 ## 高修复风险
@@ -18,6 +24,8 @@ Review 要求：
 - 采用 code review 模式，优先找真正会影响正确性、稳定性、可维护性的缺陷
 - 对修复报告中对findings逐条review
 - 重点关注：逻辑错误、边界条件、回归风险、类型问题、异常处理、测试遗漏、与现有架构约束不一致的地方
+输出：
+- review结束后给出review意见
 - 对修复报告中对findings逐条给出review结论
 - 全部findings review完毕后给出是否可commit的结论
 等我给你另外一个Agent对 findings 的修复报告再开始工作。

--- a/docs/code_review_fixer.md
+++ b/docs/code_review_fixer.md
@@ -1,17 +1,23 @@
 ## 中修复风险
 你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-medium.md 里的findings。
 medium里全部都是评估为中修复风险的finding。为了避免一次性修复太多findings 超出了你能处理的上下文范围，你先过一遍medium里的条目，把所有的findings分成N批，分成多少批，以你有把握稳定修复为准，分批结果写回到medium.md 文件头部。
-修复范式是先判断是不是和bug，是bug才修复；修复一批停下来等review，如果有review意见我会把意见贴给你继续修复，如果没有review意见就把修复结果写回medium，然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入high.md。
+修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复结果写回medium（若无问题）；然后修复下一批；如果实际修复中发现修复风险大于“中”，停止修复，并把finding写入medium.md。
 
 
 ## 高修复风险
 你充当 code review findings的fixer 角色，接下来fix code-review-0428-1727-high.md 里的findings。
-high里全部都是评估为高修复风险的finding，修复时一定要谨慎，不要引入新bug。
-修复范式是先判断是不是和bug，是bug才修复；修复一个停下来等review，如果有review意见我会把意见贴给你继续修复，如果没有review意见就把修复结果写回medium，然后修复下一个；如果实际修复中发现修复风险过大，进入plan模式，经跟我讨论后再落地实施。
+high里全部都是评估为高修复风险的finding，修复时一定要深度思考，不要引入新bug。
+修复范式是先判断是不是问题（不限于bug），先给出问题诊断和修复方案，等我确认；修复一批后输出修复报告并停下来等review，根据review意见继续修复（若还有问题）或把修复结果写回high（若无问题）；然后修复下一批；如果实际修复中发现修复风险过大，进入plan模式，经跟我讨论后再落地实施。
 
 
 ## review uncommited code
-你充当 code reviewer 角色，review的是另外一个Agent对findings的修复。
+你充当 code reviewer 角色，请帮我 review 当前代码改动，你要review的是另外一个Agent对findings的修复。
 代码在 uncommited code 里，finding 可以根据编号在 code-review-0428-1727-high.md 中找到。
+Review 要求：
+- 采用 code review 模式，优先找真正会影响正确性、稳定性、可维护性的缺陷
+- 对修复报告中对findings逐条review
+- 重点关注：逻辑错误、边界条件、回归风险、类型问题、异常处理、测试遗漏、与现有架构约束不一致的地方
+- 对修复报告中对findings逐条给出review结论
+- 全部findings review完毕后给出是否可commit的结论
 等我给你另外一个Agent对 findings 的修复报告再开始工作。
 

--- a/tests/application/test_cancellation_bridge.py
+++ b/tests/application/test_cancellation_bridge.py
@@ -10,7 +10,10 @@ from typing import cast
 
 import pytest
 
-from dayu.host.cancellation_bridge import CancellationBridge
+from dayu.host.cancellation_bridge import (
+    CancellationBridge,
+    _MAX_CONSECUTIVE_POLL_FAILURES,
+)
 from dayu.host.protocols import RunRegistryProtocol
 from dayu.contracts.run import RunRecord, RunState
 from dayu.contracts.cancellation import CancellationToken
@@ -202,4 +205,85 @@ class TestCancellationBridgePolling:
 
         # 最终检测到取消请求
         assert token.is_cancelled()
+        bridge.stop()
+
+    @pytest.mark.unit
+    def test_stops_after_consecutive_failures_reach_threshold(self) -> None:
+        """持续异常达到阈值后退出轮询，不再无限重试。"""
+
+        class _AlwaysFailingRegistry:
+            """每次查询都抛异常的 registry。"""
+
+            def __init__(self) -> None:
+                self.call_count = 0
+
+            def get_run(self, run_id: str) -> RunRecord | None:
+                self.call_count += 1
+                _ = run_id
+                raise RuntimeError("db error")
+
+        registry = _AlwaysFailingRegistry()
+        token = CancellationToken()
+        bridge = CancellationBridge(
+            run_registry=cast(RunRegistryProtocol, registry),
+            run_id="run_test",
+            token=token,
+            poll_interval=0.01,
+        )
+        bridge.start()
+        # 等待轮询线程退出
+        thread = bridge._thread
+        assert thread is not None
+        thread.join(timeout=2.0)
+        assert not thread.is_alive(), "持续失败达阈值后应退出轮询"
+        # token 不应被取消（无法判定取消请求时不应误判取消）
+        assert not token.is_cancelled()
+        # 调用次数应在阈值附近（允许少量偏差，但远小于无限循环）
+        assert registry.call_count >= _MAX_CONSECUTIVE_POLL_FAILURES
+        assert registry.call_count <= _MAX_CONSECUTIVE_POLL_FAILURES + 2
+        bridge.stop()
+
+    @pytest.mark.unit
+    def test_failure_counter_resets_on_success(self) -> None:
+        """偶发异常后能成功一次查询，失败计数应清零，不会过早退出。"""
+
+        class _IntermittentRegistry:
+            """前若干次查询失败，之后稳定成功。"""
+
+            def __init__(self, fail_times: int) -> None:
+                self._fail_times = fail_times
+                self.call_count = 0
+
+            def get_run(self, run_id: str) -> RunRecord | None:
+                self.call_count += 1
+                if self.call_count <= self._fail_times:
+                    raise RuntimeError("transient error")
+                return RunRecord(
+                    run_id=run_id,
+                    session_id=None,
+                    service_type="test",
+                    scene_name=None,
+                    state=RunState.RUNNING,
+                    created_at=datetime.now(timezone.utc),
+                    cancel_requested_at=None,
+                    owner_pid=1,
+                )
+
+        # 失败次数小于阈值，且后续始终成功；轮询线程应保持运行。
+        fail_times = max(1, _MAX_CONSECUTIVE_POLL_FAILURES - 2)
+        registry = _IntermittentRegistry(fail_times=fail_times)
+        token = CancellationToken()
+        bridge = CancellationBridge(
+            run_registry=cast(RunRegistryProtocol, registry),
+            run_id="run_test",
+            token=token,
+            poll_interval=0.01,
+        )
+        bridge.start()
+        # 给足时间让失败次数累计后再清零，并继续多轮成功轮询。
+        time.sleep(0.3)
+        thread = bridge._thread
+        assert thread is not None
+        assert thread.is_alive(), "失败计数清零后轮询线程应继续运行"
+        assert not token.is_cancelled()
         bridge.stop()

--- a/tests/application/test_chat_service.py
+++ b/tests/application/test_chat_service.py
@@ -50,6 +50,7 @@ from dayu.host.prepared_turn import (
 )
 from dayu.log import Log
 from dayu.prompting.scene_definition import (
+    PromptManifestError,
     SceneConversationDefinition,
     SceneDefinition,
     SceneModelDefinition,
@@ -1111,3 +1112,81 @@ def test_submit_turn_session_locks_do_not_accumulate_after_consumption() -> None
     # 驱动 GC，让 WeakValueDictionary 清理无强引用的锁条目。
     gc.collect()
     assert len(service._session_locks) == 0
+
+
+@pytest.mark.unit
+def test_submit_turn_translates_prompt_manifest_error_to_value_error() -> None:
+    """scene manifest 损坏时应抛出含"manifest 配置损坏"语义的 ValueError。"""
+
+    class _BrokenManifestPreparer(_FakeSceneExecutionAcceptancePreparer):
+        """模拟 manifest 加载失败时抛出 PromptManifestError 的 preparer。"""
+
+        def prepare(
+            self,
+            scene_name: str,
+            execution_options: ExecutionOptions | None = None,
+        ) -> AcceptedSceneExecution:
+            raise PromptManifestError("fragment.order 不允许重复")
+
+    resolver = _BrokenManifestPreparer()
+    session_registry = StubSessionRegistry()
+    session_registry.create_session(source=SessionSource.CLI, session_id="s1")
+    host = Host(
+        executor=StubHostExecutor(),  # type: ignore[arg-type]
+        session_registry=session_registry,  # type: ignore[arg-type]
+        run_registry=StubRunRegistry(),  # type: ignore[arg-type]
+        pending_turn_store=StubPendingTurnStore(),  # type: ignore[arg-type]
+    )
+    service = ChatService(
+        host=host,
+        scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        company_name_resolver=lambda ticker: f"{ticker}-NAME",
+        session_source=SessionSource.API,
+    )
+
+    async def scenario() -> None:
+        with pytest.raises(ValueError, match="manifest 配置损坏"):
+            await service.submit_turn(
+                ChatTurnRequest(session_id="s1", user_text="hello", ticker="AAPL"),
+            )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_submit_turn_translates_missing_scene_to_value_error() -> None:
+    """scene 不存在时应抛出含"scene 不存在"语义的 ValueError。"""
+
+    class _MissingScenePreparer(_FakeSceneExecutionAcceptancePreparer):
+        """模拟 scene 文件缺失时抛出 FileNotFoundError 的 preparer。"""
+
+        def prepare(
+            self,
+            scene_name: str,
+            execution_options: ExecutionOptions | None = None,
+        ) -> AcceptedSceneExecution:
+            raise FileNotFoundError(scene_name)
+
+    resolver = _MissingScenePreparer()
+    session_registry = StubSessionRegistry()
+    session_registry.create_session(source=SessionSource.CLI, session_id="s1")
+    host = Host(
+        executor=StubHostExecutor(),  # type: ignore[arg-type]
+        session_registry=session_registry,  # type: ignore[arg-type]
+        run_registry=StubRunRegistry(),  # type: ignore[arg-type]
+        pending_turn_store=StubPendingTurnStore(),  # type: ignore[arg-type]
+    )
+    service = ChatService(
+        host=host,
+        scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        company_name_resolver=lambda ticker: f"{ticker}-NAME",
+        session_source=SessionSource.API,
+    )
+
+    async def scenario() -> None:
+        with pytest.raises(ValueError, match="scene 不存在"):
+            await service.submit_turn(
+                ChatTurnRequest(session_id="s1", user_text="hello", ticker="AAPL"),
+            )
+
+    asyncio.run(scenario())

--- a/tests/application/test_console_output.py
+++ b/tests/application/test_console_output.py
@@ -132,7 +132,11 @@ def test_cli_main_configures_console_output_before_parsing(
         lambda: argparse.Namespace(command=""),
     )
 
-    assert cli_main_module.main() == 0
+    # `command=""` 是 mock 注入的非法值（argparse 实际声明 ``required=True``），
+    # 现在的 main 会通过 AssertionError fail-fast。本用例只验证"先配置标准流再解析参数"
+    # 的顺序约束，因此预期 AssertionError，但断言 configure 已先于 parse 完成。
+    with pytest.raises(AssertionError, match="未识别的 CLI 命令"):
+        cli_main_module.main()
     assert observed == ["configured"]
 
 

--- a/tests/application/test_host_executor.py
+++ b/tests/application/test_host_executor.py
@@ -309,6 +309,128 @@ def test_run_stream_marks_failed_when_acquire_many_raises_after_start_run() -> N
 
 
 @pytest.mark.unit
+def test_start_run_marks_failed_when_deadline_watcher_start_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bridge 已启动但 deadline watcher 启动失败时，run 必须收敛为 FAILED 且资源被停止。"""
+
+    from tests.application.conftest import StubRunRegistry
+
+    class _TrackingBridge:
+        """记录 start/stop 调用的取消桥桩。"""
+
+        instances: list["_TrackingBridge"] = []
+
+        def __init__(
+            self,
+            run_registry: object,
+            run_id: str,
+            token: executor_module.CancellationToken,
+            poll_interval: float = 0.5,
+        ) -> None:
+            del run_registry, run_id, token, poll_interval
+            self.started = False
+            self.stopped = False
+            _TrackingBridge.instances.append(self)
+
+        def start(self) -> None:
+            """记录已启动。"""
+
+            self.started = True
+
+        def stop(self) -> None:
+            """记录已停止。"""
+
+            self.stopped = True
+
+    class _FailingDeadlineWatcher:
+        """启动时抛异常的 deadline watcher 桩。"""
+
+        instances: list["_FailingDeadlineWatcher"] = []
+
+        def __init__(
+            self,
+            run_registry: object,
+            run_id: str,
+            token: executor_module.CancellationToken,
+            timeout_ms: int | None,
+        ) -> None:
+            del run_registry, run_id, token, timeout_ms
+            self.stop_calls = 0
+            _FailingDeadlineWatcher.instances.append(self)
+
+        def start(self) -> None:
+            """模拟 watcher 启动失败。"""
+
+            raise RuntimeError("deadline watcher boom")
+
+        def stop(self) -> None:
+            """记录 stop 调用。"""
+
+            self.stop_calls += 1
+
+    run_registry = StubRunRegistry()
+    run = run_registry.register_run(session_id="s1", service_type="prompt")
+    executor = DefaultHostExecutor(run_registry=run_registry)
+    spec = HostedRunSpec(operation_name="prompt", session_id="s1")
+
+    monkeypatch.setattr(executor_module, "CancellationBridge", _TrackingBridge)
+    monkeypatch.setattr(executor_module, "RunDeadlineWatcher", _FailingDeadlineWatcher)
+
+    with pytest.raises(RuntimeError, match="deadline watcher boom"):
+        executor._start_run(spec=spec, run_id=run.run_id, include_agent_lane=False)
+
+    final_run = run_registry.get_run(run.run_id)
+    assert final_run is not None
+    assert final_run.state == RunState.FAILED
+    assert final_run.completed_at is not None
+    assert run_registry.list_active_runs() == []
+    assert len(_TrackingBridge.instances) == 1
+    assert _TrackingBridge.instances[0].started is True
+    assert _TrackingBridge.instances[0].stopped is True
+    assert len(_FailingDeadlineWatcher.instances) == 1
+    assert _FailingDeadlineWatcher.instances[0].stop_calls == 1
+
+
+@pytest.mark.unit
+def test_start_run_short_circuits_when_cancel_already_requested() -> None:
+    """启动前已存在取消意图时，不应推 RUNNING，也不应申请 permit。"""
+
+    from tests.application.conftest import StubRunRegistry
+
+    run_registry = StubRunRegistry()
+    governor = _StubGovernor()
+    executor = DefaultHostExecutor(
+        run_registry=run_registry,
+        concurrency_governor=governor,  # type: ignore[arg-type]
+        event_bus=_StubEventBus(),  # type: ignore[arg-type]
+    )
+    spec = HostedRunSpec(
+        operation_name="write_pipeline",
+        session_id="s1",
+        business_concurrency_lane="write_chapter",
+    )
+    run = run_registry.register_run(
+        session_id="s1",
+        service_type="write_pipeline",
+        scene_name=spec.scene_name,
+    )
+    requested = run_registry.request_cancel(run.run_id, cancel_reason=RunCancelReason.USER_CANCELLED)
+    assert requested is True
+
+    with pytest.raises(CancelledError, match="启动前收到取消请求"):
+        executor._start_run(spec=spec, run_id=run.run_id, include_agent_lane=True)
+
+    final_run = run_registry.get_run(run.run_id)
+    assert final_run is not None
+    assert final_run.state == RunState.CANCELLED
+    assert final_run.cancel_reason == RunCancelReason.USER_CANCELLED
+    assert final_run.started_at is None
+    assert governor.acquired == []
+    assert governor.released == []
+
+
+@pytest.mark.unit
 def test_run_sync_marks_cancelled_and_uses_on_cancel() -> None:
     """同步执行取消时应标记 run 并走 on_cancel。"""
 
@@ -1720,6 +1842,7 @@ def test_host_executor_helper_functions_cover_deadline_and_summary_edges() -> No
     assert run_spec.scene_name == "interactive"
     long_summary = executor_module._summarize_tool_result({"ok": True, "value": {"body": "x" * 5000}})
     assert "<truncated" in long_summary
+    assert len(long_summary) <= executor_module._MAX_TOOL_RESULT_SUMMARY_CHARS
 
 
 @pytest.mark.unit

--- a/tests/application/test_pending_turn_store.py
+++ b/tests/application/test_pending_turn_store.py
@@ -755,3 +755,160 @@ def test_run_registry_implements_runtime_protocol(tmp_path: Path) -> None:
     from dayu.host.protocols import RunRegistryProtocol
 
     assert isinstance(registry, RunRegistryProtocol)
+
+
+@pytest.mark.unit
+def test_inmemory_release_resume_lease_warns_on_missing_pre_resume_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """pre_resume_state 为 NULL 时应输出告警并按 ACCEPTED_BY_HOST 降级回退。"""
+
+    store = InMemoryPendingConversationTurnStore()
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题一",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    # 模拟 pre_resume_state 字段损坏：手动写入 RESUMING 但不附带 pre_resume_state。
+    record = store._records[created.pending_turn_id]
+    store._records[created.pending_turn_id] = type(record)(
+        pending_turn_id=record.pending_turn_id,
+        session_id=record.session_id,
+        scene_name=record.scene_name,
+        user_text=record.user_text,
+        source_run_id=record.source_run_id,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        resumable=record.resumable,
+        state=PendingConversationTurnState.RESUMING,
+        resume_source_json=record.resume_source_json,
+        resume_attempt_count=record.resume_attempt_count,
+        last_resume_error_message=record.last_resume_error_message,
+        pre_resume_state=None,
+        metadata=record.metadata,
+    )
+
+    with caplog.at_level("WARNING"):
+        released = store.release_resume_lease(created.pending_turn_id)
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+    assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
+        "pre_resume_state 缺失时应输出告警"
+    )
+
+
+@pytest.mark.unit
+def test_inmemory_record_resume_failure_warns_on_missing_pre_resume_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RESUMING 但 pre_resume_state 为 NULL 时，record_resume_failure 应告警并降级回退。"""
+
+    store = InMemoryPendingConversationTurnStore()
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题二",
+        source_run_id="run_2",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    record = store._records[created.pending_turn_id]
+    store._records[created.pending_turn_id] = type(record)(
+        pending_turn_id=record.pending_turn_id,
+        session_id=record.session_id,
+        scene_name=record.scene_name,
+        user_text=record.user_text,
+        source_run_id=record.source_run_id,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        resumable=record.resumable,
+        state=PendingConversationTurnState.RESUMING,
+        resume_source_json=record.resume_source_json,
+        resume_attempt_count=record.resume_attempt_count,
+        last_resume_error_message=record.last_resume_error_message,
+        pre_resume_state=None,
+        metadata=record.metadata,
+    )
+
+    with caplog.at_level("WARNING"):
+        failed = store.record_resume_failure(created.pending_turn_id, error_message="boom")
+    assert failed.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+    assert failed.last_resume_error_message == "boom"
+    assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
+        "pre_resume_state 缺失时应输出告警"
+    )
+
+
+@pytest.mark.unit
+def test_sqlite_release_resume_lease_warns_on_missing_pre_resume_state(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """SQLite 版 release_resume_lease 在 pre_resume_state 为 NULL 时应告警并降级回退。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLitePendingConversationTurnStore(host_store)
+
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题一",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    # 直接通过底层连接把 state 改成 RESUMING 同时把 pre_resume_state 置 NULL，
+    # 模拟数据损坏或 acquire 路径异常导致的字段缺失。
+    conn = host_store.get_connection()
+    conn.execute(
+        "UPDATE pending_conversation_turns SET state = ?, pre_resume_state = NULL WHERE pending_turn_id = ?",
+        (PendingConversationTurnState.RESUMING.value, created.pending_turn_id),
+    )
+    conn.commit()
+
+    with caplog.at_level("WARNING"):
+        released = store.release_resume_lease(created.pending_turn_id)
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+    assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
+        "pre_resume_state 缺失时应输出告警"
+    )
+
+
+@pytest.mark.unit
+def test_sqlite_record_resume_failure_warns_on_missing_pre_resume_state(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """SQLite 版 record_resume_failure 在 pre_resume_state 为 NULL 时应告警并降级回退。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLitePendingConversationTurnStore(host_store)
+
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题二",
+        source_run_id="run_2",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    conn = host_store.get_connection()
+    conn.execute(
+        "UPDATE pending_conversation_turns SET state = ?, pre_resume_state = NULL WHERE pending_turn_id = ?",
+        (PendingConversationTurnState.RESUMING.value, created.pending_turn_id),
+    )
+    conn.commit()
+
+    with caplog.at_level("WARNING"):
+        failed = store.record_resume_failure(created.pending_turn_id, error_message="boom")
+    assert failed.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+    assert failed.last_resume_error_message == "boom"
+    assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
+        "pre_resume_state 缺失时应输出告警"
+    )

--- a/tests/application/test_wechat_ilink_client.py
+++ b/tests/application/test_wechat_ilink_client.py
@@ -328,3 +328,37 @@ def test_request_json_rethrows_timeout_when_no_fallback() -> None:
             await client.aclose()
 
     asyncio.run(_run())
+
+
+@pytest.mark.unit
+def test_request_json_logs_debug_when_timeout_fallback_hits(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """验证 timeout_fallback 命中时会留下可观测的 debug 日志，便于排查长轮询超时。"""
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timeout")
+
+    async def _run() -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+        api = IlinkApiClient(client=client)
+        try:
+            with caplog.at_level("DEBUG", logger="WECHAT.ILINK_CLIENT"):
+                payload = await api._request_json(
+                    method="POST",
+                    path="/ilink/bot/getupdates",
+                    auth_required=False,
+                    timeout_fallback={"ret": 0, "msgs": [], "get_updates_buf": ""},
+                )
+            assert payload == {"ret": 0, "msgs": [], "get_updates_buf": ""}
+            messages = [record.getMessage() for record in caplog.records]
+            assert any(
+                "iLink 请求超时命中 fallback" in msg
+                and "method=POST" in msg
+                and "path=/ilink/bot/getupdates" in msg
+                for msg in messages
+            ), messages
+        finally:
+            await client.aclose()
+
+    asyncio.run(_run())

--- a/tests/application/test_wechat_state_store.py
+++ b/tests/application/test_wechat_state_store.py
@@ -184,3 +184,32 @@ def test_state_store_private_helpers_cover_url_base64_and_extension_detection() 
     assert state_store_module._guess_binary_extension(b"\xff\xd8\xffrest") == ".jpg"
     assert state_store_module._guess_binary_extension(b"   <svg viewBox='0 0 1 1'>") == ".svg"
     assert state_store_module._guess_binary_extension(b"unknown") == ".bin"
+
+@pytest.mark.unit
+def test_write_text_atomic_closes_fd_when_fdopen_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """验证 ``_write_text_atomic`` 在 fdopen 失败时也会关闭底层 fd，避免泄漏。"""
+
+    import os as os_mod
+
+    closed_fds: list[int] = []
+    original_close = os_mod.close
+
+    def _capturing_close(fd: int) -> None:
+        closed_fds.append(fd)
+        original_close(fd)
+
+    def _failing_fdopen(*_args: object, **_kwargs: object) -> object:
+        raise OSError("simulated fdopen failure")
+
+    monkeypatch.setattr(state_store_module.os, "fdopen", _failing_fdopen)
+    monkeypatch.setattr(state_store_module.os, "close", _capturing_close)
+
+    target = tmp_path / "ledger.json"
+    with pytest.raises(OSError, match="simulated fdopen failure"):
+        state_store_module._write_text_atomic(target, "{}")
+
+    assert closed_fds, "fd 应在 fdopen 失败路径下被显式关闭"
+    # 临时文件应已被清理
+    assert not list(tmp_path.glob(f".{target.name}.*.tmp"))

--- a/tests/engine/test_async_agent.py
+++ b/tests/engine/test_async_agent.py
@@ -487,6 +487,7 @@ class DummyToolTraceRecorder:
             {
                 "iteration_id": iteration_id,
                 "iteration_index": iteration_index,
+                "termination_reason": termination_reason,
             }
         )
 
@@ -1052,9 +1053,9 @@ class TestAsyncAgentRun:
 
         third_iteration_messages = runner.calls[2]["messages"]
         assert any(
-            msg.get("role") == "user" and "same tool (tool)" in msg.get("content", "")
+            msg.get("role") == "system" and "same tool (tool)" in msg.get("content", "")
             for msg in third_iteration_messages
-        ), f"Expected duplicate hint with 'same tool (tool)' in messages: {[m.get('content','')[:80] for m in third_iteration_messages if m.get('role')=='user']}"
+        ), f"Expected duplicate hint with 'same tool (tool)' in messages: {[m.get('content','')[:80] for m in third_iteration_messages if m.get('role')=='system']}"
 
     async def test_duplicate_tool_call_with_information_gain_not_early_exit(self):
         """测试重复调用若结果有信息增量，不触发重复调用提前退出。"""
@@ -1776,6 +1777,10 @@ class TestAsyncAgentStreaming:
         assert recorder.results[0]["payload"]["result"]["ok"] is True
         assert recorder.final_responses[0]["content"] == "done"
         assert recorder.final_responses[0]["degraded"] is False
+        assert [item["termination_reason"] for item in recorder.finished_iterations] == [
+            "tool_calls_continued",
+            "final_answer",
+        ]
         # 回归 finding 086：record_final_response 必须把 filtered / finish_reason
         # 透传给 trace recorder，否则导出的 JSONL 中相关字段恒为默认值。
         assert recorder.final_responses[0]["filtered"] is False
@@ -1824,6 +1829,7 @@ class TestAsyncAgentStreaming:
 
         assert result.success is False
         assert len(recorder.finished_iterations) == 1
+        assert recorder.finished_iterations[0]["termination_reason"] == "error"
         assert len(recorder.final_responses) == 0
         assert recorder.closed is True
 

--- a/tests/engine/test_async_openai_runner.py
+++ b/tests/engine/test_async_openai_runner.py
@@ -325,6 +325,40 @@ class TestAsyncOpenAIRunnerProcessNonStream:
         assert EventType.TOOL_CALLS_BATCH_DONE in event_types
         assert EventType.DONE in event_types
 
+    async def test_process_non_stream_reasoning_content_in_metadata(self):
+        """测试非流式 reasoning_content 会透传到 content_complete metadata。"""
+
+        runner = AsyncOpenAIRunner(
+            endpoint_url="https://api.example.com",
+            model="deepseek-reasoner",
+            headers={},
+        )
+
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "结论",
+                        "reasoning_content": "思考过程",
+                    }
+                }
+            ]
+        }
+
+        events = []
+        trace_meta = {"run_id": "run_test", "iteration_id": "run_test_iteration", "request_id": "test_request"}
+        async for event in runner._process_non_stream(result, "test_request", trace_meta):
+            events.append(event)
+
+        reasoning_events = [event for event in events if event.type == EventType.REASONING_DELTA]
+        assert len(reasoning_events) == 1
+        assert reasoning_events[0].data == "思考过程"
+        content_complete_events = [event for event in events if event.type == EventType.CONTENT_COMPLETE]
+        assert len(content_complete_events) == 1
+        assert content_complete_events[0].data == "结论"
+        assert content_complete_events[0].metadata.get("reasoning_content") == "思考过程"
+
     async def test_process_tool_call_response_with_dict_arguments(self):
         """测试工具调用参数为对象时可被兼容处理。"""
         runner = AsyncOpenAIRunner(

--- a/tests/engine/test_cli_running_config.py
+++ b/tests/engine/test_cli_running_config.py
@@ -3945,7 +3945,11 @@ def test_main_prompt_path_propagates_scene_manifest_prompt_assets_and_llm_model_
 
 @pytest.mark.unit
 def test_main_non_interactive_path_returns_zero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """验证 `main` 在非 interactive 模式直接返回 0。
+    """验证 `main` 收到未识别命令时通过 AssertionError 暴露契约破坏。
+
+    argparse subparsers 已声明 ``required=True``，``args.command`` 不应为 ``None``；
+    若 mock 强行让 ``command=None``，``main`` 现在通过 AssertionError 显式 fail-fast，
+    避免静默走"返回 0"的死代码路径。
 
     Args:
         monkeypatch: pytest monkeypatch 对象。
@@ -3958,27 +3962,12 @@ def test_main_non_interactive_path_returns_zero(monkeypatch: pytest.MonkeyPatch,
         AssertionError: 断言失败时抛出。
     """
 
-    workspace_config = WorkspaceConfig(
-        workspace_dir=tmp_path,
-        output_dir=tmp_path / "output",
-        config_loader=ConfigLoader(ConfigFileResolver(tmp_path / "config")),
-        prompt_asset_store=FilePromptAssetStore(ConfigFileResolver(tmp_path / "config")),
-        ticker=None,
-        has_local_filings=False,
-    )
-    running_config = RunningConfig(
-        runner_running_config=AsyncOpenAIRunnerRunningConfig(),
-        agent_running_config=AgentRunningConfig(),
-        doc_tool_limits=DocToolLimits(),
-        fins_tool_limits=FinsToolLimits(),
-        web_tools_config=WebToolsConfig(provider="auto"),
-        tool_trace_config=TraceSettings(enabled=False, output_dir=tmp_path / "trace"),
-    )
-    model_name = ModelName(model_name="mimo-v2.5-pro")
+    _ = tmp_path
     args = Namespace(command=None, log_level=None, debug=False, verbose=False, info=False, quiet=False)
 
     monkeypatch.setattr("dayu.cli.main.parse_arguments", partial(_return_value, args))
-    assert main() == 0
+    with pytest.raises(AssertionError, match="未识别的 CLI 命令"):
+        main()
 
 
 @pytest.mark.unit

--- a/tests/engine/test_context_budget.py
+++ b/tests/engine/test_context_budget.py
@@ -1131,7 +1131,7 @@ class TestCompactMessagesSystemUserGap:
         assert result[1] == {"role": "user", "content": "goal"}
         # 摘要应包含 assistant prelude 的统计
         summary_msg = result[2]
-        assert _message_role(summary_msg) == "user"
+        assert _message_role(summary_msg) == "system"
         assert "[Context Compaction Summary]" in _message_content(summary_msg)
         # "prelude" 本身在摘要统计中应被计为 1 个 assistant
         assert "assistant=" in _message_content(summary_msg)

--- a/tests/engine/test_context_budget.py
+++ b/tests/engine/test_context_budget.py
@@ -371,7 +371,18 @@ class TestCompactMessages:
             {
                 "role": "tool",
                 "tool_call_id": "call_1",
-                "content": json.dumps({"ok": True, "value": {"ticker": "AAPL", "revenue": "100"}}),
+                "content": json.dumps(
+                    {
+                        "ok": True,
+                        "value": {
+                            "ticker": "AAPL",
+                            "revenue": "81.8B",
+                            "gross_margin": "46.3%",
+                            "segments": ["iPhone", "Services", "Mac"],
+                            "guidance": {"eps": "1.40", "fcf": "25B"},
+                        },
+                    }
+                ),
             },
             {
                 "role": "tool",
@@ -384,7 +395,10 @@ class TestCompactMessages:
 
         assert "Tool result highlights:" in summary
         assert "search_document: ok=true" in summary
-        assert '"ticker": "AAPL"' in summary
+        assert "ticker=AAPL" in summary
+        assert "revenue=81.8B" in summary
+        assert "gross_margin=46.3%" in summary
+        assert "segments=iPhone, Services, Mac" in summary
         assert "fetch_web_page: ok=false, error=403 blocked" in summary
 
     def test_compact_messages_with_gap_between_system_and_first_user(self) -> None:
@@ -1233,21 +1247,22 @@ async def test_continuation_compaction_emits_warning() -> None:
 # ========== 预测性工具结果截断测试 ==========
 
 
-class TestEstimateCharsToTokens:
-    """ToolResultBudgetCapper.estimate_chars_to_tokens 单元测试。"""
+class TestEstimateTextToTokens:
+    """ToolResultBudgetCapper.estimate_text_to_tokens 单元测试。"""
 
-    def test_basic_conversion(self) -> None:
-        """1000 chars ≈ 250 tokens（按 4 chars/token）。"""
-        assert ToolResultBudgetCapper.estimate_chars_to_tokens(1000) == 250
+    def test_half_width_text_is_estimated_conservatively(self) -> None:
+        """半角文本按更保守口径估算 token。"""
+        assert ToolResultBudgetCapper.estimate_text_to_tokens("abcd") == 2
+        assert ToolResultBudgetCapper.estimate_text_to_tokens("a" * 1000) == 500
 
     def test_zero(self) -> None:
-        """0 chars → 0 tokens。"""
-        assert ToolResultBudgetCapper.estimate_chars_to_tokens(0) == 0
+        """空文本 → 0 tokens。"""
+        assert ToolResultBudgetCapper.estimate_text_to_tokens("") == 0
 
-    def test_small_remainder(self) -> None:
-        """不足一个 token 的字符数向下取整。"""
-        assert ToolResultBudgetCapper.estimate_chars_to_tokens(3) == 0
-        assert ToolResultBudgetCapper.estimate_chars_to_tokens(4) == 1
+    def test_wide_chars_are_estimated_more_conservatively(self) -> None:
+        """宽字符文本应比旧的 chars//4 估算更保守。"""
+        assert ToolResultBudgetCapper.estimate_text_to_tokens("中文测试") == 4
+        assert ToolResultBudgetCapper.estimate_text_to_tokens("ab中文c") == 4
 
 
 class TestTruncateToolResultStr:
@@ -1323,7 +1338,7 @@ class TestCapToolResultsForBudget:
             max_context_tokens=100000,
             soft_limit_ratio=0.75,  # soft = 75000 tokens
         )
-        # available = 75000 - 60000 - 500 = 14500 tokens → 58000 chars
+        # available = 75000 - 60000 - 500 = 14500 tokens
         state.current_prompt_tokens = 60000
         state.latest_completion_tokens = 500
         small_a = "a" * 100
@@ -1339,12 +1354,12 @@ class TestCapToolResultsForBudget:
         # 小结果完整保留
         assert result[1][1] == small_a
         assert result[2][1] == small_b
-        # 大结果获得剩余预算（58000 - 100 - 500 = 57400），远多于均分的 58000/3 ≈ 19333
+        # 大结果获得剩余预算，明显多于简单均分。
         large_kept = result[0][1]
         assert "CONTEXT_BUDGET_TRUNCATED" in large_kept
-        # 截断后保留字符数应接近 57400（大于均分值 19333）
+        # 新估算口径下，保留字符数仍应显著大于均分保留。
         kept_chars = int(large_kept.split("kept=")[1].split(" ")[0])
-        assert kept_chars > 50000, f"大结果应获得远多于均分的预算，实际 {kept_chars}"
+        assert kept_chars > 20000, f"大结果应获得远多于均分的预算，实际 {kept_chars}"
 
     def test_empty_results_not_capped(self) -> None:
         """空结果不受影响。"""
@@ -1378,6 +1393,22 @@ class TestCapToolResultsForBudget:
         # 截断后保留至少 4000 chars（_MIN_RESULT_CHARS）
         # 加上 CONTEXT_BUDGET_TRUNCATED 注释
         assert result[0][1].startswith("z" * 4000)
+
+    def test_chinese_result_is_capped_under_same_budget(self) -> None:
+        """中文结果在相同预算下会按更保守口径触发截断。"""
+        state = ContextBudgetState(
+            max_context_tokens=100000,
+            soft_limit_ratio=0.75,
+        )
+        state.current_prompt_tokens = 74000
+        state.latest_completion_tokens = 0
+        chinese_result = "中" * 3000
+        pairs: list[tuple[dict[str, object], str]] = [({"id": "c1"}, chinese_result)]
+
+        result, capped = ToolResultBudgetCapper.cap_results_for_budget(pairs, state)
+
+        assert capped
+        assert "CONTEXT_BUDGET_TRUNCATED" in result[0][1]
 
 
 # ========== run_and_wait WARNING 收集测试 ==========

--- a/tests/engine/test_sec_processor.py
+++ b/tests/engine/test_sec_processor.py
@@ -2504,6 +2504,128 @@ def test_query_facts_rows_filters_textblock_and_requires_exact_local_name() -> N
 
 
 @pytest.mark.unit
+def test_infer_currency_from_units_recognizes_non_usd_compound_units() -> None:
+    """验证非 USD 复合单位也能识别为对应 ISO 4217 货币代码。
+
+    Args:
+        无。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    assert sec_processor._infer_currency_from_units("shares per CNY") == "CNY"
+    assert sec_processor._infer_currency_from_units("EUR per share") == "EUR"
+    assert sec_processor._infer_currency_from_units("HKD") == "HKD"
+
+
+@pytest.mark.unit
+def test_infer_currency_from_units_returns_none_for_non_currency_units() -> None:
+    """验证非货币单位不会被误识别为货币代码。
+
+    Args:
+        无。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    assert sec_processor._infer_currency_from_units("shares") is None
+    assert sec_processor._infer_currency_from_units("pure") is None
+    assert sec_processor._infer_currency_from_units("XYZ") is None
+
+
+@pytest.mark.unit
+def test_infer_units_from_xbrl_query_falls_back_through_revenue_candidates() -> None:
+    """验证 units 推断在首选概念无命中时回落到下一个候选概念。
+
+    Args:
+        无。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    class _ConceptAwareXbrlQueryProvider:
+        """按概念名返回不同 rows 的 XBRL 桩。"""
+
+        def __init__(self, rows_by_concept: dict[str, list[Any]]) -> None:
+            self._rows_by_concept = rows_by_concept
+            self._last_concept: Optional[str] = None
+
+        def query(self) -> "_ConceptAwareXbrlQueryProvider":
+            return self
+
+        def by_concept(self, concept: str) -> "_ConceptAwareXbrlQueryProvider":
+            self._last_concept = concept
+            return self
+
+        def execute(self) -> list[Any]:
+            assert self._last_concept is not None
+            return self._rows_by_concept.get(self._last_concept, [])
+
+    # ``Revenues`` 无命中、``Revenue`` 也无命中、``SalesRevenueNet`` 命中。
+    provider = _ConceptAwareXbrlQueryProvider(
+        rows_by_concept={
+            "Revenues": [],
+            "Revenue": [],
+            "SalesRevenueNet": [{"unit": "cny"}],
+        }
+    )
+    units = sec_processor._infer_units_from_xbrl_query(_as_xbrl(provider))
+    assert units == "CNY"
+
+
+@pytest.mark.unit
+def test_infer_scale_from_xbrl_query_falls_back_through_revenue_candidates() -> None:
+    """验证 scale 推断在首选概念无 decimals 时回落到下一个候选概念。
+
+    Args:
+        无。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    class _ConceptAwareXbrlQueryProvider:
+        def __init__(self, rows_by_concept: dict[str, list[Any]]) -> None:
+            self._rows_by_concept = rows_by_concept
+            self._last_concept: Optional[str] = None
+
+        def query(self) -> "_ConceptAwareXbrlQueryProvider":
+            return self
+
+        def by_concept(self, concept: str) -> "_ConceptAwareXbrlQueryProvider":
+            self._last_concept = concept
+            return self
+
+        def execute(self) -> list[Any]:
+            assert self._last_concept is not None
+            return self._rows_by_concept.get(self._last_concept, [])
+
+    provider = _ConceptAwareXbrlQueryProvider(
+        rows_by_concept={
+            "Revenues": [],
+            "Revenue": [{"decimals": "-6"}],
+        }
+    )
+    scale = sec_processor._infer_scale_from_xbrl_query(_as_xbrl(provider))
+    assert scale == "millions"
+
+
+@pytest.mark.unit
 def test_dataframe_to_records_handles_nan_and_whitespace() -> None:
     """验证 DataFrame 转 records 时的空值与空白标准化。
 

--- a/tests/engine/test_write_pipeline.py
+++ b/tests/engine/test_write_pipeline.py
@@ -4826,6 +4826,185 @@ def test_persist_manifest_merges_existing_results(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_load_or_create_manifest_purges_stale_artifacts_when_signature_changes(
+    tmp_path: Path,
+) -> None:
+    """验证 manifest 签名变更时会清空 chapters/ 与 sources_dedup.json。"""
+
+    runner = _build_runner(tmp_path)
+    runner._write_config.resume = True
+
+    chapters_dir = runner._store._chapters_dir
+    chapters_dir.mkdir(parents=True, exist_ok=True)
+    stale_chapter_md = chapters_dir / "01_stale.md"
+    stale_chapter_md.write_text("stale", encoding="utf-8")
+    stale_phase_dir = chapters_dir / "01_stale"
+    stale_phase_dir.mkdir(parents=True, exist_ok=True)
+    (stale_phase_dir / "phase.md").write_text("phase", encoding="utf-8")
+
+    output_dir = runner._store._output_dir
+    sources_path = output_dir / "sources_dedup.json"
+    sources_path.write_text("[]", encoding="utf-8")
+
+    existing_manifest = RunManifest(
+        version="write_manifest_v1",
+        signature="old-sig",
+        config=runner._write_config,
+        chapter_results={},
+    )
+    _write_manifest(runner._manifest_path, existing_manifest)
+
+    runner._store._load_or_create_manifest("new-sig")
+
+    assert not stale_chapter_md.exists()
+    assert not stale_phase_dir.exists()
+    assert not sources_path.exists()
+
+
+@pytest.mark.unit
+def test_purge_chapter_artifacts_removes_final_md_and_phase_dir(tmp_path: Path) -> None:
+    """验证单章重写清理同时删除最终正文与阶段产物子目录。"""
+
+    runner = _build_runner(tmp_path)
+    task = ChapterTask(
+        index=2,
+        title="经营表现与核心驱动",
+        skeleton="## 经营表现与核心驱动",
+    )
+    chapter_path = runner._store._chapter_file_path(task.index, task.title)
+    chapter_path.parent.mkdir(parents=True, exist_ok=True)
+    chapter_path.write_text("old final", encoding="utf-8")
+    phase_dir = chapter_path.parent / chapter_path.stem
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "initial_write.md").write_text("draft", encoding="utf-8")
+
+    runner._store.purge_chapter_artifacts(task)
+
+    assert not chapter_path.exists()
+    assert not phase_dir.exists()
+
+
+@pytest.mark.unit
+def test_run_middle_tasks_in_parallel_purges_artifacts_for_each_rerun_task(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """验证全文模式下并行批次中每个被重跑的章节都会先清理旧阶段产物。"""
+
+    runner = _build_runner(tmp_path)
+    monkeypatch.setattr(runner, "_resolve_middle_worker_limit", lambda: 2)
+
+    middle_tasks = [
+        ChapterTask(index=1, title="A", skeleton="## A"),
+        ChapterTask(index=2, title="B", skeleton="## B"),
+    ]
+
+    purged_titles: list[str] = []
+    original_purge = runner._store.purge_chapter_artifacts
+
+    def _record_purge(task: ChapterTask) -> None:
+        purged_titles.append(task.title)
+        original_purge(task)
+
+    monkeypatch.setattr(runner._store, "purge_chapter_artifacts", _record_purge)
+
+    def _run_worker(*, task: ChapterTask, company_name: str) -> ChapterResult:
+        del company_name
+        return ChapterResult(
+            index=task.index,
+            title=task.title,
+            status="passed",
+            content=f"## {task.title}\n正文",
+            audit_passed=True,
+        )
+
+    monkeypatch.setattr(runner, "_run_middle_task_worker", _run_worker)
+
+    manifest = RunManifest(
+        version="write_manifest_v1",
+        signature="sig",
+        config=_build_test_write_config(tmp_path),
+        chapter_results={},
+    )
+    runner._run_middle_tasks_in_parallel(
+        middle_tasks=middle_tasks,
+        chapter_results={},
+        manifest=manifest,
+        company_name="TestCo",
+    )
+    assert sorted(purged_titles) == ["A", "B"]
+
+
+@pytest.mark.unit
+def test_run_middle_tasks_in_parallel_purges_only_audit_failed_resume_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """验证 resume=True 时已通过 audit 的章节不会被清理，未通过的会被清理后重跑。"""
+
+    runner = _build_runner(tmp_path)
+    monkeypatch.setattr(runner, "_resolve_middle_worker_limit", lambda: 2)
+
+    middle_tasks = [
+        ChapterTask(index=1, title="A", skeleton="## A"),
+        ChapterTask(index=2, title="B", skeleton="## B"),
+    ]
+    chapter_results: dict[str, ChapterResult] = {
+        "A": ChapterResult(
+            index=1,
+            title="A",
+            status="passed",
+            content="## A\n旧正文",
+            audit_passed=True,
+        ),
+        "B": ChapterResult(
+            index=2,
+            title="B",
+            status="failed",
+            content="## B\n旧正文",
+            audit_passed=False,
+        ),
+    }
+
+    purged_titles: list[str] = []
+    original_purge = runner._store.purge_chapter_artifacts
+
+    def _record_purge(task: ChapterTask) -> None:
+        purged_titles.append(task.title)
+        original_purge(task)
+
+    monkeypatch.setattr(runner._store, "purge_chapter_artifacts", _record_purge)
+
+    monkeypatch.setattr(runner, "_should_skip_with_resume", lambda r: r is not None and r.audit_passed)
+
+    def _run_worker(*, task: ChapterTask, company_name: str) -> ChapterResult:
+        del company_name
+        return ChapterResult(
+            index=task.index,
+            title=task.title,
+            status="passed",
+            content=f"## {task.title}\n新正文",
+            audit_passed=True,
+        )
+
+    monkeypatch.setattr(runner, "_run_middle_task_worker", _run_worker)
+
+    manifest = RunManifest(
+        version="write_manifest_v1",
+        signature="sig",
+        config=_build_test_write_config(tmp_path),
+        chapter_results={},
+    )
+    runner._run_middle_tasks_in_parallel(
+        middle_tasks=middle_tasks,
+        chapter_results=chapter_results,
+        manifest=manifest,
+        company_name="TestCo",
+    )
+    assert purged_titles == ["B"]
+
+
+@pytest.mark.unit
 def test_read_manifest_from_dir_uses_manifest_lock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """验证打印报告路径读取 manifest 时也会包裹文件锁。"""
 

--- a/tests/fins/test_bs_ten_k_processor.py
+++ b/tests/fins/test_bs_ten_k_processor.py
@@ -12,7 +12,7 @@ import pytest
 from dayu.fins.processors import bs_ten_k_processor as module
 from dayu.fins.processors import ten_k_form_common
 from dayu.fins.processors.sec_form_section_common import _VirtualSection
-from dayu.fins.processors.ten_k_processor import _build_ten_k_markers
+from dayu.fins.processors.ten_k_form_common import _build_ten_k_markers
 
 
 class _SourceStub:

--- a/tests/fins/test_bs_ten_q_processor.py
+++ b/tests/fins/test_bs_ten_q_processor.py
@@ -18,19 +18,19 @@ import pytest
 
 from dayu.fins.processors.bs_ten_q_processor import BsTenQFormProcessor
 from dayu.fins.processors.sec_form_section_common import _VirtualSection
-from dayu.fins.processors.ten_q_processor import (
-    TenQFormProcessor,
+from dayu.fins.processors.ten_q_processor import TenQFormProcessor
+from dayu.fins.processors.ten_q_form_common import (
     _anchor_produces_meaningful_items,
     _build_ten_q_markers,
     _find_all_part_heading_positions,
     _select_best_part_i_anchor,
     expand_ten_q_virtual_sections_content,
 )
-from dayu.fins.processors.ten_q_processor import (
+from dayu.fins.processors.ten_q_form_common import (
     _PART_I_HEADING_PATTERN,
     _PART_II_HEADING_PATTERN,
 )
-from dayu.fins.processors.ten_q_processor import _html_flexible_word
+from dayu.fins.processors.ten_q_form_common import _html_flexible_word
 from dayu.fins.storage.local_file_source import LocalFileSource
 
 

--- a/tests/fins/test_bs_twenty_f_processor.py
+++ b/tests/fins/test_bs_twenty_f_processor.py
@@ -40,8 +40,8 @@ from dayu.fins.processors.twenty_f_form_common import (
     _repair_twenty_f_item_5_with_subheading_fallback,
     _repair_twenty_f_key_items_with_heading_fallback,
 )
-from dayu.fins.processors.twenty_f_processor import (
-    TwentyFFormProcessor,
+from dayu.fins.processors.twenty_f_processor import TwentyFFormProcessor
+from dayu.fins.processors.twenty_f_form_common import (
     _build_item_title,
     _build_twenty_f_markers,
     _find_twenty_f_key_heading_positions,
@@ -271,7 +271,7 @@ class TestBuildItemTitle:
             AssertionError: 断言失败时抛出。
         """
 
-        from dayu.fins.processors.twenty_f_processor import _TWENTY_F_ITEM_ORDER
+        from dayu.fins.processors.twenty_f_form_common import _TWENTY_F_ITEM_ORDER
 
         for token in _TWENTY_F_ITEM_ORDER:
             assert token in _TWENTY_F_ITEM_PART_MAP, f"Item {token} 缺少 Part 映射"
@@ -3776,7 +3776,7 @@ class TestSecRulesConsistency:
             AssertionError: 断言失败时抛出。
         """
 
-        from dayu.fins.processors.twenty_f_processor import _TWENTY_F_ITEM_ORDER
+        from dayu.fins.processors.twenty_f_form_common import _TWENTY_F_ITEM_ORDER
 
         for token in _TWENTY_F_ITEM_ORDER:
             assert token in _TWENTY_F_ITEM_PART_MAP, (

--- a/tests/fins/test_fins_tools_registry.py
+++ b/tests/fins/test_fins_tools_registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 import pytest
 
@@ -10,6 +10,7 @@ from dayu.engine.processors.source import Source
 from dayu.engine.tool_registry import ToolRegistry
 from dayu.fins.domain.document_models import CompanyMeta, SourceHandle
 from dayu.fins.domain.enums import SourceKind
+from dayu.fins.ingestion.service import FinsIngestionService
 from dayu.fins.tools import (
     FinsToolLimits,
     register_fins_ingestion_tools,
@@ -17,6 +18,16 @@ from dayu.fins.tools import (
 from tests.fins.legacy_repository_adapters import (
     register_fins_read_tools_with_legacy_repository as register_fins_read_tools,
 )
+
+
+def _stub_ingestion_service_factory() -> Callable[[str], FinsIngestionService]:
+    """返回一个仅用于注册路径的占位 ingestion service factory。
+
+    register_fins_ingestion_tools 在注册阶段不会触发 factory，因此可以用
+    返回 None 的 lambda 充当占位；通过 ``cast`` 跨过严格类型检查。
+    """
+
+    return cast(Callable[[str], FinsIngestionService], lambda _ticker: None)
 
 
 class DummySource:
@@ -356,7 +367,7 @@ def test_register_fins_ingestion_tools_registers_all_job_tool_names() -> None:
     registry = ToolRegistry()
     register_fins_ingestion_tools(
         registry,
-        service_factory=lambda _ticker: None,
+        service_factory=_stub_ingestion_service_factory(),
         manager_key="test-key",
     )
 
@@ -379,7 +390,7 @@ def test_ingestion_tool_schema_descriptions_follow_workflow() -> None:
     registry = ToolRegistry()
     register_fins_ingestion_tools(
         registry,
-        service_factory=lambda _ticker: None,
+        service_factory=_stub_ingestion_service_factory(),
         manager_key="test-key",
     )
 

--- a/tests/fins/test_sc13_section_processor_coverage.py
+++ b/tests/fins/test_sc13_section_processor_coverage.py
@@ -805,7 +805,7 @@ def test_sc13_item_pattern_matches_item_with_parenthesized_sub() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.sc13_processor import _SC13_ITEM_PATTERN
+    from dayu.fins.processors.sc13_form_common import _SC13_ITEM_PATTERN
 
     # 带括号子编号（BABA 格式）
     match = _SC13_ITEM_PATTERN.search("Item 1(a). Security and Issuer")
@@ -831,7 +831,7 @@ def test_sc13_item_pattern_matches_standard_formats() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.sc13_processor import _SC13_ITEM_PATTERN
+    from dayu.fins.processors.sc13_form_common import _SC13_ITEM_PATTERN
 
     # 标准带句点
     match = _SC13_ITEM_PATTERN.search("Item 1. Security and Issuer")
@@ -862,7 +862,7 @@ def test_sc13_item_pattern_no_false_positive_beyond_7() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.sc13_processor import _SC13_ITEM_PATTERN
+    from dayu.fins.processors.sc13_form_common import _SC13_ITEM_PATTERN
 
     assert _SC13_ITEM_PATTERN.search("Item 8. Extra Section") is None
     assert _SC13_ITEM_PATTERN.search("Item 0. Preamble") is None

--- a/tests/fins/test_sec_report_form_processors_coverage.py
+++ b/tests/fins/test_sec_report_form_processors_coverage.py
@@ -30,10 +30,8 @@ from dayu.fins.processors.bs_twenty_f_processor import (
 )
 from dayu.fins.processors.ten_k_processor import TenKFormProcessor
 from dayu.fins.processors.ten_q_processor import TenQFormProcessor
-from dayu.fins.processors.twenty_f_processor import (
-    TwentyFFormProcessor,
-    _trim_twenty_f_source_text,
-)
+from dayu.fins.processors.twenty_f_processor import TwentyFFormProcessor
+from dayu.fins.processors.twenty_f_form_common import _trim_twenty_f_source_text
 from dayu.fins.storage.local_file_source import LocalFileSource
 
 
@@ -380,9 +378,9 @@ def test_processor_toc_line_detection_supports_inline_toc() -> None:
         AssertionError: 断言失败时抛出。
     """
 
-    from dayu.fins.processors.ten_k_processor import _looks_like_toc_page_line as ten_k_toc
-    from dayu.fins.processors.ten_q_processor import _looks_like_toc_page_line as ten_q_toc
-    from dayu.fins.processors.twenty_f_processor import _looks_like_toc_page_line as twenty_f_toc
+    from dayu.fins.processors.ten_k_form_common import _looks_like_toc_page_line as ten_k_toc
+    from dayu.fins.processors.ten_q_form_common import _looks_like_toc_page_line as ten_q_toc
+    from dayu.fins.processors.twenty_f_form_common import _looks_like_toc_page_line as twenty_f_toc
 
     inline_toc = (
         "Item 1A Risk Factors 50 "
@@ -2295,7 +2293,7 @@ def test_correct_part_from_sec_rules_fills_missing() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_k_processor import _correct_part_from_sec_rules
+    from dayu.fins.processors.ten_k_form_common import _correct_part_from_sec_rules
 
     # Item 1 → Part I（缺失时补全）
     assert _correct_part_from_sec_rules("1", None) == "Part I"
@@ -2330,7 +2328,7 @@ def test_correct_part_from_sec_rules_fixes_wrong_part() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_k_processor import _correct_part_from_sec_rules
+    from dayu.fins.processors.ten_k_form_common import _correct_part_from_sec_rules
 
     # Items 2/3/4 误标为 Part II → 修正为 Part I
     assert _correct_part_from_sec_rules("2", "Part II") == "Part I"
@@ -2355,7 +2353,7 @@ def test_correct_part_from_sec_rules_preserves_correct() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_k_processor import _correct_part_from_sec_rules
+    from dayu.fins.processors.ten_k_form_common import _correct_part_from_sec_rules
 
     assert _correct_part_from_sec_rules("1", "Part I") == "Part I"
     assert _correct_part_from_sec_rules("2", "Part I") == "Part I"
@@ -2378,7 +2376,7 @@ def test_correct_part_unknown_item_preserves_original() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_k_processor import _correct_part_from_sec_rules
+    from dayu.fins.processors.ten_k_form_common import _correct_part_from_sec_rules
 
     assert _correct_part_from_sec_rules("99", "Part X") == "Part X"
     assert _correct_part_from_sec_rules("99", None) is None
@@ -2406,7 +2404,7 @@ def test_ten_q_anchor_validation_rejects_running_header() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_q_processor import (
+    from dayu.fins.processors.ten_q_form_common import (
         _anchor_produces_meaningful_items,
         _find_all_part_heading_positions,
         _select_best_part_i_anchor,
@@ -2466,7 +2464,7 @@ def test_ten_q_anchor_validation_accepts_normal_document() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_q_processor import (
+    from dayu.fins.processors.ten_q_form_common import (
         _find_all_part_heading_positions,
         _select_best_part_i_anchor,
     )
@@ -2504,7 +2502,7 @@ def test_anchor_produces_meaningful_items_rejects_short_spans() -> None:
     Raises:
         AssertionError: 断言失败时抛出。
     """
-    from dayu.fins.processors.ten_q_processor import (
+    from dayu.fins.processors.ten_q_form_common import (
         _anchor_produces_meaningful_items,
     )
 

--- a/tests/fins/test_six_k_section_processor_coverage.py
+++ b/tests/fins/test_six_k_section_processor_coverage.py
@@ -2728,6 +2728,49 @@ def test_parse_ocr_numeric_token_empty_after_clean() -> None:
 
 
 @pytest.mark.unit
+def test_parse_ocr_numeric_token_handles_currency_in_parenthesized_negative() -> None:
+    """验证 OCR 括号负数含货币符号时正确解析为负数浮点。
+
+    Args:
+        无。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    from dayu.fins.processors.six_k_form_common import _parse_ocr_numeric_token
+
+    assert _parse_ocr_numeric_token("($1,234)") == -1234.0
+    assert _parse_ocr_numeric_token("(€1,234)") == -1234.0
+    assert _parse_ocr_numeric_token("$500") == 500.0
+    assert _parse_ocr_numeric_token("£12,345.6") == 12345.6
+
+
+@pytest.mark.unit
+def test_parse_ocr_numeric_token_returns_none_on_unparseable() -> None:
+    """验证无法解析为浮点的 token 返回 None 而不抛 ValueError。
+
+    Args:
+        无。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: 断言失败时抛出。
+    """
+
+    from dayu.fins.processors.six_k_form_common import _parse_ocr_numeric_token
+
+    assert _parse_ocr_numeric_token("abc") is None
+    assert _parse_ocr_numeric_token("(abc)") is None
+    assert _parse_ocr_numeric_token("-") is None
+
+
+@pytest.mark.unit
 def test_extract_fiscal_period_from_ocr_match_fy() -> None:
     """验证 OCR 期间 match 提取 FY period（12M → FY）。
 


### PR DESCRIPTION
## Summary

完成 0428 code review 报告中 **low 风险 finding** 的逐批验真与修复。覆盖 15 个批次，共 16 次提交。每批均严格按 CLAUDE.md 思考纪律执行：先验真动机、再用第一性原理判定 root cause，仅对真问题落地修复。

### 主要修复
- **批 1（Engine 协议/消息角色）**：reasoning_content 通过 metadata 透传；duplicate hint 与压缩摘要切到 system 角色；trace 终止原因补齐。
- **批 2（Host run 状态机）**：CancellationBridge 取消意图保留；register_run 异常下 run 不再卡 CREATED；_start_run 尊重已存在取消意图。
- **批 3（context budget / compaction）**：CHARS_PER_TOKEN 中文友好估算；压缩后二次预算检查；摘要业务语义保留。
- **批 4（Host 恢复路径）**：resume failure 与 stale cleanup 竞态修复；pre_resume_state NULL 不再静默降级；CancellationBridge 异常路径有日志。
- **批 5（CLI/Service 入口）**：UI 直引 Host 改协议；Service 不再 import fins 实现类；scene 默认值与异常路径加固。
- **批 6（CLI 交互态控制流）**：跨 turn lock 复用；fence 检测窗口修正；RESUMING 超时窗口可配置。
- **批 8（Engine 公共暴露）**：tools/__init__ 不再泄漏 web_recovery 内部；processor_registry 查找路径优化。
- **批 9（WeChat 链路）**：message_id 级去重；缓存有界化；claim/fd 异常路径释放；超时日志区分。
- **批 10（Write 错误处理）**：缺失章节回退落日志；company name/meta_summary 异常不再静默吞；replay 无退避修复。
- **批 12（Fins 数值/期间）**：OCR 括号负数兼容货币符号。
- **批 13（Fins XBRL 推断）**：Revenue concept 候选扩展；ISO 4217 货币码白名单。
- **批 14a（清理兼容性 re-export）**：6 个 SEC processor 模块删除 re-export，4 个测试文件迁移导入路径。
- **批 15（会话记忆设计文档）**：README 单总池消费顺序与代码对齐；patch 字段三态契约写入 docstring。
- **批 11（Write 恢复产物清理）**：通过 #97/#98 拆分独立 PR 已 merge。

### 拒绝/未修复说明
按第一性原理判定为非 bug、动机不足或属新增需求的 finding：#56 #57 #35 #36 #37 #92 #87 #83 #84 #85 #86 #88 #89 #90 #91 等，均在 review 文档就地标注理由。

## Test plan

- [x] 各批均运行受影响 pytest，全部通过
- [x] pyright 0 errors / 0 warnings
- [x] 各批触发的 README 同步更新（`dayu/host/README.md` 等）
- [x] 不引入新增 mypy/pyright 报错