### PR TITLE
fix: 汇总中修复风险 code review 修复

### DIFF
--- a/dayu/cli/commands/fins.py
+++ b/dayu/cli/commands/fins.py
@@ -15,6 +15,7 @@ from typing import AsyncIterator, cast
 from dayu.contracts.fins import (
     DownloadCommandPayload,
     DownloadProgressPayload,
+    DownloadResultData,
     FinsCommand,
     FinsCommandName,
     FinsEvent,
@@ -25,10 +26,14 @@ from dayu.contracts.fins import (
     ProcessCommandPayload,
     ProcessFilingCommandPayload,
     ProcessMaterialCommandPayload,
+    ProcessResultData,
+    ProcessSingleResultData,
     UploadFilingCommandPayload,
+    UploadFilingResultData,
     UploadFilingsFromCommandPayload,
     UploadFilingsFromResultData,
     UploadMaterialCommandPayload,
+    UploadMaterialResultData,
 )
 from dayu.fins.cli_support import (
     _coerce_document_ids_input as coerce_document_ids_input,
@@ -227,7 +232,36 @@ def _should_log_fins_progress_as_info(command_name: str) -> bool:
     return command_name in {"upload_filing", "upload_material"}
 
 
-_FINS_FAILURE_STATUS = "failed"
+_FINS_DOWNLOAD_SUCCESS_STATUSES: frozenset[str] = frozenset({"ok", "downloaded", "skipped", "cancelled"})
+_FINS_UPLOAD_SUCCESS_STATUSES: frozenset[str] = frozenset({"ok", "uploaded", "deleted", "skipped"})
+_FINS_PROCESS_SUCCESS_STATUSES: frozenset[str] = frozenset({"ok", "cancelled"})
+_FINS_PROCESS_SINGLE_SUCCESS_STATUSES: frozenset[str] = frozenset({"processed", "skipped"})
+_FINS_FAILURE_STATUS: str = "failed"
+
+
+def _classify_fins_status(status: str, success_set: frozenset[str]) -> bool:
+    """按 per-result-type 白名单判定单条结果是否需要以失败码上报。
+
+    Args:
+        status: 结果对象的 status 字段（已 strip）。
+        success_set: 该结果类型已枚举的成功 status 白名单。
+
+    Returns:
+        当 status 命中 ``"failed"`` 时返回 ``True``；命中成功白名单时返回 ``False``。
+
+    Raises:
+        ValueError: status 既不在成功白名单也不在 ``"failed"`` 时抛出，
+            强制未来新增 status 必须显式归类，避免被静默归"成功"。
+    """
+
+    if status == _FINS_FAILURE_STATUS:
+        return True
+    if status in success_set:
+        return False
+    raise ValueError(
+        f"未知财报命令 status，未显式归类成功/失败: status={status!r}; "
+        f"已知成功集合={sorted(success_set)}; 失败={_FINS_FAILURE_STATUS!r}"
+    )
 
 
 def _is_fins_result_failure(result: FinsResultData) -> bool:
@@ -240,16 +274,25 @@ def _is_fins_result_failure(result: FinsResultData) -> bool:
         当结果显式标注 ``failed`` 状态时返回 ``True``；
         ``UploadFilingsFromResultData`` 没有 status 字段，本身代表
         脚本生成步骤已经成功完成，统一返回 ``False``；
-        其它已知非失败 status（如 ``ok`` / ``downloaded`` / ``uploaded`` /
-        ``skipped`` / ``deleted``）均视为成功，不影响退出码。
+        其它结果按 per-result-type 白名单分支显式归类。
 
     Raises:
-        无。
+        ValueError: 结果 status 既不在成功白名单也不是 ``"failed"`` 时抛出，
+            通过类型 ``match`` 的穷尽性 + 白名单 ``case _`` 双重防线，
+            强迫未来新增结果类型 / 新增 status 必须显式归类。
     """
 
-    if isinstance(result, UploadFilingsFromResultData):
-        return False
-    return result.status == _FINS_FAILURE_STATUS
+    match result:
+        case UploadFilingsFromResultData():
+            return False
+        case DownloadResultData():
+            return _classify_fins_status(result.status, _FINS_DOWNLOAD_SUCCESS_STATUSES)
+        case UploadFilingResultData() | UploadMaterialResultData():
+            return _classify_fins_status(result.status, _FINS_UPLOAD_SUCCESS_STATUSES)
+        case ProcessResultData():
+            return _classify_fins_status(result.status, _FINS_PROCESS_SUCCESS_STATUSES)
+        case ProcessSingleResultData():
+            return _classify_fins_status(result.status, _FINS_PROCESS_SINGLE_SUCCESS_STATUSES)
 
 
 def _describe_fins_status(result: FinsResultData) -> str:
@@ -337,9 +380,15 @@ def run_fins_command(args: argparse.Namespace) -> int:
         return 1
     print(format_fins_cli_result(command.name, result))
     # FinsResultData 各 variant（除 UploadFilingsFromResultData 之外）携带
-    # status 字段，"succeeded" 表示成功；其它取值（如 "failed"/"skipped"）
-    # 都视为非成功，命令需要返回非零退出码以让 shell 与 CI 管线感知。
-    if _is_fins_result_failure(result):
+    # status 字段，按 per-result-type 白名单显式归类成功/失败；未在白名单
+    # 也未命中 "failed" 的 status 视为契约违规，按非零退出码上报，避免被
+    # 静默归"成功"导致 CI 失真。
+    try:
+        is_failure = _is_fins_result_failure(result)
+    except ValueError as exc:
+        Log.error(f"财报命令结果 status 未显式归类: {exc}", module=MODULE)
+        return 1
+    if is_failure:
         Log.warn(
             f"财报命令以非成功状态结束: command={command.name.value}, status={_describe_fins_status(result)}",
             module=MODULE,

--- a/dayu/cli/dependency_setup.py
+++ b/dayu/cli/dependency_setup.py
@@ -39,9 +39,9 @@ from dayu.execution.options import (
 )
 from dayu.execution.runtime_config import AgentRuntimeConfig, RunnerRuntimeConfig
 from dayu.fins.domain.enums import SourceKind
-from dayu.fins.service_runtime import DefaultFinsRuntime
+from dayu.fins.service_runtime import DefaultFinsRuntime, FinsRuntimeProtocol
 from dayu.fins.storage import FsSourceDocumentRepository
-from dayu.host import Host
+from dayu.host import Host, purge_sessions_from_host_db
 from dayu.log import Log, set_level_from_flags
 from dayu.services import prepare_host_runtime_dependencies, WriteRunConfig
 from dayu.services.chat_service import ChatService
@@ -265,8 +265,6 @@ def _purge_old_interactive_session(
     old_session_id = resolve_interactive_state_session_id(old_state)
     host_db_path = build_host_store_default_path(workspace_dir)
 
-    from dayu.host.host_cleanup import purge_sessions_from_host_db
-
     total_pending, total_outbox = purge_sessions_from_host_db(
         host_db_path=host_db_path,
         session_ids=[old_session_id],
@@ -479,7 +477,7 @@ def _prepare_cli_host_dependencies(
     ResolvedExecutionOptions,
     SceneExecutionAcceptancePreparer,
     Host,
-    DefaultFinsRuntime,
+    FinsRuntimeProtocol,
 ]:
     """准备 CLI 的 Host 级稳定依赖。
 
@@ -570,7 +568,7 @@ def _build_chat_service(
     *,
     host: Host,
     scene_execution_acceptance_preparer: SceneExecutionAcceptancePreparer,
-    fins_runtime: DefaultFinsRuntime,
+    fins_runtime: FinsRuntimeProtocol,
 ) -> ChatService:
     """构建交互聊天服务。
 
@@ -589,6 +587,7 @@ def _build_chat_service(
     return ChatService(
         host=host,
         scene_execution_acceptance_preparer=scene_execution_acceptance_preparer,
+        default_scene_name="interactive",
         company_name_resolver=fins_runtime.get_company_name,
         session_source=SessionSource.CLI,
     )
@@ -598,7 +597,7 @@ def _build_prompt_service(
     *,
     host: Host,
     scene_execution_acceptance_preparer: SceneExecutionAcceptancePreparer,
-    fins_runtime: DefaultFinsRuntime,
+    fins_runtime: FinsRuntimeProtocol,
 ) -> PromptService:
     """构建单轮 prompt 服务。
 
@@ -627,7 +626,7 @@ def _build_write_service(
     host: Host,
     workspace: WorkspaceResources,
     scene_execution_acceptance_preparer: SceneExecutionAcceptancePreparer,
-    fins_runtime: DefaultFinsRuntime,
+    fins_runtime: FinsRuntimeProtocol,
 ) -> WriteService:
     """构建写作服务。
 

--- a/dayu/cli/interactive_ui.py
+++ b/dayu/cli/interactive_ui.py
@@ -609,6 +609,11 @@ def _resume_interactive_pending_turn_if_needed(
 ) -> None:
     """在进入 REPL 前恢复当前 interactive session 的 pending turn。
 
+    设计意图：
+    - 恢复链路上的任何失败都不应阻止 REPL 启动；下一轮新输入仍可触发 pending turn 的
+      二次恢复或被 Host 自动清理。本函数把"恢复失败 → 用户友好提示 → 静默放过"统一
+      在此处收口，调用方只需处理 ``KeyboardInterrupt``。
+
     Args:
         session: interactive 使用的 ChatService 协议实现。
         session_id: 当前 interactive 绑定的 Host session ID；为空时直接跳过恢复。
@@ -619,7 +624,7 @@ def _resume_interactive_pending_turn_if_needed(
         无。
 
     Raises:
-        Exception: 当 pending turn 仍然存在且恢复失败时，继续向上抛出原始异常。
+        KeyboardInterrupt: 用户在恢复阶段按 Ctrl-C 时由调用方处理，本函数不拦截。
     """
 
     if session_id is None:
@@ -650,14 +655,15 @@ def _resume_interactive_pending_turn_if_needed(
         try:
             asyncio.run(_resume_and_consume())
         except Exception as exc:
-            if not has_resumable_pending_turn(
+            still_resumable = has_resumable_pending_turn(
                 session,
                 session_id=pending_turn.session_id,
-                scene_name="interactive",
+                scene_name=scene_name,
                 pending_turn_id=pending_turn.pending_turn_id,
-            ):
-                Log.warning(
-                    "interactive pending turn 恢复失败，但记录已被 Host 清理，继续进入会话"
+            )
+            if still_resumable:
+                Log.error(
+                    "interactive pending turn 恢复失败，pending turn 仍可恢复，跳过本次恢复继续进入会话"
                     f" session_id={pending_turn.session_id}"
                     f" pending_turn_id={pending_turn.pending_turn_id}"
                     f" error={exc}",
@@ -665,10 +671,21 @@ def _resume_interactive_pending_turn_if_needed(
                 )
                 _render_warning_or_error(
                     state,
-                    "[warning] 上一轮 pending turn 恢复失败，但记录已被清理；当前会话继续可用",
+                    "[error] 上一轮 pending turn 恢复失败，会话继续可用，可在下一轮输入后重试",
                 )
                 return
-            raise
+            Log.warning(
+                "interactive pending turn 恢复失败，但记录已被 Host 清理，继续进入会话"
+                f" session_id={pending_turn.session_id}"
+                f" pending_turn_id={pending_turn.pending_turn_id}"
+                f" error={exc}",
+                module=MODULE,
+            )
+            _render_warning_or_error(
+                state,
+                "[warning] 上一轮 pending turn 恢复失败，但记录已被清理；当前会话继续可用",
+            )
+            return
     finally:
         status_line.stop()
         state.status_line = None

--- a/dayu/engine/tools/web_tools.py
+++ b/dayu/engine/tools/web_tools.py
@@ -543,6 +543,8 @@ def _normalize_url_for_http(url: str) -> str:
     parsed = urlparse(url)
     if not parsed.scheme or not parsed.netloc:
         raise ValueError(f"无效 URL: {url}")
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise ValueError(f"不允许的 URL scheme: {parsed.scheme} (url={url})")
 
     hostname = parsed.hostname or ""
     if not hostname:

--- a/dayu/fins/processors/sec_table_extraction.py
+++ b/dayu/fins/processors/sec_table_extraction.py
@@ -2166,7 +2166,10 @@ def _strip_trailing_footnote(text: str) -> str:
 
     cleaned = re.sub(r"(?<=\d)\[(?:\d+|[a-zA-Z])\]\s*$", "", text).strip()
     cleaned = re.sub(r"(?<=\d)\((?:\d+|[a-zA-Z])\)\s*$", "", cleaned).strip()
-    cleaned = re.sub(r"(?<=\d)[a-zA-Z]\s*$", "", cleaned).strip()
+    # 仅剥离裸尾小写单字母脚注（SEC 财报续序脚注约定为 a/b/c…）；
+    # 保留大写单字母后缀（M/K/B/T magnitude、Q/K form 标识等），由 _STRICT_NUMERIC_TEXT_PATTERN
+    # 在 _normalize_numeric_text 内主动判 None，避免数量级被静默丢失。
+    cleaned = re.sub(r"(?<=\d)[a-z]\s*$", "", cleaned).strip()
     return cleaned
 
 

--- a/dayu/fins/processors/sec_xbrl_query.py
+++ b/dayu/fins/processors/sec_xbrl_query.py
@@ -581,12 +581,18 @@ def _extract_concept_local_name(concept: str) -> str:
         RuntimeError: 无。
     """
 
-    normalized = concept.replace("_", ":").strip()
-    if not normalized:
+    stripped = concept.strip()
+    if not stripped:
         return ""
-    if ":" in normalized:
-        return normalized.split(":")[-1].strip()
-    return normalized
+    # 约定：XBRL fact 行里下划线形式的 concept 由 edgartools 等库把唯一的
+    # namespace 分隔符 `:` 替换成 `_`，本地名内部仍可含 `_`（自定义 taxonomy 常见）。
+    # 因此首个分隔符之后的全部都属本地名，必须用限次 split 而不是 `[-1]`/全文 replace，
+    # 否则形如 `company_Custom_Metric` 会被错误截短为 `Metric`。
+    if ":" in stripped:
+        return stripped.split(":", 1)[1].strip()
+    if "_" in stripped:
+        return stripped.split("_", 1)[1].strip()
+    return stripped
 
 
 def _normalize_concept_match_key(value: str) -> str:

--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -675,6 +675,6 @@ Service 单测写"如何调 Host"时：
 7. `dayu/host/concurrency.py` — lane 合并与 `acquire_many`；
 8. `dayu/host/conversation_*.py` — 两层记忆与 compaction；
 9. `dayu/host/startup_preparation.py` — 配置规范化与默认值；
-10. `dayu/host/host_cleanup.py` — 启动恢复的编排。
+10. `dayu/host/host_cleanup.py` — Host 包对装配期一次性会话残留清理的稳定 API（`purge_sessions_from_host_db`），由 UI 装配点在构造新 Host 之前 / 拆 service 时按 `host_db_path + session_ids` 直接调用。
 
 最后，任何与本文叙述冲突之处以代码为准；发现不一致请修正 README，而不是反过来。

--- a/dayu/host/__init__.py
+++ b/dayu/host/__init__.py
@@ -1,6 +1,7 @@
 """Host 层公共导出。"""
 
 from dayu.host.host import Host
+from dayu.host.host_cleanup import purge_sessions_from_host_db
 from dayu.host.host_execution import HostExecutorProtocol
 from dayu.host.startup_preparation import ResolvedHostConfig, resolve_host_config
 
@@ -8,5 +9,6 @@ __all__ = [
     "Host",
     "HostExecutorProtocol",
     "ResolvedHostConfig",
+    "purge_sessions_from_host_db",
     "resolve_host_config",
 ]

--- a/dayu/host/host_cleanup.py
+++ b/dayu/host/host_cleanup.py
@@ -1,7 +1,11 @@
 """Host 层会话数据清理工具。
 
-提供按 session_id 批量清理 pending turns 和 reply outbox 的能力，
-供 UI 层在 service uninstall 时调用。
+该模块作为 Host 包对装配期（CLI/wechat 启动或 service uninstall）的稳定公开
+API，提供按 ``session_id`` 批量清理 pending turns 与 reply outbox 的能力。
+调用时机通常发生在"无在线 Host 实例"场景（构造新 Host 之前清理上一次残留，
+或拆 service 时清理 daemon 关联会话），因此契约直接以 ``host_db_path`` 为入参，
+无需依赖 Host 聚合根；UI 装配点应通过 ``from dayu.host import
+purge_sessions_from_host_db`` 引用，避免直接 import 该子模块。
 """
 
 from __future__ import annotations

--- a/dayu/host/reply_outbox_store.py
+++ b/dayu/host/reply_outbox_store.py
@@ -33,8 +33,38 @@ MODULE = "HOST.REPLY_OUTBOX_STORE"
 
 STALE_IN_PROGRESS_ERROR_MESSAGE = "stale in_progress recovery"
 
+# stale cleanup 的 max_age 下界。低于该值时正在执行交付的 record（刚 claim、
+# 尚未 mark_delivered）会与 cleanup 的 CAS（``state='delivery_in_progress'``）
+# 在同一时间窗内竞争，导致已成功交付被错误地回退为 FAILED_RETRYABLE，引发
+# 重复投递或交付丢失。下界由 store 自身强制，避免调用方因配置错误踩到 race
+# window。如确需更小的窗口，需要先把 mark_delivered 与 cleanup 之间的隔离
+# 机制（例如 fence token / leased ownership）补齐再放开下界。
+MIN_STALE_AGE = timedelta(minutes=5)
+
 
 from dayu.host._datetime_utils import now_utc as _now_utc, parse_dt as _parse_dt, serialize_dt as _serialize_dt
+
+
+def _validate_stale_max_age(max_age: timedelta) -> None:
+    """校验 stale cleanup 的 max_age 不低于 ``MIN_STALE_AGE``。
+
+    Args:
+        max_age: 调用方传入的 stale 阈值。
+
+    Returns:
+        无。
+
+    Raises:
+        ValueError: 当 ``max_age`` 小于 ``MIN_STALE_AGE`` 时抛出，强制调用方
+            为正在执行交付的 record 留出足够的非竞态窗口。
+    """
+
+    if max_age < MIN_STALE_AGE:
+        raise ValueError(
+            "cleanup_stale_in_progress_deliveries 的 max_age 不能小于 "
+            f"{MIN_STALE_AGE}; 当前传入={max_age}; "
+            "下界用于隔离 mark_delivered CAS 与 stale cleanup CAS 的竞态窗口"
+        )
 
 
 def _normalize_text(value: str, *, field_name: str) -> str:
@@ -394,15 +424,18 @@ class InMemoryReplyOutboxStore:
         """把超过 max_age 的 DELIVERY_IN_PROGRESS 回退为 FAILED_RETRYABLE。
 
         Args:
-            max_age: 超过多久未收到终态的 IN_PROGRESS 视为 stale。
+            max_age: 超过多久未收到终态的 IN_PROGRESS 视为 stale；
+                必须 ``>= MIN_STALE_AGE``，避免与 ``mark_delivered`` CAS
+                竞态导致已成功交付被回退。
 
         Returns:
             被回退的 delivery_id 列表。
 
         Raises:
-            无。
+            ValueError: ``max_age < MIN_STALE_AGE`` 时抛出。
         """
 
+        _validate_stale_max_age(max_age)
         cutoff = _now_utc() - max_age
         stale_ids: list[str] = []
         for delivery_id, record in list(self._records.items()):
@@ -817,15 +850,18 @@ class SQLiteReplyOutboxStore:
         """把超过 max_age 的 DELIVERY_IN_PROGRESS 回退为 FAILED_RETRYABLE。
 
         Args:
-            max_age: 超过多久未收到终态的 IN_PROGRESS 视为 stale。
+            max_age: 超过多久未收到终态的 IN_PROGRESS 视为 stale；
+                必须 ``>= MIN_STALE_AGE``，避免与 ``mark_delivered`` CAS
+                竞态导致已成功交付被回退。
 
         Returns:
             被回退的 delivery_id 列表。
 
         Raises:
-            无。
+            ValueError: ``max_age < MIN_STALE_AGE`` 时抛出。
         """
 
+        _validate_stale_max_age(max_age)
         cutoff = _serialize_dt(_now_utc() - max_age)
         now_ts = _serialize_dt(_now_utc())
         conn = self._host_store.get_connection()

--- a/dayu/services/chat_service.py
+++ b/dayu/services/chat_service.py
@@ -45,6 +45,7 @@ class ChatService(ChatServiceProtocol):
 
     host: ConversationalExecutionGatewayProtocol
     scene_execution_acceptance_preparer: SceneExecutionAcceptancePreparer
+    default_scene_name: str
     company_name_resolver: Callable[[str], str] | None = None
     session_source: SessionSource = SessionSource.API
     # 以弱引用持有每 session 的串行锁：只要存在至少一个生成器/任务引用该锁对象，
@@ -195,11 +196,18 @@ class ChatService(ChatServiceProtocol):
             ValueError: 用户输入为空或 scene 非法时抛出。
         """
 
-        # scene_name 语义对齐：契约中 None 表示"未指定"，应走默认；
-        # 显式传入空串属于调用方错误，必须报错而不是被静默覆盖。
+        # scene_name 语义对齐：契约中 None 表示"未指定"，应走装配期注入的默认；
+        # 显式传入空串 / 装配期注入空白串均属契约违规，必须立刻抛出明确错误，
+        # 不能被静默 strip 掉后退化成下游 "scene 不存在" 这类误导性诊断。
         raw_scene_name = request.scene_name
         if raw_scene_name is None:
-            scene_name = "interactive"
+            stripped_default = self.default_scene_name.strip()
+            if not stripped_default:
+                raise ValueError(
+                    "ChatService.default_scene_name 装配期未注入有效值；"
+                    "请由装配点显式传入非空 scene_name"
+                )
+            scene_name = stripped_default
         else:
             stripped_scene_name = str(raw_scene_name).strip()
             if not stripped_scene_name:

--- a/dayu/services/internal/write_pipeline/audit_rules.py
+++ b/dayu/services/internal/write_pipeline/audit_rules.py
@@ -1293,6 +1293,75 @@ def _rebuild_audit_decision_with_confirmation(
     )
 
 
+def _rebuild_anchor_followup_audit_decision(
+    *,
+    audit_decision: AuditDecision,
+    confirmation_result: EvidenceConfirmationResult,
+) -> AuditDecision:
+    """在锚点轻量修复回退路径上，把被 merge 阶段静默移除的 supported_* + anchor_fix 违规重建回审计决策。
+
+    背景：``_merge_confirmed_evidence_results`` 在 confirm 合并时，对
+    ``SUPPORTED_BUT_ANCHOR_TOO_COARSE`` / ``SUPPORTED_ELSEWHERE_IN_SAME_FILING``
+    且 ``anchor_fix`` 非空的 entry 直接 ``continue``——预设后续 ``maybe_rewrite_evidence_anchors``
+    会用机械 rewrite 吸收这些违规。但若机械 rewrite 后置校验失败、原文回退，
+    那些被假设会被吸收的违规仍然真实存在却已不在 audit_decision 里，
+    审计 gate 会把章节误判为 passed。
+
+    本 helper 仅在校验失败回退路径调用：基于现有 ``confirmation_result``
+    重建对应的 S7 followup 违规并合入当前 audit_decision，
+    再用 ``_recompute_audit_result`` 重算 ``passed`` / ``category``。
+    若没有需要恢复的 entry，则原样返回。
+
+    Args:
+        audit_decision: 当前最终审计结果（已经过 confirm merge）。
+        confirmation_result: 本轮证据复核结果。
+
+    Returns:
+        若有需要恢复的违规则返回新的 ``AuditDecision``；否则返回原对象。
+
+    Raises:
+        无。
+    """
+
+    pending_entries = [
+        entry
+        for entry in confirmation_result.entries
+        if entry.status
+        in {
+            EvidenceConfirmationStatus.SUPPORTED_BUT_ANCHOR_TOO_COARSE,
+            EvidenceConfirmationStatus.SUPPORTED_ELSEWHERE_IN_SAME_FILING,
+        }
+        and entry.anchor_fix is not None
+    ]
+    if not pending_entries:
+        return audit_decision
+    existing_followups = [
+        violation
+        for violation in audit_decision.violations
+        if any(
+            _is_supported_anchor_followup_violation_for_entry(violation=violation, entry=entry)
+            for entry in pending_entries
+        )
+    ]
+    missing_entries = [
+        entry
+        for entry in pending_entries
+        if not any(
+            _is_supported_anchor_followup_violation_for_entry(violation=violation, entry=entry)
+            for violation in existing_followups
+        )
+    ]
+    if not missing_entries:
+        return audit_decision
+    rebuilt_violations: list[Violation] = list(audit_decision.violations)
+    rebuilt_violations.extend(_build_supported_anchor_followup_violation(entry) for entry in missing_entries)
+    return _rebuild_audit_decision_with_confirmation(
+        audit_decision=audit_decision,
+        violations=rebuilt_violations,
+        confirmation_result=confirmation_result,
+    )
+
+
 def _drop_resolved_supported_anchor_violations(
     *,
     audit_decision: AuditDecision,

--- a/dayu/services/internal/write_pipeline/chapter_audit_coordinator.py
+++ b/dayu/services/internal/write_pipeline/chapter_audit_coordinator.py
@@ -29,6 +29,7 @@ from dayu.services.internal.write_pipeline.audit_rules import (
     _log_chapter_confirm_result,
     _log_chapter_confirm_start,
     _merge_confirmed_evidence_results,
+    _rebuild_anchor_followup_audit_decision,
     _run_programmatic_audits,
 )
 from dayu.services.internal.write_pipeline.artifact_store import ArtifactStore, _build_phase_artifact_name
@@ -410,6 +411,16 @@ class ChapterAuditCoordinator:
                 applied=False,
                 skip_reason="no_anchor_rewrite_candidates",
             )
+
+        # 一旦确认存在 anchor rewrite 候选，先把 confirm merge 阶段因
+        # ``entry.anchor_fix is not None`` 静默丢弃的 supported_* 违规重建为 S7
+        # followup 违规，作为后续所有“未真正落地 rewrite”早退路径的基线 audit_decision。
+        # 仅当后续 rewrite 真正成功并通过后验校验时，再交由
+        # ``_drop_resolved_supported_anchor_violations`` 把已被吸收的 S7 followup 移除。
+        audit_decision = _rebuild_anchor_followup_audit_decision(
+            audit_decision=audit_decision,
+            confirmation_result=confirmation_result,
+        )
 
         rewritten_evidence_lines, resolved_violation_ids = _rewrite_evidence_lines_and_collect_resolved_anchor_issues(
             chapter_markdown=current_content,

--- a/dayu/services/internal/write_pipeline/chapter_execution_coordinator.py
+++ b/dayu/services/internal/write_pipeline/chapter_execution_coordinator.py
@@ -385,6 +385,13 @@ class ChapterExecutionCoordinator:
             execution_state.process_state["repair_skipped"] = True
             execution_state.process_state["final_stage"] = "fast_written"
             Log.info(f"fast 模式跳过审计链路: {task.title}", module=MODULE)
+            # fast 模式下 ``audit_passed`` 强制为 ``False`` 是有意为之：
+            # fast 产物不写 audit artifact（未调 ``persist_phase_audit_artifact``），
+            # ``WritePipelineRunner._recover_prior_chapter_result_from_artifacts`` 仅承认
+            # 落盘 audit artifact 中 ``pass=True`` 的章节作为 resume 复用来源，
+            # 因此 fast 产物天然不会被 non-fast resume 误当成"已通过"。
+            # 同时 ``_satisfies_audit_gate_for_current_mode`` 在当前进程为 fast 时
+            # 直接放行，``audit_passed=False`` 不会影响本进程内的成功判定。
             return ChapterResult(
                 index=task.index,
                 title=task.title,

--- a/dayu/services/internal/write_pipeline/scene_executor.py
+++ b/dayu/services/internal/write_pipeline/scene_executor.py
@@ -25,6 +25,7 @@ helper 层 ``_run_scene_prompt_with_retry`` 显式区分两类失败路径：
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncIterator, Awaitable
 from types import SimpleNamespace
@@ -38,6 +39,10 @@ from dayu.log import Log
 from dayu.services.internal.write_pipeline.audit_formatting import (
     _extract_markdown_content,
     parse_markdown_scene_output,
+)
+from dayu.services.internal.write_pipeline.audit_formatting import (
+    _extract_json_text,
+    _extract_markdown_content,
 )
 from dayu.services.internal.write_pipeline.audit_rules import (
     ConfirmOutputError,
@@ -921,9 +926,16 @@ class ScenePromptRunner:
 
 
 def _parse_audit_output(raw_text: str) -> AuditDecision:
-    """审计 success_parser：当前 ``_parse_audit_decision`` 自身已对脏数据
-    返回 ``AuditDecision``（不抛 ``ValueError``），故本 wrapper 仅原样透传，
-    保持 helper 协议形状一致。
+    """审计 success_parser：脏数据时抛 ``ValueError``，触发 helper 的
+    ``replay_on_parse_failure`` 兜底。
+
+    设计意图：
+    - JSON 不可解析 / 缺失（典型如 LLM 退化为自然语言解释）属于"脏数据"，
+      项目既有 Host.replay 兜底机制要求 success_parser 抛 ``ValueError``，
+      由 ``_run_scene_prompt_with_retry`` 进入 replay 路径让 Agent 自纠。
+    - JSON 形态合法但内部字段不规范（缺 violations / pass 等）属于"业务退化"，
+      由 ``_parse_audit_decision`` 内部规范化处理，仍返回有效 ``AuditDecision``，
+      不应触发 replay；replay 在已是合法 JSON 上重试无意义。
 
     Args:
         raw_text: 审计 Agent 原始输出。
@@ -932,28 +944,39 @@ def _parse_audit_output(raw_text: str) -> AuditDecision:
         规范化后的审计决策。
 
     Raises:
-        无。
+        ValueError: 当 ``raw_text`` 取不到 JSON 块或 JSON 解析失败时抛出，
+            交由 helper 触发 Host.replay 兜底。
     """
 
+    normalized = _extract_markdown_content(raw_text)
+    json_text = _extract_json_text(normalized)
+    if not json_text:
+        raise ValueError("审计输出不是合法 JSON：未提取到 JSON 块")
+    try:
+        json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"审计输出不是合法 JSON：{exc}") from exc
     return _parse_audit_decision(raw_text)
 
 
 def _build_audit_output_error(raw_text: str, error: ValueError) -> RuntimeError:
-    """构造审计输出解析失败异常（当前路径理论不可达，作为协议占位）。
+    """构造审计输出解析失败异常，用于 replay 仍失败后的最终上抛。
 
     Args:
         raw_text: 审计原始输出。
         error: 原始解析异常。
 
     Returns:
-        统一的 ``RuntimeError``，便于 helper 在未来若引入抛错型 parser 时复用。
+        带原始输出片段的 ``RuntimeError``，便于上层日志定位。
 
     Raises:
         无。
     """
 
-    del raw_text
-    return RuntimeError(f"审计输出解析失败: {error}")
+    snippet = raw_text.strip().replace("\n", " ")
+    if len(snippet) > 200:
+        snippet = snippet[:200] + "..."
+    return RuntimeError(f"审计输出解析失败: {error}; raw={snippet!r}")
 
 
 def _parse_repair_result(raw_text: str) -> tuple[dict[str, Any], str]:

--- a/dayu/services/startup_preparation.py
+++ b/dayu/services/startup_preparation.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from dayu.contracts.infrastructure import ModelCatalogProtocol, PromptAssetStoreProtocol
 from dayu.execution.options import ExecutionOptions, ResolvedExecutionOptions
-from dayu.fins.service_runtime import DefaultFinsRuntime
+from dayu.fins.service_runtime import DefaultFinsRuntime, FinsRuntimeProtocol
 from dayu.host import Host, resolve_host_config
 from dayu.services.concurrency_lanes import SERVICE_DEFAULT_LANE_CONFIG
 from dayu.services.conversation_policy_reader import ConversationPolicyReader
@@ -58,7 +58,7 @@ class PreparedHostRuntimeDependencies:
     default_execution_options: ResolvedExecutionOptions
     scene_execution_acceptance_preparer: SceneExecutionAcceptancePreparer
     host: Host
-    fins_runtime: DefaultFinsRuntime
+    fins_runtime: FinsRuntimeProtocol
 
 
 def prepare_scene_execution_acceptance_preparer(

--- a/dayu/web/streamlit_app.py
+++ b/dayu/web/streamlit_app.py
@@ -126,6 +126,7 @@ def _resolve_services(
         st.session_state["chat_service"] = ChatService(
             host=prepared_deps.host,
             scene_execution_acceptance_preparer=prepared_deps.scene_execution_acceptance_preparer,
+            default_scene_name="interactive",
             company_name_resolver=prepared_deps.fins_runtime.get_company_name,
             session_source=SessionSource.WEB,
         )

--- a/dayu/wechat/commands/run.py
+++ b/dayu/wechat/commands/run.py
@@ -6,12 +6,12 @@ import argparse
 import asyncio
 from dataclasses import dataclass
 
-from dayu.host.host import Host
 from dayu.log import Log
 from dayu.process_lifecycle import (
     ProcessShutdownCoordinator,
     install_async_signal_handlers,
 )
+from dayu.process_lifecycle.coordinator import HostSettleHook
 from dayu.wechat.arg_parsing import MODULE, _resolve_command_context
 from dayu.wechat.runtime import WeChatDaemonLike, _create_run_daemon
 from dayu.wechat.state_store import FileWeChatStateStore
@@ -32,14 +32,16 @@ class _DaemonShutdownState:
 async def _run_daemon_with_graceful_shutdown(
     daemon: WeChatDaemonLike,
     *,
-    host: Host,
+    host: HostSettleHook,
     require_existing_auth: bool,
 ) -> int:
     """以前台方式运行 daemon，并通过统一的进程级协调器处理退出信号。
 
     Args:
         daemon: WeChat daemon。
-        host: WeChat daemon 关联的 Host，用于让协调器执行 owner-run 收敛。
+        host: WeChat daemon 关联的 Host 协调器钩子，
+            协议层契约 ``HostSettleHook``，由装配点（``runtime._create_run_daemon``）
+            注入实际 Host 实例；本函数仅依赖协议方法以避免反向耦合到具体类型。
         require_existing_auth: 是否要求已有登录态。
 
     Returns:

--- a/dayu/wechat/daemon.py
+++ b/dayu/wechat/daemon.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import asyncio
+import traceback
 from concurrent.futures import Future as ConcurrentFuture, ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -283,16 +284,37 @@ def _rebuild_wechat_delivery_context(
     )
 
 
-def _is_retryable_delivery_error(exc: Exception) -> bool:
-    """判断发送失败是否允许后续重试。"""
+_NON_RETRYABLE_DELIVERY_PROGRAMMING_ERRORS: tuple[type[BaseException], ...] = (
+    TypeError,
+    AttributeError,
+    ValueError,
+    KeyError,
+    NotImplementedError,
+)
 
-    if not isinstance(exc, IlinkApiError):
-        return True
-    if exc.business_ret_code is not None:
+
+def _is_retryable_delivery_error(exc: Exception) -> bool:
+    """判断发送失败是否允许后续重试。
+
+    判定规则：
+    - `IlinkApiError`：iLink 已返回错误响应，按业务约定一律不可重试。
+    - 编程类错误（`TypeError`/`AttributeError`/`ValueError`/`KeyError`/
+      `NotImplementedError`）：重试无法恢复，直接判为不可重试。
+    - 其它异常（网络、超时、未知运行时错误）：保留可重试兜底。
+
+    Args:
+        exc: 发送链路上抛出的异常实例。
+
+    Returns:
+        允许后续重试返回 ``True``；否则返回 ``False``。
+
+    Raises:
+        无。
+    """
+
+    if isinstance(exc, IlinkApiError):
         return False
-    if exc.status_code is None:
-        return True
-    if 400 <= exc.status_code < 500:
+    if isinstance(exc, _NON_RETRYABLE_DELIVERY_PROGRAMMING_ERRORS):
         return False
     return True
 
@@ -1035,13 +1057,27 @@ class WeChatDaemon:
         if not isinstance(messages, list):
             messages = []
         structured_messages = [message for message in messages if isinstance(message, dict)]
-        processed_counts = await asyncio.gather(
+        group_results = await asyncio.gather(
             *(
                 self._handle_inbound_message_group(message_group, state)
                 for message_group in _group_inbound_messages_by_chat_key(structured_messages)
-            )
+            ),
+            return_exceptions=True,
         )
-        processed_count = sum(processed_counts)
+        processed_count = 0
+        for group_result in group_results:
+            if isinstance(group_result, BaseException):
+                tb_text = "".join(
+                    traceback.format_exception(
+                        type(group_result), group_result, group_result.__traceback__
+                    )
+                )
+                Log.error(
+                    f"处理 chat_key 群组失败，本组按 0 条计入: {group_result!r}\n{tb_text}",
+                    module=MODULE,
+                )
+                continue
+            processed_count += group_result
         next_cursor = payload.get("get_updates_buf")
         if isinstance(next_cursor, str) and next_cursor:
             state.get_updates_buf = next_cursor

--- a/dayu/wechat/runtime.py
+++ b/dayu/wechat/runtime.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Protocol
 
 from dayu.contracts.session import SessionSource
+from dayu.host import purge_sessions_from_host_db
 from dayu.host.host import Host
 from dayu.log import Log
 from dayu.services import prepare_host_runtime_dependencies
@@ -718,6 +719,7 @@ def _create_run_daemon(
     chat_service = ChatService(
         host=host,
         scene_execution_acceptance_preparer=scene_execution_acceptance_preparer,
+        default_scene_name="interactive",
         company_name_resolver=fins_runtime.get_company_name,
         session_source=SessionSource.WECHAT,
     )
@@ -901,9 +903,6 @@ def _purge_tracked_session_data(*, workspace_root: Path, state_dir: Path) -> Non
     host_db_path = build_host_store_default_path(workspace_root)
     if not host_db_path.exists():
         return
-
-    # host cleanup 仅在卸载 service 时需要，延迟导入避免影响冷启动路径。
-    from dayu.host.host_cleanup import purge_sessions_from_host_db
 
     total_pending, total_outbox = purge_sessions_from_host_db(
         host_db_path=host_db_path,

--- a/docs/code_review_fixer.md
+++ b/docs/code_review_fixer.md
@@ -26,7 +26,7 @@ Review 要求：
 - 重点关注：逻辑错误、边界条件、回归风险、类型问题、异常处理、测试遗漏、与现有架构约束不一致的地方
 输出：
 - review结束后给出review意见
-- 对修复报告中对findings逐条给出review结论
+- 对修复报告中的findings逐条给出review结论
 - 全部findings review完毕后给出是否可commit的结论
 等我给你另外一个Agent对 findings 的修复报告再开始工作。
 

--- a/tests/application/test_chat_service.py
+++ b/tests/application/test_chat_service.py
@@ -265,6 +265,7 @@ def _build_service(
     service = ChatService(
         host=host,
         scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        default_scene_name="interactive",
         company_name_resolver=lambda ticker: f"{ticker}-NAME",
         session_source=session_source,
     )
@@ -1140,6 +1141,7 @@ def test_submit_turn_translates_prompt_manifest_error_to_value_error() -> None:
     service = ChatService(
         host=host,
         scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        default_scene_name="interactive",
         company_name_resolver=lambda ticker: f"{ticker}-NAME",
         session_source=SessionSource.API,
     )
@@ -1179,6 +1181,7 @@ def test_submit_turn_translates_missing_scene_to_value_error() -> None:
     service = ChatService(
         host=host,
         scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        default_scene_name="interactive",
         company_name_resolver=lambda ticker: f"{ticker}-NAME",
         session_source=SessionSource.API,
     )
@@ -1187,6 +1190,71 @@ def test_submit_turn_translates_missing_scene_to_value_error() -> None:
         with pytest.raises(ValueError, match="scene 不存在"):
             await service.submit_turn(
                 ChatTurnRequest(session_id="s1", user_text="hello", ticker="AAPL"),
+            )
+
+    asyncio.run(scenario())
+
+
+def test_submit_turn_rejects_blank_default_scene_name() -> None:
+    """装配期注入空白 ``default_scene_name`` 时应在请求阶段立刻抛出明确错误，
+    而不是被静默 strip 后退化成下游 'scene 不存在' 这类误导性诊断（#24 review 补丁）。"""
+
+    resolver = _FakeSceneExecutionAcceptancePreparer()
+    session_registry = StubSessionRegistry()
+    session_registry.create_session(source=SessionSource.CLI, session_id="s1")
+    host = Host(
+        executor=StubHostExecutor(),  # type: ignore[arg-type]
+        session_registry=session_registry,  # type: ignore[arg-type]
+        run_registry=StubRunRegistry(),  # type: ignore[arg-type]
+        pending_turn_store=StubPendingTurnStore(),  # type: ignore[arg-type]
+    )
+    service = ChatService(
+        host=host,
+        scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        default_scene_name="   ",
+        company_name_resolver=lambda ticker: f"{ticker}-NAME",
+        session_source=SessionSource.API,
+    )
+
+    async def scenario() -> None:
+        with pytest.raises(ValueError, match="default_scene_name 装配期未注入有效值"):
+            await service.submit_turn(
+                ChatTurnRequest(session_id="s1", user_text="hello", ticker="AAPL"),
+            )
+
+    asyncio.run(scenario())
+
+
+def test_submit_turn_rejects_explicit_blank_scene_name() -> None:
+    """显式传入纯空白 ``scene_name`` 时应抛出"不能为空字符串"的 ValueError，
+    与默认值校验路径保持对称契约。"""
+
+    resolver = _FakeSceneExecutionAcceptancePreparer()
+    session_registry = StubSessionRegistry()
+    session_registry.create_session(source=SessionSource.CLI, session_id="s1")
+    host = Host(
+        executor=StubHostExecutor(),  # type: ignore[arg-type]
+        session_registry=session_registry,  # type: ignore[arg-type]
+        run_registry=StubRunRegistry(),  # type: ignore[arg-type]
+        pending_turn_store=StubPendingTurnStore(),  # type: ignore[arg-type]
+    )
+    service = ChatService(
+        host=host,
+        scene_execution_acceptance_preparer=cast(SceneExecutionAcceptancePreparer, resolver),
+        default_scene_name="interactive",
+        company_name_resolver=lambda ticker: f"{ticker}-NAME",
+        session_source=SessionSource.API,
+    )
+
+    async def scenario() -> None:
+        with pytest.raises(ValueError, match="scene_name 不能为空字符串"):
+            await service.submit_turn(
+                ChatTurnRequest(
+                    session_id="s1",
+                    user_text="hello",
+                    ticker="AAPL",
+                    scene_name="   ",
+                ),
             )
 
     asyncio.run(scenario())

--- a/tests/application/test_interactive_resume.py
+++ b/tests/application/test_interactive_resume.py
@@ -14,17 +14,20 @@ from dayu.services.contracts import ChatPendingTurnView, ChatResumeRequest
 class _FakeChatService:
     """测试用可恢复聊天服务。"""
 
-    def __init__(self) -> None:
+    def __init__(self, *, expected_scene_name: str = "interactive") -> None:
         self.resume_requests: list[ChatResumeRequest] = []
+        self._expected_scene_name = expected_scene_name
+        self.list_scene_names: list[str | None] = []
 
     def list_resumable_pending_turns(self, *, session_id: str | None = None, scene_name: str | None = None) -> list[ChatPendingTurnView]:
         assert session_id == "interactive-session"
-        assert scene_name == "interactive"
+        assert scene_name == self._expected_scene_name
+        self.list_scene_names.append(scene_name)
         return [
             ChatPendingTurnView(
                 pending_turn_id="pending-1",
                 session_id="interactive-session",
-                scene_name="interactive",
+                scene_name=self._expected_scene_name,
                 user_text="未完成问题",
                 source_run_id="run-old",
                 resumable=True,
@@ -70,6 +73,9 @@ class _AutoCleaningRejectingChatService(_FakeChatService):
         scene_name: str | None = None,
     ) -> list[ChatPendingTurnView]:
         if self._cleared:
+            assert session_id == "interactive-session"
+            assert scene_name == self._expected_scene_name
+            self.list_scene_names.append(scene_name)
             return []
         return super().list_resumable_pending_turns(session_id=session_id, scene_name=scene_name)
 
@@ -102,20 +108,30 @@ def test_interactive_startup_resumes_pending_turn(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.unit
-def test_interactive_startup_keeps_pending_turn_when_resume_is_rejected() -> None:
-    """Host gate 拒绝恢复时，interactive 只应停止恢复，不做额外收口。"""
+def test_interactive_startup_continues_when_resume_fails_but_pending_turn_still_resumable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host gate 拒绝恢复但 pending turn 仍可恢复时，interactive 应给出错误提示并继续进入 REPL。"""
 
     service = _RejectingChatService()
+    rendered: list[str] = []
+    monkeypatch.setattr(
+        "dayu.cli.interactive_ui._render_warning_or_error",
+        lambda current_state, message: rendered.append(message),
+    )
 
-    with pytest.raises(ValueError, match="不可恢复"):
-        _resume_interactive_pending_turn_if_needed(
-            service,  # type: ignore[arg-type]
-            session_id="interactive-session",
-            show_thinking=False,
-        )
+    # 不应抛异常，REPL 启动流程能继续
+    _resume_interactive_pending_turn_if_needed(
+        service,  # type: ignore[arg-type]
+        session_id="interactive-session",
+        show_thinking=False,
+    )
 
     assert [request.pending_turn_id for request in service.resume_requests] == ["pending-1"]
     assert [request.session_id for request in service.resume_requests] == ["interactive-session"]
+    assert rendered == [
+        "[error] 上一轮 pending turn 恢复失败，会话继续可用，可在下一轮输入后重试"
+    ]
 
 
 @pytest.mark.unit
@@ -139,6 +155,35 @@ def test_interactive_startup_allows_session_when_failed_pending_turn_has_been_cl
 
     assert [request.pending_turn_id for request in service.resume_requests] == ["pending-1"]
     assert rendered == ["[warning] 上一轮 pending turn 恢复失败，但记录已被清理；当前会话继续可用"]
+
+
+@pytest.mark.unit
+def test_interactive_startup_propagates_custom_scene_name_when_resume_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """非默认 scene 的 interactive resume 失败但仍 resumable 时，二次探测必须沿用调用方传入的 scene_name。"""
+
+    service = _RejectingChatService(expected_scene_name="custom-scene")
+    rendered: list[str] = []
+    monkeypatch.setattr(
+        "dayu.cli.interactive_ui._render_warning_or_error",
+        lambda current_state, message: rendered.append(message),
+    )
+
+    _resume_interactive_pending_turn_if_needed(
+        service,  # type: ignore[arg-type]
+        session_id="interactive-session",
+        scene_name="custom-scene",
+        show_thinking=False,
+    )
+
+    # 关键：list_resumable_pending_turns 必须以 custom-scene 调用两次
+    # （首次启动探测 + 失败后二次确认），否则会误判 pending turn 已清理
+    assert service.list_scene_names == ["custom-scene", "custom-scene"]
+    assert [request.pending_turn_id for request in service.resume_requests] == ["pending-1"]
+    assert rendered == [
+        "[error] 上一轮 pending turn 恢复失败，会话继续可用，可在下一轮输入后重试"
+    ]
 
 
 @pytest.mark.unit

--- a/tests/application/test_reply_outbox_store.py
+++ b/tests/application/test_reply_outbox_store.py
@@ -13,6 +13,7 @@ from dayu.host.host_store import HostStore
 from dayu.host.protocols import ReplyOutboxStoreProtocol
 from dayu.host.reply_outbox_store import (
     InMemoryReplyOutboxStore,
+    MIN_STALE_AGE,
     SQLiteReplyOutboxStore,
     STALE_IN_PROGRESS_ERROR_MESSAGE,
 )
@@ -498,6 +499,61 @@ def test_cleanup_stale_in_progress_skips_fresh_records(tmp_path: Path) -> None:
     store.claim_reply(submitted.delivery_id)
 
     stale = store.cleanup_stale_in_progress_deliveries(max_age=timedelta(hours=1))
+    assert stale == []
+    refreshed = store.get_reply(submitted.delivery_id)
+    assert refreshed is not None
+    assert refreshed.state == ReplyOutboxState.DELIVERY_IN_PROGRESS
+
+
+@pytest.mark.unit
+def test_inmemory_cleanup_rejects_max_age_below_min() -> None:
+    """InMemory 实现拒绝小于 ``MIN_STALE_AGE`` 的 max_age，避免与 mark_delivered 竞态。"""
+
+    store = InMemoryReplyOutboxStore()
+    submitted = store.submit_reply(_build_submit_request())
+    store.claim_reply(submitted.delivery_id)
+    too_small = MIN_STALE_AGE - timedelta(seconds=1)
+    with pytest.raises(ValueError, match="max_age 不能小于"):
+        store.cleanup_stale_in_progress_deliveries(max_age=too_small)
+    refreshed = store.get_reply(submitted.delivery_id)
+    assert refreshed is not None
+    # 拒绝后状态保持 IN_PROGRESS，未被错误回退
+    assert refreshed.state == ReplyOutboxState.DELIVERY_IN_PROGRESS
+
+
+@pytest.mark.unit
+def test_sqlite_cleanup_rejects_max_age_below_min(tmp_path: Path) -> None:
+    """SQLite 实现拒绝小于 ``MIN_STALE_AGE`` 的 max_age，避免误回退。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLiteReplyOutboxStore(host_store)
+    submitted = store.submit_reply(_build_submit_request())
+    store.claim_reply(submitted.delivery_id)
+    too_small = MIN_STALE_AGE - timedelta(seconds=1)
+    with pytest.raises(ValueError, match="max_age 不能小于"):
+        store.cleanup_stale_in_progress_deliveries(max_age=too_small)
+    refreshed = store.get_reply(submitted.delivery_id)
+    assert refreshed is not None
+    assert refreshed.state == ReplyOutboxState.DELIVERY_IN_PROGRESS
+
+
+@pytest.mark.unit
+def test_sqlite_cleanup_at_min_stale_age_does_not_revert_fresh_record(tmp_path: Path) -> None:
+    """``max_age = MIN_STALE_AGE`` 时，刚 claim 的 record 不会被错误回退。
+
+    防回归点：早期实现允许调用方传入很小的 max_age，刚 claim 的 record
+    会与 mark_delivered 在 ``state='delivery_in_progress'`` 上竞态。本测
+    试断言下界恰好为 ``MIN_STALE_AGE`` 时该 record 仍处于 IN_PROGRESS。
+    """
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLiteReplyOutboxStore(host_store)
+    submitted = store.submit_reply(_build_submit_request())
+    store.claim_reply(submitted.delivery_id)
+
+    stale = store.cleanup_stale_in_progress_deliveries(max_age=MIN_STALE_AGE)
     assert stale == []
     refreshed = store.get_reply(submitted.delivery_id)
     assert refreshed is not None

--- a/tests/application/test_wechat_daemon.py
+++ b/tests/application/test_wechat_daemon.py
@@ -417,7 +417,7 @@ class _BusinessFailingIlinkClient(_FakeIlinkClient):
 
 
 class _TransientFailingIlinkClient(_FakeIlinkClient):
-    """发送文本时持续返回可重试错误。"""
+    """发送文本时持续抛出可重试的网络错误（非 IlinkApiError，模拟连接异常）。"""
 
     async def send_text_message(
         self,
@@ -433,7 +433,7 @@ class _TransientFailingIlinkClient(_FakeIlinkClient):
             text=text,
             group_id=group_id,
         )
-        raise IlinkApiError("iLink HTTP 错误: 503", status_code=503, payload={"ret": 0})
+        raise ConnectionError("transient network failure")
 
 
 class _ThreadRecordingStateStore(FileWeChatStateStore):
@@ -2009,30 +2009,46 @@ def test_rebuild_wechat_delivery_context_with_group() -> None:
 
 
 @pytest.mark.unit
-def test_is_retryable_delivery_error_non_ilink_error() -> None:
-    """非 IlinkApiError 的异常始终可重试。"""
+def test_is_retryable_delivery_error_non_ilink_runtime_error() -> None:
+    """非 IlinkApiError 的运行时异常（含网络错误）保留可重试兜底。"""
 
     assert _is_retryable_delivery_error(RuntimeError("network")) is True
+    assert _is_retryable_delivery_error(ConnectionError("conn refused")) is True
+    assert _is_retryable_delivery_error(TimeoutError("timeout")) is True
 
 
 @pytest.mark.unit
-def test_is_retryable_delivery_error_business_ret_code() -> None:
-    """IlinkApiError 有 business_ret_code 时不可重试。"""
+def test_is_retryable_delivery_error_programming_errors_not_retryable() -> None:
+    """编程类错误重试无法恢复，必须判为不可重试。"""
+
+    for exc in (
+        TypeError("bad type"),
+        AttributeError("missing attr"),
+        ValueError("bad value"),
+        KeyError("missing key"),
+        NotImplementedError("todo"),
+    ):
+        assert _is_retryable_delivery_error(exc) is False
+
+
+@pytest.mark.unit
+def test_is_retryable_delivery_error_ilink_business_ret_code() -> None:
+    """IlinkApiError 携带 business_ret_code 时不可重试。"""
 
     exc = IlinkApiError("biz fail", status_code=200, business_ret_code=-1)
     assert _is_retryable_delivery_error(exc) is False
 
 
 @pytest.mark.unit
-def test_is_retryable_delivery_error_no_status_code() -> None:
-    """IlinkApiError 无 status_code 时可重试。"""
+def test_is_retryable_delivery_error_ilink_without_status_code() -> None:
+    """IlinkApiError 即使无 status_code 也属于"已收到 iLink 响应"，不可重试。"""
 
     exc = IlinkApiError("unknown")
-    assert _is_retryable_delivery_error(exc) is True
+    assert _is_retryable_delivery_error(exc) is False
 
 
 @pytest.mark.unit
-def test_is_retryable_delivery_error_4xx_not_retryable() -> None:
+def test_is_retryable_delivery_error_ilink_4xx_not_retryable() -> None:
     """4xx 状态码的 IlinkApiError 不可重试。"""
 
     exc = IlinkApiError("bad request", status_code=400)
@@ -2040,11 +2056,11 @@ def test_is_retryable_delivery_error_4xx_not_retryable() -> None:
 
 
 @pytest.mark.unit
-def test_is_retryable_delivery_error_5xx_retryable() -> None:
-    """5xx 状态码的 IlinkApiError 可重试。"""
+def test_is_retryable_delivery_error_ilink_5xx_not_retryable() -> None:
+    """iLink 已返回 5xx 响应也按业务约定不可重试（避免重复推送）。"""
 
     exc = IlinkApiError("server error", status_code=500)
-    assert _is_retryable_delivery_error(exc) is True
+    assert _is_retryable_delivery_error(exc) is False
 
 
 @pytest.mark.unit
@@ -2612,3 +2628,46 @@ def test_ensure_authenticated_no_bot_token_after_confirm(tmp_path: Path) -> None
 
     with pytest.raises(RuntimeError, match="bot_token"):
         asyncio.run(daemon.ensure_authenticated(force_relogin=True))
+
+
+@pytest.mark.unit
+def test_process_once_isolates_group_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """当某个 chat_key 群组的处理协程抛异常时，其他群组应继续完成。"""
+
+    store = FileWeChatStateStore(tmp_path / ".wechat")
+    store.save(WeChatDaemonState(bot_token="token-1", base_url="https://ilink.example"))
+    service = _FakeChatService(
+        scripted_turns=[
+            _ScriptedTurn(events=(AppEvent(type=AppEventType.FINAL_ANSWER, payload={"content": "答1"}, meta={}),)),
+        ]
+    )
+    client = _FakeIlinkClient(
+        updates_payloads=[
+            {
+                "ret": 0,
+                "msgs": [
+                    _build_text_message(text="ok", context_token="ctx-ok", from_user_id="user-ok@im.wechat"),
+                    _build_text_message(text="boom", context_token="ctx-boom", from_user_id="user-boom@im.wechat"),
+                ],
+                "get_updates_buf": "cursor-1",
+            },
+        ]
+    )
+    daemon = _build_daemon(chat_service=service, state_store=store, client=client)
+
+    real_handle = daemon._handle_inbound_message_group
+
+    async def _selective_handler(messages: list, state: WeChatDaemonState) -> int:
+        if messages and messages[0].get("from_user_id") == "user-boom@im.wechat":
+            raise RuntimeError("group failure")
+        return await real_handle(messages, state)
+
+    monkeypatch.setattr(daemon, "_handle_inbound_message_group", _selective_handler)
+
+    processed = asyncio.run(daemon.process_once())
+
+    # 仅成功的 chat_key 计入；失败的 chat_key 不影响 cursor 推进
+    assert processed == 1
+    assert store.load().get_updates_buf == "cursor-1"

--- a/tests/application/test_wechat_outbox_integration.py
+++ b/tests/application/test_wechat_outbox_integration.py
@@ -16,7 +16,7 @@ from dayu.host.reply_outbox_store import InMemoryReplyOutboxStore
 from dayu.services.contracts import ChatPendingTurnView, ChatResumeRequest, ChatTurnRequest, ChatTurnSubmission
 from dayu.services.reply_delivery_service import ReplyDeliveryService
 from dayu.wechat.daemon import WeChatDaemon
-from dayu.wechat.ilink_client import IlinkApiError, QRCodeLoginStatus, QRCodeLoginTicket
+from dayu.wechat.ilink_client import QRCodeLoginStatus, QRCodeLoginTicket
 from dayu.wechat.state_store import FileWeChatStateStore, WeChatDaemonState, build_wechat_session_id
 from tests.application.conftest import StubHostExecutor, StubRunRegistry, StubSessionRegistry
 
@@ -241,7 +241,7 @@ def test_wechat_process_once_marks_retryable_failure_when_delivery_errors(tmp_pa
         updates_payloads=[
             {"ret": 0, "msgs": [_build_text_message(text="问题", context_token="ctx-2")], "get_updates_buf": "cursor-2"}
         ],
-        fail_send=IlinkApiError("temporary failure", status_code=500),
+        fail_send=ConnectionError("temporary failure"),
     )
     daemon = WeChatDaemon(
         chat_service=chat_service,

--- a/tests/cli/test_fins_commands.py
+++ b/tests/cli/test_fins_commands.py
@@ -10,8 +10,10 @@ import pytest
 
 from dayu.cli.commands.fins import (
     _build_fins_command,
+    _classify_fins_status,
     _consume_fins_stream,
     _format_fins_progress_line,
+    _is_fins_result_failure,
     run_fins_command,
     _should_log_fins_progress_as_info,
 )
@@ -29,7 +31,10 @@ from dayu.contracts.fins import (
     ProcessResultData,
     ProcessSingleResultData,
     UploadFilingProgressPayload,
+    UploadFilingResultData,
+    UploadFilingsFromResultData,
     UploadMaterialProgressPayload,
+    UploadMaterialResultData,
 )
 
 
@@ -435,7 +440,7 @@ class TestRunFinsCommand:
         result_data = ProcessSingleResultData(
             pipeline="process_filing",
             action="process",
-            status="ok",
+            status="processed",
             ticker="AAPL",
             document_id="doc-1",
         )
@@ -493,3 +498,146 @@ class TestRunFinsCommand:
             exit_code = run_fins_command(args)
 
         assert exit_code == 1
+
+# --------------------------------------------------------------------------- #
+#  _is_fins_result_failure / _classify_fins_status
+# --------------------------------------------------------------------------- #
+
+
+class TestIsFinsResultFailure:
+    """`_is_fins_result_failure` 按 per-result-type 白名单显式归类。"""
+
+    def test_upload_filings_from_result_always_succeeds(self) -> None:
+        """``UploadFilingsFromResultData`` 没有 status 字段，统一归成功。"""
+
+        result = UploadFilingsFromResultData(
+            script_path="/tmp/x.sh",
+            script_platform="linux",
+            ticker="AAPL",
+            source_dir="/tmp",
+            total_files=0,
+            recognized_count=0,
+            material_count=0,
+            skipped_count=0,
+        )
+        assert _is_fins_result_failure(result) is False
+
+    def test_download_status_failed_returns_true(self) -> None:
+        """``DownloadResultData.status='failed'`` 上报失败。"""
+
+        result = DownloadResultData(pipeline="download", status="failed", ticker="AAPL")
+        assert _is_fins_result_failure(result) is True
+
+    def test_download_status_cancelled_is_success(self) -> None:
+        """``cancelled`` 是 download 白名单中的成功状态。"""
+
+        result = DownloadResultData(pipeline="download", status="cancelled", ticker="AAPL")
+        assert _is_fins_result_failure(result) is False
+
+    def test_process_single_status_processed_is_success(self) -> None:
+        """``processed`` 是 process_filing/process_material 白名单中的成功状态。"""
+
+        result = ProcessSingleResultData(
+            pipeline="process_filing",
+            action="process",
+            status="processed",
+            ticker="AAPL",
+            document_id="doc-1",
+        )
+        assert _is_fins_result_failure(result) is False
+
+    def test_process_single_status_skipped_is_success(self) -> None:
+        """``skipped`` 是 ProcessSingleResultData 白名单中的成功状态。"""
+
+        result = ProcessSingleResultData(
+            pipeline="process_filing",
+            action="process",
+            status="skipped",
+            ticker="AAPL",
+            document_id="doc-1",
+        )
+        assert _is_fins_result_failure(result) is False
+
+    def test_upload_filing_status_uploaded_is_success(self) -> None:
+        """``uploaded`` 是 upload_filing 白名单中的成功状态。"""
+
+        result = UploadFilingResultData(
+            pipeline="upload_filing",
+            status="uploaded",
+            ticker="AAPL",
+            filing_action="upload_filing",
+        )
+        assert _is_fins_result_failure(result) is False
+
+    def test_upload_material_status_deleted_is_success(self) -> None:
+        """``deleted`` 是 upload_material 白名单中的成功状态。"""
+
+        result = UploadMaterialResultData(
+            pipeline="upload_material",
+            status="deleted",
+            ticker="AAPL",
+            material_action="delete",
+        )
+        assert _is_fins_result_failure(result) is False
+
+    def test_unknown_status_raises_value_error(self) -> None:
+        """未在白名单也不是 ``failed`` 的 status 必须抛 ValueError。"""
+
+        result = ProcessResultData(pipeline="process", status="unknown_status", ticker="AAPL")
+        with pytest.raises(ValueError, match="未知财报命令 status"):
+            _is_fins_result_failure(result)
+
+    def test_run_fins_command_unknown_status_returns_one(self) -> None:
+        """run_fins_command 在未知 status 上必须以非零退出码上报。"""
+
+        args = argparse.Namespace(
+            command="process_filing",
+            ticker="AAPL",
+            document_id="doc-1",
+            overwrite=False,
+            ci=False,
+            log_level=None,
+            debug=False,
+            verbose=False,
+            info=False,
+            quiet=False,
+        )
+
+        result_data = ProcessSingleResultData(
+            pipeline="process_filing",
+            action="process",
+            status="brand_new_status",
+            ticker="AAPL",
+            document_id="doc-1",
+        )
+        mock_result = FinsResult(
+            command=FinsCommandName.PROCESS_FILING,
+            data=result_data,
+        )
+        mock_service = MagicMock()
+        mock_service.submit.return_value = MagicMock(execution=mock_result)
+
+        with patch("dayu.cli.commands.fins._build_fins_ops_service", return_value=mock_service):
+            exit_code = run_fins_command(args)
+
+        assert exit_code == 1
+
+
+class TestClassifyFinsStatus:
+    """``_classify_fins_status`` 私有 helper 直接测试。"""
+
+    def test_failed_returns_true(self) -> None:
+        """显式 ``failed`` 直接归失败。"""
+
+        assert _classify_fins_status("failed", frozenset({"ok"})) is True
+
+    def test_in_success_set_returns_false(self) -> None:
+        """命中白名单归成功。"""
+
+        assert _classify_fins_status("ok", frozenset({"ok", "skipped"})) is False
+
+    def test_unknown_raises(self) -> None:
+        """未知 status 抛 ValueError。"""
+
+        with pytest.raises(ValueError):
+            _classify_fins_status("running", frozenset({"ok"}))

--- a/tests/engine/test_sec_processor_supplement.py
+++ b/tests/engine/test_sec_processor_supplement.py
@@ -4291,17 +4291,27 @@ def test_table_classification_numeric_and_quality_helpers() -> None:
     assert sec_table_extraction._normalize_numeric_cell_text("1.234,56") == "1234.56"
     assert sec_table_extraction._normalize_numeric_cell_text("1,234.56") == "1234.56"
 
-    # 回归守护：脚注剥离规则只能匹配单字母脚注（如 "1,234a"），
-    # 必须保留多字母单位/缩写后缀（bps / mm 等），否则会把语义上的非纯数字单元
-    # 误规范化为数字，污染下游表格解析。详见 medium 文件 finding 025。
-    # 注意：单字母规则下 "10Q" 仍会被吃为 "10"，是当前已知盲点（finding 025 升级到 medium 处理）。
+    # 回归守护：脚注剥离规则只能匹配单小写字母脚注（SEC 续序脚注约定 a/b/c…），
+    # 多字母（bps/mm 等）以及任何大写单字母（M/K/B/T magnitude、Q/K form 标识）必须保留，
+    # 否则会把语义上的非纯数字单元误规范化为数字，污染下游表格解析。详见 medium #54。
     assert sec_table_extraction._strip_trailing_footnote("1,234a") == "1,234"
     assert sec_table_extraction._strip_trailing_footnote("10bps") == "10bps"
     assert sec_table_extraction._strip_trailing_footnote("10mm") == "10mm"
     assert sec_table_extraction._strip_trailing_footnote("123ab") == "123ab"
+    # 大写 magnitude / form 后缀必须保留：
+    assert sec_table_extraction._strip_trailing_footnote("1,234M") == "1,234M"
+    assert sec_table_extraction._strip_trailing_footnote("567K") == "567K"
+    assert sec_table_extraction._strip_trailing_footnote("890B") == "890B"
+    assert sec_table_extraction._strip_trailing_footnote("10T") == "10T"
+    assert sec_table_extraction._strip_trailing_footnote("10Q") == "10Q"
     assert sec_table_extraction._normalize_numeric_cell_text("10bps") is None
     assert sec_table_extraction._normalize_numeric_cell_text("10mm") is None
     assert sec_table_extraction._normalize_numeric_cell_text("123ab") is None
+    # 保留大写后缀后，严格数字校验主动返回 None，由上游决定是否丢弃 / 保留单位语义：
+    assert sec_table_extraction._normalize_numeric_cell_text("1,234M") is None
+    assert sec_table_extraction._normalize_numeric_cell_text("567K") is None
+    assert sec_table_extraction._normalize_numeric_cell_text("890B") is None
+    assert sec_table_extraction._normalize_numeric_cell_text("10Q") is None
 
     assert sec_table_extraction._looks_like_default_headers(["", " "]) is True
     assert sec_table_extraction._looks_like_default_headers(["1", "2", "3"]) is True
@@ -4537,3 +4547,64 @@ class TestExtractTextFromRawHtml:
         )
         result = sec_dom_helpers._extract_text_from_raw_html(html)
         assert "Content after declaration" in result
+
+
+class TestExtractConceptLocalName:
+    """覆盖 ``_extract_concept_local_name`` 在 ``namespace:local`` 与
+    ``namespace_local`` 两种形式下的本地名提取，重点验证本地名内部含 ``_``
+    时不会被错误截短（#55 回归）。"""
+
+    def test_colon_namespace_returns_full_local_name(self) -> None:
+        """`namespace:local` 形式应返回冒号后的完整本地名。"""
+        assert (
+            sec_xbrl_query._extract_concept_local_name("us-gaap:Revenues")
+            == "Revenues"
+        )
+
+    def test_underscore_namespace_returns_full_local_name(self) -> None:
+        """`namespace_local` 形式应返回首个下划线后的完整本地名。"""
+        assert (
+            sec_xbrl_query._extract_concept_local_name("us-gaap_Revenues")
+            == "Revenues"
+        )
+
+    def test_underscore_in_local_name_is_preserved(self) -> None:
+        """本地名内部含 `_` 时不得被错误截短（#55 关键回归）。"""
+        assert (
+            sec_xbrl_query._extract_concept_local_name("company_Custom_Metric")
+            == "Custom_Metric"
+        )
+
+    def test_colon_with_underscore_in_local_name(self) -> None:
+        """冒号分隔 + 本地名内含 `_` 时应保留全部本地名。"""
+        assert (
+            sec_xbrl_query._extract_concept_local_name("company:Custom_Metric")
+            == "Custom_Metric"
+        )
+
+    def test_no_separator_returns_input(self) -> None:
+        """无分隔符时直接返回原值。"""
+        assert sec_xbrl_query._extract_concept_local_name("Revenues") == "Revenues"
+
+    def test_empty_string_returns_empty(self) -> None:
+        """空字符串应返回空。"""
+        assert sec_xbrl_query._extract_concept_local_name("") == ""
+
+    def test_normalize_concept_match_key_preserves_underscore(self) -> None:
+        """`_normalize_concept_match_key` 必须基于完整本地名构造键，
+        含 `_` 的本地名不能被截短。"""
+        assert (
+            sec_xbrl_query._normalize_concept_match_key("company_Custom_Metric")
+            == "custom_metric"
+        )
+
+    def test_matches_concept_exact_local_name_handles_underscore_namespace(
+        self,
+    ) -> None:
+        """`namespace:local` 与 `namespace_local` 表示同一 concept 时应判等。"""
+        assert (
+            sec_xbrl_query._matches_concept_exact_local_name(
+                "company_Custom_Metric", "company:Custom_Metric"
+            )
+            is True
+        )

--- a/tests/engine/test_web_tools.py
+++ b/tests/engine/test_web_tools.py
@@ -41,6 +41,7 @@ from dayu.engine.tools.web_tools import (
     _fetch_and_convert_content,
     _is_safe_public_url,
     _is_sec_host,
+    _normalize_url_for_http,
     _normalize_whitespace,
     _prepare_call_session,
     _resolve_timeout_budget,
@@ -4671,3 +4672,23 @@ def test_detect_bot_challenge_catches_antibot() -> None:
 
     assert result.challenge_detected is True
     assert any("antibot" in s for s in result.challenge_signals)
+
+
+def test_normalize_url_for_http_rejects_non_http_scheme() -> None:
+    """_normalize_url_for_http 应拒绝非 http(s) scheme，作为统一入口收敛 SSRF/本地文件风险。"""
+
+    for bad in (
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "ftp://example.com/x",
+        "data:text/plain,hello",
+    ):
+        with pytest.raises(ValueError):
+            _normalize_url_for_http(bad)
+
+
+def test_normalize_url_for_http_accepts_http_and_https() -> None:
+    """合法 http(s) URL 应正常归一化。"""
+
+    assert _normalize_url_for_http("http://example.com/a").startswith("http://example.com/")
+    assert _normalize_url_for_http("https://example.com/b?q=1").startswith("https://example.com/")

--- a/tests/engine/test_write_pipeline.py
+++ b/tests/engine/test_write_pipeline.py
@@ -7440,6 +7440,217 @@ def test_maybe_rewrite_evidence_anchors_rolls_back_when_post_validation_fails(
 
 
 @pytest.mark.unit
+def test_maybe_rewrite_evidence_anchors_rebuilds_dropped_followup_when_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """校验失败回退时，必须把因 anchor_fix 在 merge 阶段被静默移除的 supported_* 违规重建回 audit_decision，
+    避免审计 gate 把章节误判为 passed。"""
+
+    runner = _build_runner(tmp_path)
+    task = ChapterTask(index=5, title="经营表现与核心驱动", skeleton="## 经营表现与核心驱动")
+    current_content = (
+        "## 经营表现与核心驱动\n\n"
+        "### 结论要点\n\n"
+        "- 自由现金流下降。\n\n"
+        "### 证据与出处\n\n"
+        "- SEC EDGAR | Form 10-K | Filed 2026-01-29 | Accession 0001628280-26-003942 | "
+        "Financial Statement:cash_flow | Period:FY2025,FY2024 | Rows:Purchases of property and equipment,Net cash provided by operating activities\n"
+    )
+    suspected = AuditDecision(passed=True, category=AuditCategory.OK)
+    # audit_decision 模拟 merge 后状态：anchor_fix 非空时原 violation 被丢弃，
+    # passed 错误地保持为 True，等待 maybe_rewrite_evidence_anchors 通过机械 rewrite 实际修复。
+    audit = AuditDecision(passed=True, category=AuditCategory.OK, violations=[])
+    confirmation = EvidenceConfirmationResult(
+        entries=[
+            EvidenceConfirmationEntry(
+                violation_id="evidence_1",
+                rule=AuditRuleCode.E1,
+                excerpt="自由现金流从521亿美元降至436亿美元",
+                status=EvidenceConfirmationStatus.SUPPORTED_ELSEWHERE_IN_SAME_FILING,
+                reason="自由现金流数字在同一 filing 的 Part II - Item 7 | Free Cash Flow 中明确列示。",
+                rewrite_hint="将证据条目更改为：SEC EDGAR | Form 10-K | Filed 2026-01-29 | Accession 0001628280-26-003942 | Part II - Item 7 | Free Cash Flow",
+                anchor_fix=EvidenceAnchorFix(
+                    kind="same_filing_section",
+                    action="refine_existing",
+                    section_path="Part II - Item 7 | Free Cash Flow",
+                ),
+            )
+        ]
+    )
+
+    failing_decision = AuditDecision(
+        passed=False,
+        category=AuditCategory.CONTENT_VIOLATION,
+        violations=[Violation(rule=AuditRuleCode.P1, severity="high", excerpt="", reason="结构不匹配")],
+        notes=["结构不匹配"],
+        repair_contract=RepairContract(repair_strategy="regenerate"),
+        raw='{"pass": false}',
+    )
+    monkeypatch.setattr(
+        "dayu.services.internal.write_pipeline.audit_evidence_rewriter._run_programmatic_audits",
+        lambda *_args, **_kwargs: failing_decision,
+    )
+    process_state = build_process_state_template()
+
+    rewritten_content, _rewritten_suspected, rewritten_audit, _rewritten_confirmation = runner._chapter_audit_coordinator.maybe_rewrite_evidence_anchors(
+        task=task,
+        current_content=current_content,
+        suspected_decision=suspected,
+        audit_decision=audit,
+        confirmation_result=confirmation,
+        phase="repair_1",
+        skeleton=task.skeleton,
+        allowed_conditional_headings=set(),
+        process_state=process_state,
+    )
+
+    assert rewritten_content == current_content
+    # 关键断言：audit_decision 不再保留旧对象，而是重建后的版本，
+    # 必须包含一条对应该 confirm entry 的 S7 followup violation，
+    # 不能让违规因 anchor_fix 在 merge 阶段被静默吞掉。
+    assert rewritten_audit is not audit
+    followup_violations = [v for v in rewritten_audit.violations if v.rule == AuditRuleCode.S7]
+    assert len(followup_violations) == 1
+    assert followup_violations[0].excerpt == "自由现金流从521亿美元降至436亿美元"
+    assert process_state["latest_anchor_rewrite"]["attempted"] is True
+    assert process_state["latest_anchor_rewrite"]["applied"] is False
+
+
+@pytest.mark.unit
+def test_maybe_rewrite_evidence_anchors_rebuilds_dropped_followup_on_no_material_change(
+    tmp_path: Path,
+) -> None:
+    """early-return 分支 ``no_material_change``：rewrite 候选与现有 evidence 一致、
+    rewrite 实际未落地，audit_decision 仍必须含 supported_* 对应的 S7 followup violation，
+    不能让 confirm merge 阶段静默吞掉的违规丢失。"""
+
+    runner = _build_runner(tmp_path)
+    task = ChapterTask(index=5, title="经营表现与核心驱动", skeleton="## 经营表现与核心驱动")
+    # evidence_line 直接给出与 anchor_fix.evidence_line 完全一致的内容，
+    # 触发 ``rewritten_evidence_lines == current_evidence_lines`` 的早退路径。
+    evidence_line = (
+        "SEC EDGAR | Form 10-K | Filed 2026-01-29 | Accession 0001628280-26-003942 | "
+        "Part II - Item 7 | Free Cash Flow"
+    )
+    current_content = (
+        "## 经营表现与核心驱动\n\n"
+        "### 结论要点\n\n"
+        "- 自由现金流下降。\n\n"
+        "### 证据与出处\n\n"
+        f"- {evidence_line}\n"
+    )
+    suspected = AuditDecision(passed=True, category=AuditCategory.OK)
+    # 模拟 confirm merge 阶段已经把 anchor_fix 非空的 supported_* violation 静默丢弃后的状态。
+    audit = AuditDecision(passed=True, category=AuditCategory.OK, violations=[])
+    confirmation = EvidenceConfirmationResult(
+        entries=[
+            EvidenceConfirmationEntry(
+                violation_id="evidence_1",
+                rule=AuditRuleCode.E1,
+                excerpt="自由现金流从521亿美元降至436亿美元",
+                status=EvidenceConfirmationStatus.SUPPORTED_ELSEWHERE_IN_SAME_FILING,
+                reason="自由现金流数字在同一 filing 的 Part II - Item 7 | Free Cash Flow 中明确列示。",
+                rewrite_hint=f"将证据条目更改为：{evidence_line}",
+                anchor_fix=EvidenceAnchorFix(
+                    kind="same_filing_evidence_line",
+                    action="refine_existing",
+                    evidence_line=evidence_line,
+                ),
+            )
+        ]
+    )
+    process_state = build_process_state_template()
+
+    rewritten_content, _rewritten_suspected, rewritten_audit, _rewritten_confirmation = runner._chapter_audit_coordinator.maybe_rewrite_evidence_anchors(
+        task=task,
+        current_content=current_content,
+        suspected_decision=suspected,
+        audit_decision=audit,
+        confirmation_result=confirmation,
+        phase="repair_1",
+        skeleton=task.skeleton,
+        allowed_conditional_headings=set(),
+        process_state=process_state,
+    )
+
+    assert rewritten_content == current_content
+    assert rewritten_audit is not audit
+    followup_violations = [v for v in rewritten_audit.violations if v.rule == AuditRuleCode.S7]
+    assert len(followup_violations) == 1
+    assert followup_violations[0].excerpt == "自由现金流从521亿美元降至436亿美元"
+    assert process_state["latest_anchor_rewrite"]["attempted"] is False
+    assert process_state["latest_anchor_rewrite"]["applied"] is False
+    assert process_state["latest_anchor_rewrite"]["skip_reason"] == "no_material_change"
+
+
+@pytest.mark.unit
+def test_maybe_rewrite_evidence_anchors_rebuilds_dropped_followup_on_missing_evidence_section(
+    tmp_path: Path,
+) -> None:
+    """early-return 分支 ``missing_evidence_section``：原文没有"### 证据与出处"块，
+    rewrite 完全无法落地；audit_decision 仍必须含 supported_* 对应的 S7 followup violation。"""
+
+    runner = _build_runner(tmp_path)
+    task = ChapterTask(index=5, title="经营表现与核心驱动", skeleton="## 经营表现与核心驱动")
+    evidence_line = (
+        "SEC EDGAR | Form 10-K | Filed 2026-01-29 | Accession 0001628280-26-003942 | "
+        "Part II - Item 7 | Free Cash Flow"
+    )
+    # 故意去掉"### 证据与出处"小节，触发 missing_evidence_section 早退路径。
+    current_content = (
+        "## 经营表现与核心驱动\n\n"
+        "### 结论要点\n\n"
+        "- 自由现金流下降。\n"
+    )
+    suspected = AuditDecision(passed=True, category=AuditCategory.OK)
+    audit = AuditDecision(passed=True, category=AuditCategory.OK, violations=[])
+    confirmation = EvidenceConfirmationResult(
+        entries=[
+            EvidenceConfirmationEntry(
+                violation_id="evidence_1",
+                rule=AuditRuleCode.E1,
+                excerpt="自由现金流从521亿美元降至436亿美元",
+                status=EvidenceConfirmationStatus.SUPPORTED_ELSEWHERE_IN_SAME_FILING,
+                reason="自由现金流数字在同一 filing 的 Part II - Item 7 | Free Cash Flow 中明确列示。",
+                rewrite_hint=f"将证据条目更改为：{evidence_line}",
+                anchor_fix=EvidenceAnchorFix(
+                    kind="same_filing_evidence_line",
+                    action="refine_existing",
+                    evidence_line=evidence_line,
+                ),
+            )
+        ]
+    )
+    process_state = build_process_state_template()
+
+    _rewritten_content, _rewritten_suspected, rewritten_audit, _rewritten_confirmation = runner._chapter_audit_coordinator.maybe_rewrite_evidence_anchors(
+        task=task,
+        current_content=current_content,
+        suspected_decision=suspected,
+        audit_decision=audit,
+        confirmation_result=confirmation,
+        phase="repair_1",
+        skeleton=task.skeleton,
+        allowed_conditional_headings=set(),
+        process_state=process_state,
+    )
+
+    assert rewritten_audit is not audit
+    followup_violations = [v for v in rewritten_audit.violations if v.rule == AuditRuleCode.S7]
+    assert len(followup_violations) == 1
+    assert followup_violations[0].excerpt == "自由现金流从521亿美元降至436亿美元"
+    # missing_evidence_section / no_rewritten_evidence_lines 均会进入 early-return；
+    # 只断言核心契约：违规已被重建，且 attempted=False 表示未真正落地 rewrite。
+    assert process_state["latest_anchor_rewrite"]["attempted"] is False
+    assert process_state["latest_anchor_rewrite"]["applied"] is False
+    assert process_state["latest_anchor_rewrite"]["skip_reason"] in {
+        "missing_evidence_section",
+        "no_rewritten_evidence_lines",
+    }
+
+
+@pytest.mark.unit
 def test_persist_phase_confirm_parse_error_artifacts(tmp_path: Path) -> None:
     """验证 confirm 非法 JSON 时会落盘原始输出与解析错误。"""
 

--- a/tests/engine/test_write_pipeline_scene_replay.py
+++ b/tests/engine/test_write_pipeline_scene_replay.py
@@ -396,21 +396,49 @@ def test_replay_path_propagates_cancellation(
 def test_run_audit_prompt_replays_on_dirty_output(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """audit success_parser 自身从不抛 ValueError，故脏数据不触发 replay；
-    本测试验证当前行为：首轮脏 JSON 也直接被 _parse_audit_decision 兜底成失败决策返回。"""
+    """audit success_parser 在拿不到合法 JSON 时必须抛 ValueError，
+    helper 借此触发 Host.replay 兜底；replay 返回合法 JSON 后正常解析为审计结果。"""
 
     runner = _build_runner(tmp_path)
     executor = _FakeContractExecutor(
         run_results=[_make_app_result(content="not json")],
+        replay_results=[
+            _make_app_result(
+                content='{"pass": true, "class": "ok", "violations": [], "notes": []}'
+            )
+        ],
     )
     _install_fake_executor(runner, executor, monkeypatch)
 
     decision = runner._prompt_runner.run_audit_prompt("prompt")
 
-    assert decision.passed is False
-    assert decision.violations
-    # audit 当前 success_parser 不抛 ValueError，故 replay 不触发
-    assert executor.replay_calls == []
+    assert decision.passed is True
+    assert decision.violations == []
+    # 关键：audit 路径已接入 Host.replay 兜底，replay 必须被调用一次
+    assert len(executor.replay_calls) == 1
+
+
+@pytest.mark.unit
+def test_run_audit_prompt_replay_failure_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """audit replay 仍返回脏数据时，helper 必须把解析失败上抛为 RuntimeError，
+    而不是再用伪装 STYLE_VIOLATION 决策吞掉错误。"""
+
+    runner = _build_runner(tmp_path)
+    executor = _FakeContractExecutor(
+        run_results=[_make_app_result(content="not json")],
+        replay_results=[
+            _make_app_result(content="still not json"),
+            _make_app_result(content="still bad"),
+            _make_app_result(content="still bad too"),
+        ],
+    )
+    _install_fake_executor(runner, executor, monkeypatch)
+
+    with pytest.raises(RuntimeError, match="审计输出解析失败"):
+        runner._prompt_runner.run_audit_prompt("prompt")
+    assert len(executor.replay_calls) >= 1
 
 
 # 防止 lint 抱怨未使用的 cast 导入；保留以便将来按需断言。


### PR DESCRIPTION
## 背景
本 PR 汇总 code review 中修复风险批次（批 1-7）的落地结果。

## 本次包含
- 修复 WeChat daemon 的重试判定、group 级容错与 URL scheme 校验相关问题。
- 修复 interactive pending turn 恢复失败时错误中断会话的问题。
- 修复 write pipeline 中 anchor rewrite 回退导致审计误判 passed，以及 audit dirty output 未触发 replay 的问题。
- 修复 SEC 数值尾注与 XBRL concept local name 解析问题。
- 收敛 Host / ChatService / runtime 装配边界，补齐 default_scene_name 契约。
- 收紧 fins CLI 的结果状态判断，未知 status 改为显式报错退出。
- 修复 reply outbox stale cleanup 与活跃 delivery 的竞态窗口。

## 未在本 PR 内处理
以下为本地 code review finding 编号，不是 GitHub Issue / PR 编号；这些项已转入 `workspace/code-review-0428-1727-high.md` 继续跟踪：
- finding 03
- finding 22
- finding 31
- finding 46
- finding 49
- finding 53

## 验证
- `pytest tests/application -q`
- `pytest tests/application/test_reply_outbox_store.py -q`
- 各批次对应的 targeted pytest / pyright 已在修复过程中逐批通过
