### PR TITLE
feat: Host 层为 assistant_reasoning 增加独立历史展示持久化能力 (#118)

### DIFF
--- a/dayu/cli/workspace_migrations/conversation_archive_init.py
+++ b/dayu/cli/workspace_migrations/conversation_archive_init.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any
 
 from dayu.host.conversation_session_archive import (
     ConversationHistoryArchive,
@@ -86,7 +85,7 @@ def _migrate_single_file(json_path: Path) -> bool:
         return False
 
     try:
-        payload: Any = json.loads(raw_text)
+        payload: object = json.loads(raw_text)
     except json.JSONDecodeError as exc:
         print(
             f"⚠ 工作区迁移: 跳过 {json_path.name}（JSON 解析失败：{exc}）",

--- a/dayu/cli/workspace_migrations/conversation_archive_init.py
+++ b/dayu/cli/workspace_migrations/conversation_archive_init.py
@@ -1,0 +1,154 @@
+"""conversation transcript → ConversationSessionArchive 原地迁移。
+
+旧 conversation 落盘 schema 是 ``ConversationTranscript`` 的 JSON
+（顶层有 ``turns`` key、无 ``runtime_transcript`` key）。``#118``
+引入 ``ConversationSessionArchive`` 聚合根后，落盘 schema 升级为
+``conversation_session_archive/v1``：
+
+- ``runtime_transcript``：保留旧 transcript 全量字段，作为运行态送模子视图。
+- ``history_archive``：从 ``runtime_transcript.turns`` 全量投影出
+  ``user_text``/``assistant_text``/``created_at`` 等展示字段，
+  ``assistant_reasoning`` 缺省为空字符串（老会话当时没有 reasoning，
+  这与"老会话无可展示历史"的退化是两回事）。
+
+本迁移按硬约束执行：
+
+- **原地** 覆盖旧文件路径（``CONVERSATION_STORE_RELATIVE_DIR``），
+  不换目录、不双写、不留兼容读取路径。
+- **幂等**：识别到顶层已有 ``runtime_transcript`` 的新 schema 直接跳过。
+- 单文件失败仅 stderr warning 跳过，不阻塞整体迁移。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from dayu.host.conversation_session_archive import (
+    ConversationHistoryArchive,
+    ConversationHistoryTurnRecord,
+    ConversationSessionArchive,
+)
+from dayu.host.conversation_store import ConversationTranscript
+from dayu.workspace_paths import CONVERSATION_STORE_RELATIVE_DIR
+
+
+_NEW_SCHEMA_KEY = "runtime_transcript"
+_LEGACY_TURNS_KEY = "turns"
+
+
+def migrate_conversation_archive_init(workspace_root: Path) -> int:
+    """将旧 transcript JSON 全量包装成 ``ConversationSessionArchive``。
+
+    Args:
+        workspace_root: 工作区根目录。
+
+    Returns:
+        实际被改写的文件数量。
+
+    Raises:
+        无：单文件失败仅 stderr warning 跳过；目录不存在则返回 0。
+    """
+
+    target_dir = workspace_root / CONVERSATION_STORE_RELATIVE_DIR
+    if not target_dir.is_dir():
+        return 0
+
+    rewritten = 0
+    for json_path in sorted(target_dir.glob("*.json")):
+        if _migrate_single_file(json_path):
+            rewritten += 1
+    return rewritten
+
+
+def _migrate_single_file(json_path: Path) -> bool:
+    """迁移单个 transcript JSON 文件。
+
+    Args:
+        json_path: 目标文件绝对路径。
+
+    Returns:
+        True 表示实际重写了文件；False 表示已是新 schema 或异常跳过。
+
+    Raises:
+        无：所有异常都被吞掉并 stderr warning。
+    """
+
+    try:
+        raw_text = json_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"⚠ 工作区迁移: 跳过 {json_path.name}（读取失败：{exc}）",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        payload: Any = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        print(
+            f"⚠ 工作区迁移: 跳过 {json_path.name}（JSON 解析失败：{exc}）",
+            file=sys.stderr,
+        )
+        return False
+    if not isinstance(payload, dict):
+        print(
+            f"⚠ 工作区迁移: 跳过 {json_path.name}（顶层不是对象）",
+            file=sys.stderr,
+        )
+        return False
+
+    if _NEW_SCHEMA_KEY in payload:
+        return False
+    if _LEGACY_TURNS_KEY not in payload:
+        return False
+
+    try:
+        runtime_transcript = ConversationTranscript.from_dict(payload)
+    except (ValueError, KeyError, TypeError) as exc:
+        print(
+            f"⚠ 工作区迁移: 跳过 {json_path.name}（旧 transcript 反序列化失败：{exc}）",
+            file=sys.stderr,
+        )
+        return False
+
+    history_records = tuple(
+        ConversationHistoryTurnRecord(
+            turn_id=turn.turn_id,
+            scene_name=turn.scene_name,
+            user_text=turn.user_text,
+            assistant_text=turn.assistant_final,
+            assistant_reasoning="",
+            created_at=turn.created_at,
+        )
+        for turn in runtime_transcript.turns
+    )
+    history_archive = ConversationHistoryArchive(
+        session_id=runtime_transcript.session_id,
+        turns=history_records,
+    )
+
+    archive = ConversationSessionArchive(
+        session_id=runtime_transcript.session_id,
+        revision=runtime_transcript.revision,
+        created_at=runtime_transcript.created_at,
+        updated_at=runtime_transcript.created_at,
+        runtime_transcript=runtime_transcript,
+        history_archive=history_archive,
+    )
+
+    new_text = json.dumps(archive.to_dict(), ensure_ascii=False, indent=2) + "\n"
+    try:
+        json_path.write_text(new_text, encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"⚠ 工作区迁移: 跳过 {json_path.name}（写回失败：{exc}）",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+__all__ = ["migrate_conversation_archive_init"]

--- a/dayu/cli/workspace_migrations/runner.py
+++ b/dayu/cli/workspace_migrations/runner.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from dayu.cli.workspace_migrations.conversation_archive_init import (
+    migrate_conversation_archive_init,
+)
 from dayu.cli.workspace_migrations.host_store_rename_concurrency_lane import (
     migrate_host_store_rename_concurrency_lane,
 )
@@ -55,4 +58,11 @@ def apply_all_workspace_migrations(*, base_dir: Path, config_dir: Path) -> None:
         print(
             "✓ 工作区迁移: Host SQLite pending turn 快照已剥离 "
             f"max_output_tokens 字段（共 {stripped} 行）"
+        )
+
+    archive_rewritten = migrate_conversation_archive_init(base_dir)
+    if archive_rewritten > 0:
+        print(
+            "✓ 工作区迁移: 旧 conversation transcript 已升级为 "
+            f"ConversationSessionArchive（共 {archive_rewritten} 个会话）"
         )

--- a/dayu/contracts/agent_types.py
+++ b/dayu/contracts/agent_types.py
@@ -172,6 +172,23 @@ class ConversationTurnPersistenceProtocol(Protocol):
     ) -> None:
         """持久化当前 conversation turn 的执行结果。"""
 
+    def record_reasoning_delta(self, chunk: str) -> None:
+        """累积本轮 reasoning 增量到展示侧 buffer。
+
+        语义说明：reasoning 仅作为历史展示字段持久化，**不**进入运行态送模、
+        memory、compaction、resume 决策链路。executor 在收到 reasoning 增量
+        事件时调用本方法做 buffer，``persist_turn`` 时统一刷入展示侧子视图。
+
+        Args:
+            chunk: 单次 reasoning 增量文本。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
 
 __all__ = [
     "AgentMessage",

--- a/dayu/contracts/session.py
+++ b/dayu/contracts/session.py
@@ -2,7 +2,7 @@
 
 定义会话（Session）的来源、状态和记录结构。
 Session 是宿主层对一个交互会话的元数据索引，存储在 SQLite 中。
-对话内容（ConversationTranscript）由 ConversationStore 独立管理。
+对话内容（ConversationSessionArchive）由 ConversationSessionArchiveStore 独立管理。
 """
 
 from __future__ import annotations

--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -481,6 +481,51 @@ Compaction 有两条触发路径，职责分离：
 
 具体的 token 预算数值、触发阈值倍数定义在 `dayu/config/run.json`、`dayu/contracts/execution_options.py::ConversationMemorySettings` 与 `dayu/host/conversation_memory.py`，三处默认值通过单元测试 `test_default_conversation_memory_settings_match_runtime_default` 保持一致。详细字段说明见 [config/README.md §5.8](../config/README.md)。
 
+### 10.9 会话存储（ConversationSessionArchive）
+
+会话级真源被收敛到一个聚合根 `ConversationSessionArchive`，定义在 `dayu/host/conversation_session_archive.py`，物理落盘在 `<workspace>/<CONVERSATION_STORE_RELATIVE_DIR>/<session_id>.json`。聚合根包含两个**逻辑分离、物理同写**的子视图：
+
+| 子视图 | 内容 | 谁能读 | 谁能写 |
+| --- | --- | --- | --- |
+| `runtime_transcript` | 运行态真源（`ConversationTurnRecord` 列表 + `compacted_turn_count` + memory layers） | 送模/memory/compaction/resume/prepared snapshot | `with_next_turn`（新轮）/ `with_runtime_transcript`（compaction 写回） |
+| `history_archive` | 仅供历史展示的扁平副本（`ConversationHistoryTurnRecord`，含 `assistant_reasoning`） | 历史展示链路 | 仅 `with_next_turn`（新轮同步推进） |
+
+**单聚合 / 单 revision / 单文件原子提交**：`runtime_transcript` 与 `history_archive` 共享同一 `archive.revision`，落盘走 `FileConversationSessionArchiveStore.save(archive, expected_revision=...)`：取文件锁 → 校验 revision → 临时文件 → fsync → replace → fsync 父目录。任一失败 → 整个聚合写失败、磁盘旧版本完整保留。**不**做 sidecar 双写、不做两阶段提交。
+
+**首轮装配走 `load_or_create`，不用 `save(expected_revision=None)`**：`scene_preparer.prepare` 在 session 第一次进来时通过 `archive_store.load_or_create(session_id)` 拿到真源——该方法在文件锁保护下做 load-or-create，先到的胜出、后到的拿到 live archive。这条路径**严禁**回退到"先 `load` 看是否存在再 `save(create_empty, expected_revision=None)`"——`save` 只在 `expected_revision is not None` 时做冲突校验，TOCTOU 窗口里的并发 prepare 会把另一进程已经写好的 live archive 直接覆盖成空文件。
+
+**`from_dict` fail-closed**：`ConversationSessionArchive.from_dict` 对 `history_archive` 字段缺失或非对象**直接抛 `ValueError`**，不静默降级为 `create_empty`。理由：`history_archive` 是聚合根的物理同写组成，缺失只可能是数据损坏或迁移不完整；若降级为空历史，下一次 `persist_turn` / compaction 写回会把这份空历史持久化覆盖，永久抹掉已有 `assistant_reasoning`。损坏数据必须走 migration / repair 路径修复，不通过运行态读取被静默吞掉。
+
+**结构边界（硬约束）**：
+
+- `runtime_transcript` / `ConversationTurnRecord` 字段集**不含** `assistant_reasoning`。
+- `history_archive` 内容**不进入** prepared snapshot / `resume_source_json` / `restore_prepared_execution` / `to_messages` / compaction 输入；它纯粹是展示侧字段。
+- 模块结构隔离由 `tests/application/test_history_archive_isolation.py` 反射式回归——`dayu/host/conversation_memory.py` / `pending_turn_store.py` / `prepared_turn.py` / `dayu/contracts/agent_execution.py` / `agent_execution_serialization.py` / `agent_types.py` 六处源码不得出现 `assistant_reasoning` / `ConversationHistoryTurnRecord` / `ConversationHistoryArchive` 三个 token。
+
+**reasoning 的采集与落盘**（`#118` 关键链路）：
+
+1. Engine 层流式产出 `EventType.REASONING_DELTA`。
+2. Executor 在 `agent_input.session_state` 存在时调 `session_state.record_reasoning_delta(text)`，否则静默丢弃。
+3. `ConversationSessionState` 把 chunk 累计在内部 `_reasoning_buffer`。
+4. 在 `persist_turn(...)` 时把 `"".join(_reasoning_buffer)` 一次性投影到 `ConversationHistoryTurnRecord.assistant_reasoning`，与新 `ConversationTurnRecord` 一同走 `with_next_turn` 推进聚合根，再一次原子落盘；落盘成功才清空 buffer，失败重试不丢内容。
+5. `ConversationTurnPersistenceProtocol.persist_turn` 签名**不变**——展示字段不污染契约。
+
+**resume：输入只信 prepared snapshot；输出走 reconcile-on-write**
+
+- **输入**：`restore_prepared_execution` 仍只从 `PreparedConversationSessionSnapshot.transcript` 重建运行态——prepare 与 resume 之间外部状态变化（清空、compaction、文件丢失）**不影响** resume 决策。
+- 重建 `current_archive` 时构造**临时 placeholder archive**：`runtime_transcript = snapshot.transcript`、`history_archive = create_empty(session_id)`、`revision = ""`。`revision == ""` 是路径分叉标记位。
+- **输出**：`persist_turn` 路径分叉
+  - `current_archive.revision == ""` → 走 `archive_store.append_turn(session_id, *, turn_record, history_record)`：取文件锁 → load live → live 缺失抛 `ConversationArchiveMissingError` → 在 live 上 `with_next_turn` → 原子写。**不**预设"自动 create_empty"，缺失时显式报错（清空 vs pending turn 并发处置策略由 `#117` 决定）。
+  - 否则（正常路径）→ `with_next_turn` + `save(... expected_revision=current_archive.revision)`。
+
+**compaction：两层 stale-check（业务层 + 物理层）**
+
+- **业务层**：比较 `live.runtime_transcript.revision` 与 `compaction_input_transcript.revision`，不一致 → 丢弃结果（依靠下一轮 turn 触发 schedule_compaction 自愈）。这一层**不能**被偷换成"只看 archive 乐观锁"。
+- **物理层**：`archive_store.save(next_archive, expected_revision=live.revision)`。
+- compaction 任何路径**不修改** `history_archive`，仅通过 `with_runtime_transcript` 替换运行态子视图。
+
+**旧 schema 迁移**：`dayu-cli init` 走 `dayu/cli/workspace_migrations/conversation_archive_init.py`：识别"顶层缺 `runtime_transcript` 但含 `turns`"的旧 transcript 文件，原地包成 archive；`history_archive.turns` 全量从旧 turns 投影（`assistant_reasoning=""`）。损坏文件 warning 跳过、新 schema 文件 no-op。`FileConversationSessionArchiveStore.load` 遇到旧 schema 直接抛 `RuntimeError` 提示运行迁移，**不**做兼容读取。
+
 ---
 
 ## 11. 场景准备（scene preparation）

--- a/dayu/host/_coercion.py
+++ b/dayu/host/_coercion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 
 def _coerce_string_tuple(values: object) -> tuple[str, ...]:
     """将任意列表值规范化为字符串元组。
@@ -26,4 +28,39 @@ def _coerce_string_tuple(values: object) -> tuple[str, ...]:
     return tuple(normalized)
 
 
-__all__ = ["_coerce_string_tuple"]
+def _utc_now_iso() -> str:
+    """返回当前 UTC 时间的 ISO 字符串。
+
+    Args:
+        无。
+
+    Returns:
+        ISO 8601 字符串。
+
+    Raises:
+        无。
+    """
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_session_id(session_id: str) -> str:
+    """规范化 session_id。
+
+    Args:
+        session_id: 原始会话 ID。
+
+    Returns:
+        去除首尾空白后的会话 ID。
+
+    Raises:
+        ValueError: 当会话 ID 为空时抛出。
+    """
+
+    normalized = str(session_id or "").strip()
+    if not normalized:
+        raise ValueError("session_id 不能为空")
+    return normalized
+
+
+__all__ = ["_coerce_string_tuple", "_normalize_session_id", "_utc_now_iso"]

--- a/dayu/host/conversation_memory.py
+++ b/dayu/host/conversation_memory.py
@@ -24,7 +24,7 @@ from dayu.host._coercion import _coerce_string_tuple
 from dayu.host.conversation_store import (
     ConversationEpisodeSummary,
     ConversationPinnedState,
-    ConversationStore,
+    ConversationSessionArchiveStore,
     ConversationToolUseSummary,
     ConversationTranscript,
     ConversationTurnRecord,
@@ -1131,7 +1131,7 @@ class DefaultConversationMemoryManager:
         self,
         runtime: ConversationRuntimeProtocol,
         *,
-        conversation_store: ConversationStore,
+        archive_store: ConversationSessionArchiveStore,
         working_memory_policy: WorkingMemoryPolicyProtocol | None = None,
         episodic_memory_compressor: EpisodicMemoryCompressorProtocol | None = None,
         durable_memory_store: DurableMemoryStoreProtocol | None = None,
@@ -1142,7 +1142,7 @@ class DefaultConversationMemoryManager:
 
         Args:
             runtime: 默认 Runtime 实现。
-            conversation_store: transcript 存储。
+            archive_store: 会话 archive 存储。
             working_memory_policy: working memory 策略。
             episodic_memory_compressor: episode 摘要压缩器。
             durable_memory_store: durable memory 存储。
@@ -1157,7 +1157,7 @@ class DefaultConversationMemoryManager:
         """
 
         self._runtime = runtime
-        self._conversation_store = conversation_store
+        self._archive_store = archive_store
         self._working_memory_policy = working_memory_policy or DefaultWorkingMemoryPolicy()
         self._episodic_memory_compressor = episodic_memory_compressor or DefaultEpisodicMemoryCompressor(runtime)
         self._durable_memory_store = durable_memory_store or NullDurableMemoryStore()
@@ -1226,7 +1226,22 @@ class DefaultConversationMemoryManager:
                 episodes=(*current.episodes, result.episode_summary),
                 compacted_turn_count=current.compacted_turn_count + len(candidate_turns),
             )
-            current = self._conversation_store.save(next_transcript, expected_revision=current.revision)
+            # archive 形态下：只在聚合根上替换运行态子视图，``history_archive`` 原样保留。
+            live_archive = self._archive_store.load(session_id)
+            if live_archive is None or live_archive.runtime_transcript.revision != current.revision:
+                # 同步 compaction 罕见冲突路径（外部并发推进 archive）：放弃本次写回，
+                # 与既有 _run_compaction 自愈链路一致——下一轮 turn 会重新触发判定。
+                Log.verbose(
+                    f"同步 compaction 写回 archive 冲突，跳过本次：session_id={session_id}",
+                    module=MODULE,
+                )
+                return current
+            next_archive = live_archive.with_runtime_transcript(next_transcript)
+            persisted_archive = self._archive_store.save(
+                next_archive,
+                expected_revision=live_archive.revision,
+            )
+            current = persisted_archive.runtime_transcript
             self._retrieval_index.index_transcript(current)
             Log.verbose(
                 f"同步压缩写回 transcript: session_id={session_id}, revision={current.revision}, compacted_turn_count={current.compacted_turn_count}",
@@ -1558,10 +1573,11 @@ class DefaultConversationMemoryManager:
                     module=MODULE,
                 )
                 return
-            current_transcript = self._conversation_store.load(session_id)
-            if current_transcript is None:
-                Log.debug(f"后台 compaction 写回前 transcript 已不存在: session_id={session_id}", module=MODULE)
+            live_archive = self._archive_store.load(session_id)
+            if live_archive is None:
+                Log.debug(f"后台 compaction 写回前 archive 已不存在: session_id={session_id}", module=MODULE)
                 return
+            current_transcript = live_archive.runtime_transcript
             if current_transcript.revision != transcript.revision:
                 # REVIEW NOTE (finding 078, 驳回留观):
                 # revision 冲突时本次后台压缩结果被丢弃且**不在此处退避重试**。
@@ -1573,6 +1589,13 @@ class DefaultConversationMemoryManager:
                 #    抢占调度器"，与新到来的 schedule 产生竞态窗口（cancel vs 重入）。
                 # 3. 失效场景只有"session 永久闲置"，此时 compaction 的价值本身也消失。
                 # 下一位 reviewer：若要改动此分支，请先核对上述自愈假设是否仍成立。
+                #
+                # archive 形态硬规则：业务层 stale-check 比较的是
+                # ``live.runtime_transcript.revision``（与运行态语义对齐），不是
+                # ``live.revision``（那是物理层 archive 乐观锁的参与方）。两层语义
+                # 必须保持独立——禁止偷换为 archive.revision 比较，否则在
+                # history_archive 单独被推进、runtime_transcript 未变的场景下会
+                # 误判 stale。
                 Log.verbose(
                     f"conversation compaction 结果已过期，跳过写回：session_id={session_id}",
                     module=MODULE,
@@ -1583,7 +1606,9 @@ class DefaultConversationMemoryManager:
                 episodes=(*current_transcript.episodes, result.episode_summary),
                 compacted_turn_count=current_transcript.compacted_turn_count + len(turns),
             )
-            self._conversation_store.save(next_transcript, expected_revision=current_transcript.revision)
+            # archive 形态：只替换运行态子视图，``history_archive`` 原样保留。
+            next_archive = live_archive.with_runtime_transcript(next_transcript)
+            self._archive_store.save(next_archive, expected_revision=live_archive.revision)
             self._retrieval_index.index_transcript(next_transcript)
             Log.verbose(
                 f"后台 compaction 写回成功: session_id={session_id}, revision={next_transcript.revision}, compacted_turn_count={next_transcript.compacted_turn_count}",

--- a/dayu/host/conversation_session_archive.py
+++ b/dayu/host/conversation_session_archive.py
@@ -1,0 +1,420 @@
+"""会话存储聚合根 ``ConversationSessionArchive`` 与历史展示子视图。
+
+本模块定义 Host 落盘的会话存储聚合根：
+
+- ``runtime_transcript``：运行态送模视图，沿用 ``ConversationTranscript``，
+  字段集合不变；conversation memory / compaction / 送模 prompt 装配
+  仅消费此子视图。
+- ``history_archive``：历史展示子视图，承载 ``assistant_reasoning`` 等
+  仅供 UI 历史回放使用、**绝不**进入运行态决策的字段。
+
+聚合根硬约束：
+
+- 单聚合、单 revision、单文件原子提交。
+- ``runtime_transcript`` 与 ``history_archive`` 必须在同一次写入下原子推进。
+- ``with_*`` 在推进 ``archive.revision`` 时同步刷新
+  ``runtime_transcript.revision``，保持两者一致以兼容现有读运行态字段访问；
+  乐观锁参与方仍是 ``archive.revision``。
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+
+from dayu.host.conversation_store import (
+    ConversationTranscript,
+    ConversationTurnRecord,
+)
+
+
+def _utc_now_iso() -> str:
+    """返回当前 UTC 时间的 ISO 字符串。
+
+    Args:
+        无。
+
+    Returns:
+        ISO 8601 字符串。
+
+    Raises:
+        无。
+    """
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_session_id(session_id: str) -> str:
+    """规范化 session_id。
+
+    Args:
+        session_id: 原始会话 ID。
+
+    Returns:
+        去除首尾空白后的会话 ID。
+
+    Raises:
+        ValueError: 当 ID 为空时抛出。
+    """
+
+    normalized = str(session_id or "").strip()
+    if not normalized:
+        raise ValueError("session_id 不能为空")
+    return normalized
+
+
+class ConversationArchiveMissingError(RuntimeError):
+    """live archive 缺失时由 archive store reconcile 路径抛出。
+
+    显式语义：``append_turn`` 在 reconcile-on-write 路径下要求 live archive
+    存在；缺失时不预设默认行为（例如自动 ``create_empty``），而是直接报错，
+    把"清空 vs pending turn 并发"的处置策略留给上层（``#117``）决定。
+    """
+
+
+@dataclass(frozen=True)
+class ConversationHistoryTurnRecord:
+    """历史展示子视图中的单轮记录。
+
+    Attributes:
+        turn_id: 与同步写入的 ``ConversationTurnRecord.turn_id`` 一一对应。
+        scene_name: 触发该轮的 scene 名称。
+        user_text: 用户输入文本。
+        assistant_text: 助手最终回复文本。
+        assistant_reasoning: 助手 reasoning 文本，**仅展示**，禁止参与运行态。
+        created_at: 创建时间 ISO 字符串。
+    """
+
+    turn_id: str
+    scene_name: str
+    user_text: str
+    assistant_text: str
+    assistant_reasoning: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class ConversationHistoryArchive:
+    """历史展示子视图聚合。
+
+    Attributes:
+        session_id: 会话 ID。
+        turns: 按时间从旧到新排列的历史轮次。
+    """
+
+    session_id: str
+    turns: tuple[ConversationHistoryTurnRecord, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def create_empty(cls, session_id: str) -> "ConversationHistoryArchive":
+        """创建空 history archive。
+
+        Args:
+            session_id: 会话 ID。
+
+        Returns:
+            空 history archive。
+
+        Raises:
+            ValueError: 当会话 ID 为空时抛出。
+        """
+
+        return cls(session_id=_normalize_session_id(session_id), turns=())
+
+    def append_turn(self, record: ConversationHistoryTurnRecord) -> "ConversationHistoryArchive":
+        """追加一条历史记录。
+
+        Args:
+            record: 新增历史记录。
+
+        Returns:
+            追加后的 history archive。
+
+        Raises:
+            无。
+        """
+
+        return ConversationHistoryArchive(
+            session_id=self.session_id,
+            turns=(*self.turns, record),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """序列化为 JSON 对象。
+
+        Args:
+            无。
+
+        Returns:
+            JSON 可序列化字典。
+
+        Raises:
+            无。
+        """
+
+        return {
+            "session_id": self.session_id,
+            "turns": [
+                {
+                    "turn_id": turn.turn_id,
+                    "scene_name": turn.scene_name,
+                    "user_text": turn.user_text,
+                    "assistant_text": turn.assistant_text,
+                    "assistant_reasoning": turn.assistant_reasoning,
+                    "created_at": turn.created_at,
+                }
+                for turn in self.turns
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "ConversationHistoryArchive":
+        """从 JSON 对象反序列化。
+
+        Args:
+            data: 原始 JSON 对象。
+
+        Returns:
+            ``ConversationHistoryArchive`` 实例。
+
+        Raises:
+            ValueError: 当核心字段非法时抛出。
+        """
+
+        session_id = _normalize_session_id(str(data.get("session_id") or ""))
+        raw_turns = data.get("turns")
+        turns: list[ConversationHistoryTurnRecord] = []
+        if isinstance(raw_turns, list):
+            for raw_turn in raw_turns:
+                if not isinstance(raw_turn, dict):
+                    continue
+                turns.append(
+                    ConversationHistoryTurnRecord(
+                        turn_id=str(raw_turn.get("turn_id") or "").strip() or uuid.uuid4().hex,
+                        scene_name=str(raw_turn.get("scene_name") or "").strip(),
+                        user_text=str(raw_turn.get("user_text") or ""),
+                        assistant_text=str(raw_turn.get("assistant_text") or ""),
+                        assistant_reasoning=str(raw_turn.get("assistant_reasoning") or ""),
+                        created_at=str(raw_turn.get("created_at") or "").strip() or _utc_now_iso(),
+                    )
+                )
+        return cls(session_id=session_id, turns=tuple(turns))
+
+
+@dataclass(frozen=True)
+class ConversationSessionArchive:
+    """会话存储聚合根。
+
+    单 revision、单文件原子提交；``runtime_transcript`` 与
+    ``history_archive`` 任一推进都必须经过聚合根的 ``with_*`` 接口。
+
+    Attributes:
+        session_id: 会话 ID。
+        revision: 聚合根 revision，作为乐观锁参与方。
+        created_at: 创建时间 ISO 字符串。
+        updated_at: 更新时间 ISO 字符串。
+        runtime_transcript: 运行态送模视图。
+        history_archive: 历史展示子视图。
+    """
+
+    session_id: str
+    revision: str
+    created_at: str
+    updated_at: str
+    runtime_transcript: ConversationTranscript
+    history_archive: ConversationHistoryArchive
+
+    @classmethod
+    def create_empty(cls, session_id: str) -> "ConversationSessionArchive":
+        """创建空聚合根。
+
+        Args:
+            session_id: 会话 ID。
+
+        Returns:
+            空 ``ConversationSessionArchive``。
+
+        Raises:
+            ValueError: 当会话 ID 为空时抛出。
+        """
+
+        normalized_session_id = _normalize_session_id(session_id)
+        now = _utc_now_iso()
+        archive_revision = uuid.uuid4().hex
+        runtime_transcript = ConversationTranscript.create_empty(normalized_session_id)
+        runtime_transcript = replace(runtime_transcript, revision=archive_revision)
+        history_archive = ConversationHistoryArchive.create_empty(normalized_session_id)
+        return cls(
+            session_id=normalized_session_id,
+            revision=archive_revision,
+            created_at=now,
+            updated_at=now,
+            runtime_transcript=runtime_transcript,
+            history_archive=history_archive,
+        )
+
+    def with_next_turn(
+        self,
+        turn_record: ConversationTurnRecord,
+        history_record: ConversationHistoryTurnRecord,
+    ) -> "ConversationSessionArchive":
+        """同步推进运行态与历史展示子视图。
+
+        Args:
+            turn_record: 新增运行态 turn。
+            history_record: 与之一一对应的历史展示记录；``turn_id`` 必须一致。
+
+        Returns:
+            推进后的聚合根。
+
+        Raises:
+            ValueError: 当 ``turn_id`` 不一致时抛出。
+        """
+
+        if turn_record.turn_id != history_record.turn_id:
+            raise ValueError(
+                "ConversationSessionArchive.with_next_turn 要求 turn_record 与 history_record "
+                f"的 turn_id 一致：runtime={turn_record.turn_id!r}, history={history_record.turn_id!r}"
+            )
+        next_runtime_transcript = self.runtime_transcript.append_turn(turn_record)
+        next_history_archive = self.history_archive.append_turn(history_record)
+        return self._with_synchronized_revision(
+            runtime_transcript=next_runtime_transcript,
+            history_archive=next_history_archive,
+        )
+
+    def with_runtime_transcript(
+        self,
+        runtime_transcript: ConversationTranscript,
+    ) -> "ConversationSessionArchive":
+        """仅替换运行态子视图。
+
+        compaction 写回路径专用：``history_archive`` 原样保留。
+
+        Args:
+            runtime_transcript: 新的运行态子视图。
+
+        Returns:
+            替换后的聚合根。
+
+        Raises:
+            无。
+        """
+
+        return self._with_synchronized_revision(
+            runtime_transcript=runtime_transcript,
+            history_archive=self.history_archive,
+        )
+
+    def _with_synchronized_revision(
+        self,
+        *,
+        runtime_transcript: ConversationTranscript,
+        history_archive: ConversationHistoryArchive,
+    ) -> "ConversationSessionArchive":
+        """推进聚合根 revision 并同步刷新 runtime_transcript.revision。
+
+        Args:
+            runtime_transcript: 新的运行态子视图。
+            history_archive: 新的历史展示子视图。
+
+        Returns:
+            推进后的聚合根。
+
+        Raises:
+            无。
+        """
+
+        next_archive_revision = uuid.uuid4().hex
+        synchronized_runtime_transcript = replace(runtime_transcript, revision=next_archive_revision)
+        return ConversationSessionArchive(
+            session_id=self.session_id,
+            revision=next_archive_revision,
+            created_at=self.created_at,
+            updated_at=_utc_now_iso(),
+            runtime_transcript=synchronized_runtime_transcript,
+            history_archive=history_archive,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """序列化聚合根为 JSON 对象。
+
+        Args:
+            无。
+
+        Returns:
+            JSON 可序列化字典。
+
+        Raises:
+            无。
+        """
+
+        from dayu.host.conversation_store import _serialize_transcript  # 避免循环导入语义膨胀
+
+        return {
+            "schema": "conversation_session_archive/v1",
+            "session_id": self.session_id,
+            "revision": self.revision,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "runtime_transcript": _serialize_transcript(self.runtime_transcript),
+            "history_archive": self.history_archive.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "ConversationSessionArchive":
+        """从 JSON 对象反序列化聚合根。
+
+        Args:
+            data: 原始 JSON 对象。
+
+        Returns:
+            ``ConversationSessionArchive`` 实例。
+
+        Raises:
+            ValueError: 当核心字段非法或缺失运行态子视图时抛出。
+        """
+
+        if "runtime_transcript" not in data:
+            raise ValueError(
+                "conversation session archive 缺少 runtime_transcript 字段，"
+                "可能仍是旧 schema，请运行 dayu-cli init 完成迁移"
+            )
+        session_id = _normalize_session_id(str(data.get("session_id") or ""))
+        raw_runtime_transcript = data.get("runtime_transcript")
+        if not isinstance(raw_runtime_transcript, dict):
+            raise ValueError("conversation session archive runtime_transcript 必须是对象")
+        runtime_transcript = ConversationTranscript.from_dict(raw_runtime_transcript)
+        if "history_archive" not in data:
+            raise ValueError(
+                "conversation session archive 缺少 history_archive 字段；"
+                "新 schema 要求显式承载历史展示子视图。请通过 dayu-cli init "
+                "或 repair 流程修复，禁止静默降级为空历史以避免覆盖丢失 reasoning。"
+            )
+        raw_history_archive = data.get("history_archive")
+        if not isinstance(raw_history_archive, dict):
+            raise ValueError(
+                "conversation session archive history_archive 必须是对象，"
+                "禁止静默降级为空历史。"
+            )
+        history_archive = ConversationHistoryArchive.from_dict(raw_history_archive)
+        revision = str(data.get("revision") or "").strip() or runtime_transcript.revision
+        created_at = str(data.get("created_at") or "").strip() or runtime_transcript.created_at
+        updated_at = str(data.get("updated_at") or "").strip() or created_at
+        return cls(
+            session_id=session_id,
+            revision=revision,
+            created_at=created_at,
+            updated_at=updated_at,
+            runtime_transcript=runtime_transcript,
+            history_archive=history_archive,
+        )
+
+
+__all__ = [
+    "ConversationArchiveMissingError",
+    "ConversationHistoryArchive",
+    "ConversationHistoryTurnRecord",
+    "ConversationSessionArchive",
+]

--- a/dayu/host/conversation_session_archive.py
+++ b/dayu/host/conversation_session_archive.py
@@ -21,47 +21,15 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field, replace
-from datetime import datetime, timezone
 
+from dayu.host._coercion import _normalize_session_id, _utc_now_iso
 from dayu.host.conversation_store import (
     ConversationTranscript,
     ConversationTurnRecord,
 )
+from dayu.log import Log
 
-
-def _utc_now_iso() -> str:
-    """返回当前 UTC 时间的 ISO 字符串。
-
-    Args:
-        无。
-
-    Returns:
-        ISO 8601 字符串。
-
-    Raises:
-        无。
-    """
-
-    return datetime.now(timezone.utc).isoformat()
-
-
-def _normalize_session_id(session_id: str) -> str:
-    """规范化 session_id。
-
-    Args:
-        session_id: 原始会话 ID。
-
-    Returns:
-        去除首尾空白后的会话 ID。
-
-    Raises:
-        ValueError: 当 ID 为空时抛出。
-    """
-
-    normalized = str(session_id or "").strip()
-    if not normalized:
-        raise ValueError("session_id 不能为空")
-    return normalized
+_MODULE = "HOST.CONVERSATION_SESSION_ARCHIVE"
 
 
 class ConversationArchiveMissingError(RuntimeError):
@@ -188,6 +156,10 @@ class ConversationHistoryArchive:
         if isinstance(raw_turns, list):
             for raw_turn in raw_turns:
                 if not isinstance(raw_turn, dict):
+                    Log.warning(
+                        f"history_archive 跳过非法 turn 元素（非对象）: session_id={session_id}",
+                        module=_MODULE,
+                    )
                     continue
                 turns.append(
                     ConversationHistoryTurnRecord(

--- a/dayu/host/conversation_store.py
+++ b/dayu/host/conversation_store.py
@@ -1,4 +1,20 @@
-"""通用会话 transcript 存储抽象与默认实现。"""
+"""会话 transcript 数据类与 archive store 抽象 / 默认实现。
+
+本模块同时承载三类职责：
+
+1. ``ConversationTranscript`` / ``ConversationTurnRecord`` /
+   ``ConversationPinnedState`` / ``ConversationEpisodeSummary``：运行态送模真源
+   的数据结构。
+2. ``ConversationSessionArchiveStore`` Protocol：archive 聚合根的存储抽象。
+3. ``FileConversationSessionArchiveStore``：基于文件系统的默认实现，封装文件
+   锁、原子写、fsync 等 IO 工具。
+
+把 store 抽象与运行态数据类放在同一模块，是因为
+``ConversationSessionArchive``（定义于 ``conversation_session_archive``）依赖
+``ConversationTranscript``；如果再让 store 反过来依赖 archive 模块，会形成
+循环导入。当前组织把 transcript 数据类与 store 抽象同住、archive 聚合根
+单独成模块，是务实的边界划分。
+"""
 
 from __future__ import annotations
 
@@ -9,7 +25,6 @@ import tempfile
 import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Protocol, TextIO
 
@@ -22,37 +37,16 @@ if TYPE_CHECKING:
 import dayu.file_lock as file_lock_module
 
 from dayu.log import Log
-from dayu.host._coercion import _coerce_string_tuple
+from dayu.host._coercion import (
+    _coerce_string_tuple,
+    _normalize_session_id,
+    _utc_now_iso,
+)
 
 _SESSION_FILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 MODULE = "HOST.CONVERSATION_STORE"
 _CONVERSATION_LOCK_REGION_BYTES = 1
 _LOCK_FILE_SUFFIX = ".lock"
-
-
-def _utc_now_iso() -> str:
-    """返回当前 UTC 时间的 ISO 字符串。"""
-
-    return datetime.now(timezone.utc).isoformat()
-
-
-def _normalize_session_id(session_id: str) -> str:
-    """规范化 session_id。
-
-    Args:
-        session_id: 原始会话 ID。
-
-    Returns:
-        去除首尾空白后的会话 ID。
-
-    Raises:
-        ValueError: 当会话 ID 为空时抛出。
-    """
-
-    normalized = str(session_id or "").strip()
-    if not normalized:
-        raise ValueError("session_id 不能为空")
-    return normalized
 
 
 def _coerce_non_negative_int(value: object, *, default: int = 0) -> int:

--- a/dayu/host/conversation_store.py
+++ b/dayu/host/conversation_store.py
@@ -11,7 +11,13 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator, Protocol, TextIO
+from typing import TYPE_CHECKING, Iterator, Protocol, TextIO
+
+if TYPE_CHECKING:
+    from dayu.host.conversation_session_archive import (
+        ConversationHistoryTurnRecord,
+        ConversationSessionArchive,
+    )
 
 import dayu.file_lock as file_lock_module
 
@@ -498,52 +504,122 @@ def _parse_turn_list(raw: object) -> tuple[ConversationTurnRecord, ...]:
     return tuple(turns)
 
 
-class ConversationStore(Protocol):
-    """会话 transcript 存储协议。"""
+class ConversationSessionArchiveStore(Protocol):
+    """会话 archive 存储协议。
 
-    def load(self, session_id: str) -> ConversationTranscript | None:
-        """读取指定 session 的 transcript。
+    存储对象升级为 ``ConversationSessionArchive`` 聚合根；``runtime_transcript``
+    与 ``history_archive`` 子视图通过聚合根在单文件下原子提交。
+    """
+
+    def load(self, session_id: str) -> "ConversationSessionArchive | None":
+        """读取指定 session 的 archive。
 
         Args:
             session_id: 会话 ID。
 
         Returns:
-            transcript；不存在时返回 ``None``。
+            archive；不存在时返回 ``None``。
 
         Raises:
             ValueError: session_id 非法时抛出。
+            RuntimeError: 磁盘内容是旧 transcript schema 时抛出。
         """
         ...
 
     def save(
         self,
-        transcript: ConversationTranscript,
+        archive: "ConversationSessionArchive",
         *,
         expected_revision: str | None = None,
-    ) -> ConversationTranscript:
-        """保存 transcript。
+    ) -> "ConversationSessionArchive":
+        """保存 archive。
 
         Args:
-            transcript: 待保存 transcript。
-            expected_revision: 预期旧 revision；用于乐观锁控制。
+            archive: 待保存 archive。
+            expected_revision: 预期旧 archive revision；用于乐观锁控制。
 
         Returns:
-            实际保存后的 transcript。
+            实际保存后的 archive。
 
         Raises:
             RuntimeError: revision 冲突时抛出。
         """
         ...
 
+    def load_or_create(self, session_id: str) -> "ConversationSessionArchive":
+        """读取 archive；若磁盘缺失则在锁内原子创建空 archive。
 
-class FileConversationStore:
-    """基于文件系统的 transcript 存储。"""
+        ``prepare`` 首轮装配真源专用：消除 ``load -> save(expected_revision=None)``
+        之间的 TOCTOU 窗口，避免并发 prepare 把另一进程已经写好的 live archive
+        覆盖成空文件。
+
+        语义：取 session 文件锁 -> ``load`` live -> 若 ``None`` 则**在锁内**
+        原子写入 ``ConversationSessionArchive.create_empty(session_id)`` -> 返回
+        live archive 或新建 archive。任何并发写入只会让先到的胜出，后到的拿到
+        live archive 而不会回写空版本。
+
+        Args:
+            session_id: 会话 ID。
+
+        Returns:
+            读到或新建的 archive。
+
+        Raises:
+            ValueError: session_id 非法时抛出。
+            RuntimeError: 磁盘内容是旧 transcript schema 时抛出。
+        """
+        ...
+
+    def append_turn(
+        self,
+        session_id: str,
+        *,
+        turn_record: ConversationTurnRecord,
+        history_record: "ConversationHistoryTurnRecord",
+    ) -> "ConversationSessionArchive":
+        """resume 落盘专用：在 live archive 上 reconcile 写入新一轮。
+
+        语义：取 session 文件锁 -> ``load`` live -> 若 ``None`` 则抛
+        ``ConversationArchiveMissingError`` -> 在 live 上 ``with_next_turn`` 推进 ->
+        单文件原子写。**不**预设"自动 create_empty"策略。
+
+        Args:
+            session_id: 会话 ID。
+            turn_record: 新增运行态 turn。
+            history_record: 与之一一对应的历史展示记录。
+
+        Returns:
+            落盘后的 archive。
+
+        Raises:
+            ConversationArchiveMissingError: live archive 缺失时抛出。
+            ValueError: 当 ``turn_id`` 不一致时抛出。
+        """
+        ...
+
+    def delete(self, session_id: str) -> bool:
+        """删除指定 session 的 archive。
+
+        Args:
+            session_id: 会话 ID。
+
+        Returns:
+            archive 文件存在并被删除返回 ``True``，否则 ``False``。
+
+        Raises:
+            ValueError: session_id 非法时抛出。
+        """
+        ...
+
+
+class FileConversationSessionArchiveStore:
+    """基于文件系统的 archive 存储。"""
 
     def __init__(self, root_dir: Path) -> None:
         """初始化存储实现。
 
         Args:
-            root_dir: transcript 根目录。
+            root_dir: archive 根目录。
 
         Returns:
             无。
@@ -557,75 +633,197 @@ class FileConversationStore:
         self._lock_dir = self._root_dir / ".locks"
         self._lock_dir.mkdir(parents=True, exist_ok=True)
 
-    def load(self, session_id: str) -> ConversationTranscript | None:
-        """读取指定 session 的 transcript。
+    def load(self, session_id: str) -> "ConversationSessionArchive | None":
+        """读取指定 session 的 archive。
 
         Args:
             session_id: 会话 ID。
 
         Returns:
-            transcript；文件不存在时返回 ``None``。
+            archive；文件不存在时返回 ``None``。
 
         Raises:
             ValueError: session_id 为空时抛出。
+            RuntimeError: 磁盘内容是旧 transcript schema 时抛出。
         """
+
+        from dayu.host.conversation_session_archive import ConversationSessionArchive
 
         file_path = self._resolve_file_path(session_id)
         if not file_path.exists():
-            Log.debug(f"transcript 不存在: session_id={session_id}", module=MODULE)
+            Log.debug(f"archive 不存在: session_id={session_id}", module=MODULE)
             return None
         payload = json.loads(file_path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
-            raise ValueError(f"conversation transcript 非法: {file_path}")
-        Log.debug(f"加载 transcript: session_id={session_id}, file={file_path.name}", module=MODULE)
-        return ConversationTranscript.from_dict(payload)
+            raise ValueError(f"conversation session archive 非法: {file_path}")
+        if "runtime_transcript" not in payload and "turns" in payload:
+            raise RuntimeError(
+                "conversation transcript 已升级为 archive schema，请运行 dayu-cli init 完成迁移："
+                f"session_id={session_id}, file={file_path}"
+            )
+        Log.debug(f"加载 archive: session_id={session_id}, file={file_path.name}", module=MODULE)
+        return ConversationSessionArchive.from_dict(payload)
 
     def save(
         self,
-        transcript: ConversationTranscript,
+        archive: "ConversationSessionArchive",
         *,
         expected_revision: str | None = None,
-    ) -> ConversationTranscript:
-        """保存 transcript。
+    ) -> "ConversationSessionArchive":
+        """保存 archive。
 
         Args:
-            transcript: 待保存 transcript。
-            expected_revision: 预期旧 revision；用于乐观锁控制。
+            archive: 待保存 archive。
+            expected_revision: 预期旧 archive revision；用于乐观锁控制。
 
         Returns:
-            实际保存后的 transcript。
+            实际保存后的 archive。
 
         Raises:
             RuntimeError: revision 冲突时抛出。
         """
 
-        file_path = self._resolve_file_path(transcript.session_id)
-        with self._transcript_file_lock(transcript.session_id):
+        file_path = self._resolve_file_path(archive.session_id)
+        with self._transcript_file_lock(archive.session_id):
             if file_path.exists():
-                existing = self.load(transcript.session_id)
-                if existing is not None and expected_revision is not None and existing.revision != expected_revision:
+                existing = self.load(archive.session_id)
+                if (
+                    existing is not None
+                    and expected_revision is not None
+                    and existing.revision != expected_revision
+                ):
                     Log.warning(
-                        "conversation transcript revision 冲突: "
-                        f"session_id={transcript.session_id}, expected={expected_revision}, actual={existing.revision}",
+                        "conversation session archive revision 冲突: "
+                        f"session_id={archive.session_id}, expected={expected_revision}, actual={existing.revision}",
                         module=MODULE,
                     )
                     raise RuntimeError(
-                        "conversation transcript revision 冲突："
-                        f"session_id={transcript.session_id}, expected={expected_revision}, actual={existing.revision}"
+                        "conversation session archive revision 冲突："
+                        f"session_id={archive.session_id}, expected={expected_revision}, actual={existing.revision}"
                     )
-            # 文件不存在时直接写入：首轮 transcript 仅存在于内存，不构成并发冲突
+            # 文件不存在时直接写入：首轮 archive 仅存在于内存，不构成并发冲突
             _atomic_write_text(
                 file_path,
-                json.dumps(_serialize_transcript(transcript), ensure_ascii=False, indent=2),
+                json.dumps(archive.to_dict(), ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
         Log.debug(
-            "保存 transcript: "
-            f"session_id={transcript.session_id}, revision={transcript.revision}, turns={len(transcript.turns)}, "
-            f"episodes={len(transcript.episodes)}, compacted_turn_count={transcript.compacted_turn_count}",
+            "保存 archive: "
+            f"session_id={archive.session_id}, revision={archive.revision}, "
+            f"turns={len(archive.runtime_transcript.turns)}, history_turns={len(archive.history_archive.turns)}",
             module=MODULE,
         )
-        return transcript
+        return archive
+
+    def load_or_create(self, session_id: str) -> "ConversationSessionArchive":
+        """读取 archive；磁盘缺失时在锁内原子创建空 archive。
+
+        消除 ``prepare`` 首轮装配真源的 TOCTOU 窗口：``load`` 与 ``save`` 之间
+        若另一进程已经写好真实 archive，普通的
+        ``save(create_empty, expected_revision=None)`` 会把对方刚落下的历史
+        覆盖成空文件。本方法在文件锁保护下做 load-or-create，先到的胜出，
+        后到的拿到 live archive。
+
+        Args:
+            session_id: 会话 ID。
+
+        Returns:
+            读到或新建的 archive。
+
+        Raises:
+            ValueError: session_id 非法时抛出。
+            RuntimeError: 磁盘内容是旧 transcript schema 时抛出。
+        """
+
+        from dayu.host.conversation_session_archive import ConversationSessionArchive
+
+        normalized_session_id = _normalize_session_id(session_id)
+        file_path = self._resolve_file_path(normalized_session_id)
+        with self._transcript_file_lock(normalized_session_id):
+            existing = self.load(normalized_session_id)
+            if existing is not None:
+                return existing
+            new_archive = ConversationSessionArchive.create_empty(normalized_session_id)
+            _atomic_write_text(
+                file_path,
+                json.dumps(new_archive.to_dict(), ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        Log.debug(
+            f"创建空 archive: session_id={normalized_session_id}, revision={new_archive.revision}",
+            module=MODULE,
+        )
+        return new_archive
+
+    def append_turn(
+        self,
+        session_id: str,
+        *,
+        turn_record: ConversationTurnRecord,
+        history_record: "ConversationHistoryTurnRecord",
+    ) -> "ConversationSessionArchive":
+        """resume 落盘专用：在 live archive 上 reconcile 写入新一轮。
+
+        Args:
+            session_id: 会话 ID。
+            turn_record: 新增运行态 turn。
+            history_record: 与之一一对应的历史展示记录。
+
+        Returns:
+            落盘后的 archive。
+
+        Raises:
+            ConversationArchiveMissingError: live archive 缺失时抛出。
+            ValueError: 当 ``turn_id`` 不一致时抛出。
+        """
+
+        from dayu.host.conversation_session_archive import ConversationArchiveMissingError
+
+        normalized_session_id = _normalize_session_id(session_id)
+        file_path = self._resolve_file_path(normalized_session_id)
+        with self._transcript_file_lock(normalized_session_id):
+            live = self.load(normalized_session_id)
+            if live is None:
+                raise ConversationArchiveMissingError(
+                    "conversation session archive 缺失，无法 reconcile-on-write："
+                    f"session_id={normalized_session_id}"
+                )
+            next_archive = live.with_next_turn(turn_record, history_record)
+            _atomic_write_text(
+                file_path,
+                json.dumps(next_archive.to_dict(), ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        Log.debug(
+            "reconcile 写入 archive: "
+            f"session_id={normalized_session_id}, revision={next_archive.revision}, "
+            f"turns={len(next_archive.runtime_transcript.turns)}",
+            module=MODULE,
+        )
+        return next_archive
+
+    def delete(self, session_id: str) -> bool:
+        """删除指定 session 的 archive。
+
+        Args:
+            session_id: 会话 ID。
+
+        Returns:
+            archive 文件存在并被删除返回 ``True``，否则 ``False``。
+
+        Raises:
+            ValueError: session_id 非法时抛出。
+        """
+
+        normalized_session_id = _normalize_session_id(session_id)
+        file_path = self._resolve_file_path(normalized_session_id)
+        with self._transcript_file_lock(normalized_session_id):
+            if not file_path.exists():
+                return False
+            file_path.unlink()
+            _fsync_parent_directory(file_path)
+        Log.debug(f"删除 archive: session_id={normalized_session_id}", module=MODULE)
+        return True
 
     def _resolve_file_path(self, session_id: str) -> Path:
         """解析指定 session 的文件路径。
@@ -686,9 +884,9 @@ class FileConversationStore:
 __all__ = [
     "ConversationEpisodeSummary",
     "ConversationPinnedState",
-    "ConversationStore",
+    "ConversationSessionArchiveStore",
     "ConversationToolUseSummary",
     "ConversationTranscript",
     "ConversationTurnRecord",
-    "FileConversationStore",
+    "FileConversationSessionArchiveStore",
 ]

--- a/dayu/host/executor.py
+++ b/dayu/host/executor.py
@@ -1287,6 +1287,13 @@ class DefaultHostExecutor(HostExecutorProtocol):
                 final_content = str(stream_event.data.get("content") or "")
                 degraded = bool(stream_event.data.get("degraded", False))
                 filtered = bool(stream_event.data.get("filtered", False))
+            elif stream_event.type == EventType.REASONING_DELTA:
+                # reasoning 仅作为历史展示字段 buffer，不进入运行态 transcript / persist。
+                # session_state 缺失时静默丢弃；reasoning 是展示侧能力，不应阻塞 run。
+                if agent_input.session_state is not None:
+                    agent_input.session_state.record_reasoning_delta(
+                        str(stream_event.data or "")
+                    )
         if replay_capture is not None:
             # 即使被取消或失败也把当前历史快照交给 caller，由调用方决定是否登记。
             replay_capture.messages = list(running_messages)

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -20,7 +20,10 @@ from dayu.contracts.session import SessionRecord, SessionSource, SessionState
 from dayu.execution.options import ResolvedExecutionOptions
 from dayu.engine.tool_registry import ToolRegistry
 from dayu.host.concurrency import SQLiteConcurrencyGovernor
-from dayu.host.conversation_store import ConversationStore, FileConversationStore
+from dayu.host.conversation_store import (
+    ConversationSessionArchiveStore,
+    FileConversationSessionArchiveStore,
+)
 from dayu.host.executor import DefaultHostExecutor, should_delete_pending_turn_after_terminal_run
 from dayu.host.host_execution import HostExecutorProtocol, HostedRunContext, HostedRunSpec
 from dayu.host._datetime_utils import now_utc as _now_utc
@@ -112,16 +115,16 @@ def _to_pending_turn_summary(record: PendingConversationTurn) -> PendingTurnSumm
     )
 
 
-def _build_default_conversation_store(
+def _build_default_conversation_archive_store(
     workspace: WorkspaceResourcesProtocol | None,
-) -> ConversationStore | None:
-    """根据工作区构造默认 conversation 存储。
+) -> ConversationSessionArchiveStore | None:
+    """根据工作区构造默认 conversation archive 存储。
 
     Args:
         workspace: Host 运行所需工作区稳定资源。
 
     Returns:
-        conversation 存储；未提供工作区时返回 ``None``。
+        conversation archive 存储；未提供工作区时返回 ``None``。
 
     Raises:
         无。
@@ -129,7 +132,9 @@ def _build_default_conversation_store(
 
     if workspace is None:
         return None
-    return FileConversationStore(build_conversation_store_dir(workspace.workspace_dir))
+    return FileConversationSessionArchiveStore(
+        build_conversation_store_dir(workspace.workspace_dir)
+    )
 
 
 def _empty_conversation_session_digest() -> ConversationSessionDigest:
@@ -221,7 +226,7 @@ class Host:
         concurrency_governor: ConcurrencyGovernorProtocol | None = None,
         pending_turn_store: PendingConversationTurnStoreProtocol | None = None,
         reply_outbox_store: ReplyOutboxStoreProtocol | None = None,
-        conversation_store: ConversationStore | None = None,
+        archive_store: ConversationSessionArchiveStore | None = None,
     ) -> None:
         """初始化 Host。"""
 
@@ -260,16 +265,16 @@ class Host:
             self._event_bus = event_bus
             self._pending_turn_resume_max_attempts = pending_turn_resume_max_attempts
             self._pending_turn_retention = timedelta(hours=pending_turn_retention_hours)
-            self._conversation_store = conversation_store or _build_default_conversation_store(workspace)
+            self._archive_store = archive_store or _build_default_conversation_archive_store(workspace)
             return
 
         if host_store_path is None:
             raise ValueError("默认 Host 装配缺少 host_store_path")
 
-        # 默认装配路径下 Host 与内部 ScenePreparer 共享同一 conversation_store 实例，
+        # 默认装配路径下 Host 与内部 ScenePreparer 共享同一 archive_store 实例，
         # 避免出现指向同一 workspace 目录的多实例（文件锁虽保证跨实例一致性，
         # 但内存缓存/订阅状态无法共享，后续若引入 transcript 缓存会触发 stale read）。
-        shared_conversation_store = conversation_store or _build_default_conversation_store(workspace)
+        shared_archive_store = archive_store or _build_default_conversation_archive_store(workspace)
         default_components = _build_default_host_components(
             workspace=workspace,
             model_catalog=model_catalog,
@@ -277,7 +282,7 @@ class Host:
             host_store_path=host_store_path,
             lane_config=lane_config,
             event_bus=event_bus,
-            conversation_store=shared_conversation_store,
+            archive_store=shared_archive_store,
         )
         self._executor = executor or default_components._executor
         self._session_registry = session_registry or default_components._session_registry
@@ -288,7 +293,7 @@ class Host:
         self._event_bus = event_bus
         self._pending_turn_resume_max_attempts = pending_turn_resume_max_attempts
         self._pending_turn_retention = timedelta(hours=pending_turn_retention_hours)
-        self._conversation_store = shared_conversation_store
+        self._archive_store = shared_archive_store
 
     def create_session(
         self,
@@ -431,15 +436,15 @@ class Host:
             无。
         """
 
-        if self._conversation_store is None:
+        if self._archive_store is None:
             return _empty_conversation_session_digest()
-        transcript = self._conversation_store.load(session_id)
-        if transcript is None or not transcript.turns:
+        archive = self._archive_store.load(session_id)
+        if archive is None or not archive.runtime_transcript.turns:
             return _empty_conversation_session_digest()
-        first_turn = transcript.turns[0]
-        last_turn = transcript.turns[-1]
+        first_turn = archive.runtime_transcript.turns[0]
+        last_turn = archive.runtime_transcript.turns[-1]
         return ConversationSessionDigest(
-            turn_count=len(transcript.turns),
+            turn_count=len(archive.runtime_transcript.turns),
             first_question_preview=_truncate_conversation_preview(first_turn.user_text),
             last_question_preview=_truncate_conversation_preview(last_turn.user_text),
         )
@@ -463,12 +468,12 @@ class Host:
             无。
         """
 
-        if self._conversation_store is None or limit <= 0:
+        if self._archive_store is None or limit <= 0:
             return []
-        transcript = self._conversation_store.load(session_id)
-        if transcript is None or not transcript.turns:
+        archive = self._archive_store.load(session_id)
+        if archive is None or not archive.runtime_transcript.turns:
             return []
-        recent_turns = transcript.turns[-limit:]
+        recent_turns = archive.runtime_transcript.turns[-limit:]
         return [
             ConversationSessionTurnExcerpt(
                 user_text=turn.user_text,
@@ -1713,7 +1718,7 @@ def _build_default_host_components(
     host_store_path: Path,
     lane_config: dict[str, int] | None,
     event_bus: RunEventBusProtocol | None,
-    conversation_store: ConversationStore | None,
+    archive_store: ConversationSessionArchiveStore | None,
 ) -> _DefaultHostComponents:
     """构造 Host 默认内部子组件。
 
@@ -1724,7 +1729,7 @@ def _build_default_host_components(
         host_store_path: Host SQLite 路径。
         lane_config: 并发 lane 配置。
         event_bus: 事件总线。
-        conversation_store: Host 外层构造并共享的 conversation 存储；
+        archive_store: Host 外层构造并共享的 conversation archive 存储；
             传入后将由内部 ScenePreparer 与 Host 公共字段复用同一实例。
 
     Returns:
@@ -1751,7 +1756,7 @@ def _build_default_host_components(
         workspace=workspace,
         model_catalog=model_catalog,
         default_execution_options=default_execution_options,
-        conversation_store=conversation_store,
+        archive_store=archive_store,
     )
     executor = DefaultHostExecutor(
         run_registry=run_registry,
@@ -1775,7 +1780,7 @@ def _build_default_scene_preparation(
     workspace: WorkspaceResourcesProtocol | None,
     model_catalog: ModelCatalogProtocol | None,
     default_execution_options: ResolvedExecutionOptions | None,
-    conversation_store: ConversationStore | None,
+    archive_store: ConversationSessionArchiveStore | None,
 ) -> DefaultScenePreparer | None:
     """构造 Host 默认 scene preparation。
 
@@ -1783,7 +1788,7 @@ def _build_default_scene_preparation(
         workspace: 工作区稳定资源。
         model_catalog: 模型目录。
         default_execution_options: 默认执行基线。
-        conversation_store: 由 Host 构造并共享的 conversation 存储；
+        archive_store: 由 Host 构造并共享的 conversation archive 存储；
             传入 ``None`` 时 ScenePreparer 会回退为按 workspace 自建实例，
             正式默认装配路径不应使用该回退。
     Returns:
@@ -1812,7 +1817,7 @@ def _build_default_scene_preparation(
         model_catalog=model_catalog,
         default_execution_options=default_execution_options,
         tool_registry_factory=lambda: ToolRegistry(),
-        conversation_store=conversation_store,
+        archive_store=archive_store,
     )
 
 

--- a/dayu/host/scene_preparer.py
+++ b/dayu/host/scene_preparer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 import uuid
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Literal, Protocol, cast, runtime_checkable
 
@@ -51,11 +51,17 @@ from dayu.host.conversation_runtime import (
     ConversationCompactionSceneProtocol,
 )
 from dayu.host.conversation_store import (
-    ConversationStore,
+    ConversationSessionArchiveStore,
     ConversationToolUseSummary,
     ConversationTranscript,
     ConversationTurnRecord,
-    FileConversationStore,
+    FileConversationSessionArchiveStore,
+)
+from dayu.host.conversation_session_archive import (
+    ConversationArchiveMissingError,
+    ConversationHistoryArchive,
+    ConversationHistoryTurnRecord,
+    ConversationSessionArchive,
 )
 from dayu.host.host_execution import HostedRunContext
 from dayu.host.prepared_turn import PreparedAgentTurnSnapshot, PreparedConversationSessionSnapshot
@@ -181,16 +187,60 @@ class PreparedSceneState:
 
 @dataclass
 class ConversationSessionState:
-    """多轮 Host Session 的会话状态快照。"""
+    """多轮 Host Session 的会话状态快照。
+
+    ``current_archive`` 是落盘真源；``transcript`` 仅暴露运行态送模子视图，
+    ``_reasoning_buffer`` 在 turn 内累积 reasoning 流式 chunk，仅在
+    ``persist_turn`` 落盘时投影进 ``history_archive``，**绝不**进入运行态
+    transcript / messages / memory / compaction 任何路径。
+    """
 
     session_id: str
     scene_name: str
-    transcript: ConversationTranscript
-    conversation_store: ConversationStore
+    current_archive: ConversationSessionArchive
+    archive_store: ConversationSessionArchiveStore
     memory_manager: DefaultConversationMemoryManager
     prepared_scene: PreparedSceneState
     user_message: str
     system_prompt: str
+    _reasoning_buffer: list[str] = field(default_factory=list, init=False)
+
+    @property
+    def transcript(self) -> ConversationTranscript:
+        """返回当前 archive 的运行态送模子视图。
+
+        Args:
+            无。
+
+        Returns:
+            ``current_archive.runtime_transcript``。
+
+        Raises:
+            无。
+        """
+
+        return self.current_archive.runtime_transcript
+
+    def record_reasoning_delta(self, chunk: str) -> None:
+        """累积本轮 reasoning 流式增量到展示侧 buffer。
+
+        展示侧字段：仅在 ``persist_turn`` 时投影到 ``history_archive``，
+        不进入运行态 transcript / 送模 messages / memory / compaction。
+
+        Args:
+            chunk: 流式 reasoning 增量文本。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        normalized = str(chunk or "")
+        if not normalized:
+            return
+        self._reasoning_buffer.append(normalized)
 
     def persist_turn(
         self,
@@ -201,7 +251,34 @@ class ConversationSessionState:
         warnings: tuple[str, ...],
         errors: tuple[str, ...],
     ) -> None:
-        """把当前轮结果写回 transcript 并调度后台压缩。"""
+        """把当前轮结果写回 archive 并调度后台压缩。
+
+        路径分叉（必须在构造 ``next_archive`` 之前）：
+
+        - ``current_archive.revision == ""`` 表示当前 archive 是 resume 路径
+          的临时 placeholder（不持有 live revision）。走
+          ``archive_store.append_turn(... reconcile-on-write)`` 落盘合并 live。
+          缺失 live archive 时 ``ConversationArchiveMissingError`` 直接上抛。
+        - 否则（正常路径）走 ``with_next_turn`` + ``save(expected_revision=...)``
+          的乐观锁路径。
+
+        任一步失败 → 异常上抛、``_reasoning_buffer`` 不清空（重试不丢内容）、
+        磁盘旧 archive 完整。
+
+        Args:
+            final_content: assistant 最终回复文本。
+            degraded: 本轮是否进入降级路径。
+            tool_uses: 本轮工具调用摘要。
+            warnings: 本轮告警。
+            errors: 本轮错误。
+
+        Returns:
+            无。
+
+        Raises:
+            ConversationArchiveMissingError: resume 路径下 live archive 缺失时抛出。
+            RuntimeError: 乐观锁冲突时抛出。
+        """
 
         turn_record = ConversationTurnRecord(
             turn_id=f"turn_{uuid.uuid4().hex[:8]}",
@@ -213,12 +290,32 @@ class ConversationSessionState:
             warnings=warnings,
             errors=errors,
         )
-        next_transcript = self.transcript.append_turn(turn_record)
-        persisted = self.conversation_store.save(next_transcript, expected_revision=self.transcript.revision)
+        history_record = ConversationHistoryTurnRecord(
+            turn_id=turn_record.turn_id,
+            scene_name=turn_record.scene_name,
+            user_text=turn_record.user_text,
+            assistant_text=final_content,
+            assistant_reasoning="".join(self._reasoning_buffer),
+            created_at=turn_record.created_at,
+        )
+        if self.current_archive.revision == "":
+            persisted = self.archive_store.append_turn(
+                self.session_id,
+                turn_record=turn_record,
+                history_record=history_record,
+            )
+        else:
+            next_archive = self.current_archive.with_next_turn(turn_record, history_record)
+            persisted = self.archive_store.save(
+                next_archive,
+                expected_revision=self.current_archive.revision,
+            )
+        self.current_archive = persisted
+        self._reasoning_buffer.clear()
         self.memory_manager.schedule_compaction(
             session_id=self.session_id,
             prepared_scene=self.prepared_scene,
-            transcript=persisted,
+            transcript=persisted.runtime_transcript,
             system_prompt=self.system_prompt,
         )
 
@@ -352,20 +449,23 @@ class DefaultScenePreparer(ScenePreparationProtocol):
     model_catalog: ModelCatalogProtocol
     default_execution_options: ResolvedExecutionOptions
     tool_registry_factory: ToolRegistryFactory
-    conversation_store: ConversationStore | None = None
+    archive_store: ConversationSessionArchiveStore | None = None
 
     def __post_init__(self) -> None:
         """初始化辅助依赖。"""
 
         self._prompt_composer = PromptComposer()
         self._trace_provider = TraceRecorderFactoryProvider()
-        self._conversation_store_impl = self.conversation_store or FileConversationStore(
-            build_conversation_store_dir(self.workspace.workspace_dir)
+        self._archive_store_impl: ConversationSessionArchiveStore = (
+            self.archive_store
+            or FileConversationSessionArchiveStore(
+                build_conversation_store_dir(self.workspace.workspace_dir)
+            )
         )
         self._conversation_runtime = _ConversationRuntimeAdapter(self)
         self._memory_manager = DefaultConversationMemoryManager(
             self._conversation_runtime,
-            conversation_store=self._conversation_store_impl,
+            archive_store=self._archive_store_impl,
         )
 
     async def prepare(
@@ -399,26 +499,32 @@ class DefaultScenePreparer(ScenePreparationProtocol):
         session_state: ConversationSessionState | None = None
         if prepared_scene.scene_definition.conversation.enabled and session_key:
             await self._memory_manager.cancel_pending_compaction(session_key)
-            existing_transcript = self._conversation_store_impl.load(session_key)
-            transcript = existing_transcript or ConversationTranscript.create_empty(session_key)
+            existing_archive = self._archive_store_impl.load_or_create(session_key)
+            current_archive = existing_archive
             transcript = await self._memory_manager.prepare_transcript(
                 session_id=session_key,
                 prepared_scene=prepared_scene,
-                transcript=transcript,
+                transcript=current_archive.runtime_transcript,
                 system_prompt=system_prompt,
                 user_text=user_message,
             )
+            if transcript.revision != current_archive.runtime_transcript.revision:
+                # prepare_transcript 内部走 archive_store.save 后，archive 已被推进；
+                # 这里重新读 live archive 保证 current_archive 持有最新 revision。
+                refreshed = self._archive_store_impl.load(session_key)
+                if refreshed is not None:
+                    current_archive = refreshed
             messages = self._memory_manager.build_messages(
                 prepared_scene=prepared_scene,
-                transcript=transcript,
+                transcript=current_archive.runtime_transcript,
                 system_prompt=system_prompt,
                 user_text=user_message,
             )
             session_state = ConversationSessionState(
                 session_id=session_key,
                 scene_name=execution_contract.scene_name,
-                transcript=transcript,
-                conversation_store=self._conversation_store_impl,
+                current_archive=current_archive,
+                archive_store=self._archive_store_impl,
                 memory_manager=self._memory_manager,
                 prepared_scene=prepared_scene,
                 user_message=user_message,
@@ -472,11 +578,21 @@ class DefaultScenePreparer(ScenePreparationProtocol):
         session_state: ConversationSessionState | None = None
         session_snapshot = prepared_turn.conversation_session
         if session_snapshot is not None:
+            # resume 输入只信 prepared snapshot：构造临时 placeholder archive，
+            # revision="" 标记位让 persist_turn 走 reconcile-on-write 落盘合并 live。
+            placeholder_archive = ConversationSessionArchive(
+                session_id=session_snapshot.session_id,
+                revision="",
+                created_at=session_snapshot.transcript.created_at,
+                updated_at=session_snapshot.transcript.updated_at,
+                runtime_transcript=session_snapshot.transcript,
+                history_archive=ConversationHistoryArchive.create_empty(session_snapshot.session_id),
+            )
             session_state = ConversationSessionState(
                 session_id=session_snapshot.session_id,
                 scene_name=prepared_turn.scene_name,
-                transcript=session_snapshot.transcript,
-                conversation_store=self._conversation_store_impl,
+                current_archive=placeholder_archive,
+                archive_store=self._archive_store_impl,
                 memory_manager=self._memory_manager,
                 prepared_scene=prepared_scene,
                 user_message=session_snapshot.user_message,

--- a/tests/application/test_executor_reasoning_collection.py
+++ b/tests/application/test_executor_reasoning_collection.py
@@ -1,0 +1,177 @@
+"""Executor REASONING_DELTA → session_state.record_reasoning_delta 接线测试。
+
+守住 `#118` 接线契约：
+
+1. 当 ``agent_input.session_state`` 提供时，executor 必须把 REASONING_DELTA 流式
+   增量原文转交给 ``session_state.record_reasoning_delta``。
+2. ``session_state`` 缺失时 REASONING_DELTA 被静默丢弃，不抛异常、不污染流。
+3. reasoning 永不进入运行态 transcript（持久化后仍守住该约束）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import dayu.host.executor as executor_module
+from dayu.contracts.agent_execution import AgentCreateArgs, AgentInput
+from dayu.engine.events import EventType, StreamEvent
+from dayu.host import scene_preparer as scene_preparer_module
+from dayu.host.conversation_session_archive import ConversationSessionArchive
+from dayu.host.conversation_store import FileConversationSessionArchiveStore
+from dayu.host.executor import DefaultHostExecutor
+from tests.application.conftest import StubPendingTurnStore, StubRunRegistry
+
+
+def _build_stub_executor() -> DefaultHostExecutor:
+    """构造仅满足 ``_run_prepared_agent_stream`` 直接调用的 executor。"""
+
+    return DefaultHostExecutor(
+        run_registry=cast("executor_module.RunRegistryProtocol", StubRunRegistry()),
+        pending_turn_store=cast(
+            "executor_module.PendingConversationTurnStoreProtocol",
+            StubPendingTurnStore(),
+        ),
+        scene_preparation=cast(
+            "executor_module.ScenePreparationProtocol", SimpleNamespace()
+        ),
+    )
+
+
+class _StreamScriptedAgent:
+    """按脚本顺序产出 StreamEvent 的最小 stub agent。"""
+
+    def __init__(self, script: list[StreamEvent]) -> None:
+        self._script = script
+
+    async def run_messages(self, messages, *, session_id, run_id, stream):
+        del messages, session_id, run_id, stream
+        for event in self._script:
+            yield event
+
+
+def _drain_executor_stream(
+    executor: DefaultHostExecutor,
+    *,
+    agent_input: AgentInput,
+    session_id: str | None = None,
+) -> list[object]:
+    """收集 ``_run_prepared_agent_stream`` 输出。
+
+    需要先在 run_registry 注册 + start，否则 stream 结束时
+    ``complete_run`` 会因为找不到 run_id 报 KeyError。
+    """
+
+    record = executor.run_registry.register_run(
+        session_id=session_id, service_type="chat_turn"
+    )
+    executor.run_registry.start_run(record.run_id)
+    collected: list[object] = []
+
+    async def _run() -> None:
+        async for event in executor._run_prepared_agent_stream(
+            run_id=record.run_id,
+            session_id=session_id,
+            pending_turn_id=None,
+            agent_input=agent_input,
+        ):
+            collected.append(event)
+
+    asyncio.run(_run())
+    return collected
+
+
+@pytest.mark.unit
+def test_executor_forwards_reasoning_delta_to_session_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REASONING_DELTA → session_state.record_reasoning_delta，FINAL_ANSWER 正常处理。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = store.save(
+        ConversationSessionArchive.create_empty("sess_exec1"),
+        expected_revision=None,
+    )
+    captured: list[object] = []
+
+    def _schedule(*, session_id, prepared_scene, transcript, system_prompt) -> None:
+        del session_id, prepared_scene, transcript, system_prompt
+        captured.append("scheduled")
+
+    state = scene_preparer_module.ConversationSessionState(
+        session_id="sess_exec1",
+        scene_name="interactive",
+        current_archive=archive,
+        archive_store=store,
+        memory_manager=cast(
+            scene_preparer_module.DefaultConversationMemoryManager,
+            SimpleNamespace(schedule_compaction=_schedule),
+        ),
+        prepared_scene=cast(
+            scene_preparer_module.PreparedSceneState, SimpleNamespace()
+        ),
+        user_message="问题",
+        system_prompt="SYS",
+    )
+
+    script = [
+        StreamEvent(EventType.REASONING_DELTA, "想-", {}),
+        StreamEvent(EventType.REASONING_DELTA, "一下", {}),
+        StreamEvent(EventType.FINAL_ANSWER, {"content": "答", "degraded": False}, {}),
+    ]
+    monkeypatch.setattr(
+        executor_module,
+        "build_async_agent",
+        lambda **_: _StreamScriptedAgent(script),
+    )
+
+    executor = _build_stub_executor()
+    agent_input = AgentInput(
+        system_prompt="SYS",
+        messages=[],
+        agent_create_args=AgentCreateArgs(runner_type="openai_compatible", model_name="m"),
+        session_state=state,
+    )
+    _drain_executor_stream(executor, agent_input=agent_input, session_id="sess_exec1")
+
+    # executor 在 FINAL_ANSWER 后已经调用 persist_turn，buffer 被清空，
+    # reasoning 已经投影到 history_archive。
+    assert state._reasoning_buffer == []
+    persisted = store.load("sess_exec1")
+    assert persisted is not None
+    assert persisted.history_archive.turns[-1].assistant_reasoning == "想-一下"
+    runtime_turn = persisted.runtime_transcript.turns[-1]
+    assert not hasattr(runtime_turn, "assistant_reasoning")
+    assert runtime_turn.assistant_final == "答"
+
+
+@pytest.mark.unit
+def test_executor_silently_drops_reasoning_delta_when_session_state_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """session_state 为 None 时 REASONING_DELTA 静默丢弃，run 不抛错。"""
+
+    script = [
+        StreamEvent(EventType.REASONING_DELTA, "ignored", {}),
+        StreamEvent(EventType.FINAL_ANSWER, {"content": "ok", "degraded": False}, {}),
+    ]
+    monkeypatch.setattr(
+        executor_module,
+        "build_async_agent",
+        lambda **_: _StreamScriptedAgent(script),
+    )
+    executor = _build_stub_executor()
+    agent_input = AgentInput(
+        system_prompt="SYS",
+        messages=[],
+        agent_create_args=AgentCreateArgs(runner_type="openai_compatible", model_name="m"),
+        session_state=None,
+    )
+    # 不应抛异常
+    events = _drain_executor_stream(executor, agent_input=agent_input)
+    # 至少 FINAL_ANSWER 被映射出去（具体事件类型留给 build_app_event_from_stream_event 决定）
+    assert events  # 非空即可，不依赖具体 mapping 数量

--- a/tests/application/test_history_archive_isolation.py
+++ b/tests/application/test_history_archive_isolation.py
@@ -1,0 +1,54 @@
+"""结构性回归保险：禁止历史展示字段污染运行态真源。
+
+`#118` 把 `assistant_reasoning` 作为展示侧字段独立放在 `ConversationHistoryArchive`
+里，不能扩散到 `ConversationTurnRecord` / pending turn / prepared turn /
+agent execution 序列化等运行态契约模块。本文件以源码反射方式硬性守住该边界。
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from dayu.host.conversation_store import ConversationTurnRecord
+
+_FORBIDDEN_TOKENS = (
+    "assistant_reasoning",
+    "ConversationHistoryTurnRecord",
+    "ConversationHistoryArchive",
+)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+_GUARDED_FILES = (
+    "dayu/host/conversation_memory.py",
+    "dayu/host/pending_turn_store.py",
+    "dayu/host/prepared_turn.py",
+    "dayu/contracts/agent_execution.py",
+    "dayu/contracts/agent_execution_serialization.py",
+    "dayu/contracts/agent_types.py",
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("relative_path", _GUARDED_FILES)
+def test_runtime_modules_must_not_reference_history_archive_tokens(
+    relative_path: str,
+) -> None:
+    """运行态契约/记忆/恢复模块不得出现历史展示字段相关 token。"""
+
+    source = (_PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+    for token in _FORBIDDEN_TOKENS:
+        assert token not in source, (
+            f"{relative_path} 不允许出现历史展示字段 token: {token}"
+        )
+
+
+@pytest.mark.unit
+def test_conversation_turn_record_field_set_excludes_assistant_reasoning() -> None:
+    """`ConversationTurnRecord` 字段集严禁含 `assistant_reasoning`。"""
+
+    field_names = {f.name for f in fields(ConversationTurnRecord)}
+    assert "assistant_reasoning" not in field_names

--- a/tests/application/test_host_commands.py
+++ b/tests/application/test_host_commands.py
@@ -684,11 +684,11 @@ def test_format_helpers_cover_invalid_and_elapsed_cases(monkeypatch: pytest.Monk
 
 
 @pytest.mark.unit
-def test_default_host_assembly_shares_conversation_store_with_scene_preparer(tmp_path: Path) -> None:
-    """Host 默认装配应让 ScenePreparer 与 Host 本体持有同一 conversation_store 实例。
+def test_default_host_assembly_shares_archive_store_with_scene_preparer(tmp_path: Path) -> None:
+    """Host 默认装配应让 ScenePreparer 与 Host 本体持有同一 archive_store 实例。
 
     回归 review 条目 080：此前 `DefaultScenePreparer.__post_init__` 会在未收到外部
-    conversation_store 时自建 `FileConversationStore`，导致 Host 与其内部 ScenePreparer
+    archive_store 时自建实例，导致 Host 与其内部 ScenePreparer
     指向同一目录的两个独立实例，未来引入 transcript 内存缓存会触发 stale read。
     """
 
@@ -699,7 +699,7 @@ def test_default_host_assembly_shares_conversation_store_with_scene_preparer(tmp
         OpenAIRunnerRuntimeConfig,
     )
     from dayu.host.host import _build_default_host_components
-    from dayu.host.conversation_store import FileConversationStore
+    from dayu.host.conversation_store import FileConversationSessionArchiveStore
     from dayu.host.scene_preparer import DefaultScenePreparer
     from dayu.workspace_paths import build_conversation_store_dir
 
@@ -718,7 +718,7 @@ def test_default_host_assembly_shares_conversation_store_with_scene_preparer(tmp
         trace_settings=TraceSettings(enabled=False, output_dir=tmp_path / "trace"),
         temperature=None,
     )
-    shared_store = FileConversationStore(build_conversation_store_dir(workspace_root))
+    shared_store = FileConversationSessionArchiveStore(build_conversation_store_dir(workspace_root))
     components = _build_default_host_components(
         workspace=workspace,
         model_catalog=cast(Any, object()),
@@ -726,10 +726,10 @@ def test_default_host_assembly_shares_conversation_store_with_scene_preparer(tmp
         host_store_path=tmp_path / "host.sqlite3",
         lane_config={"llm_api": 1},
         event_bus=None,
-        conversation_store=shared_store,
+        archive_store=shared_store,
     )
 
     executor = components._executor
     scene_preparation = cast(DefaultScenePreparer, executor.scene_preparation)
     assert scene_preparation is not None
-    assert scene_preparation._conversation_store_impl is shared_store
+    assert scene_preparation._archive_store_impl is shared_store

--- a/tests/application/test_host_executor.py
+++ b/tests/application/test_host_executor.py
@@ -938,6 +938,9 @@ def test_run_agent_stream_skips_persist_turn_after_external_cancel(monkeypatch: 
         def __init__(self) -> None:
             self.persist_calls: list[dict[str, object]] = []
 
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
+
         def persist_turn(self, **kwargs) -> None:
             self.persist_calls.append(kwargs)
 
@@ -1016,6 +1019,9 @@ def test_run_agent_stream_emits_verbose_logs_for_pending_turn_lifecycle(monkeypa
         def __init__(self) -> None:
             self.persist_calls = 0
             self.pending_states_during_persist: list[PendingConversationTurnState] = []
+
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
 
         def persist_turn(self, **_kwargs) -> None:
             self.persist_calls += 1
@@ -1433,6 +1439,9 @@ def test_run_agent_stream_keeps_prepared_pending_turn_when_persist_turn_fails(mo
     from tests.application.conftest import StubPendingTurnStore, StubRunRegistry
 
     class _BrokenSessionState:
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
+
         def persist_turn(self, **_kwargs) -> None:
             raise RuntimeError("persist failed")
 
@@ -1505,6 +1514,9 @@ def test_run_agent_stream_keeps_success_when_sent_to_llm_update_fails(monkeypatc
     class _RecordingSessionState:
         def __init__(self) -> None:
             self.persist_calls = 0
+
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
 
         def persist_turn(self, **_kwargs) -> None:
             self.persist_calls += 1
@@ -1583,6 +1595,9 @@ def test_run_agent_stream_delete_pending_failure_keeps_succeeded_run_and_blocks_
     from tests.application.conftest import StubHostExecutor, StubPendingTurnStore, StubRunRegistry, StubSessionRegistry
 
     class _RecordingSessionState:
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
+
         def persist_turn(self, **_kwargs) -> None:
             return None
 
@@ -2110,6 +2125,9 @@ def test_resume_pending_turn_stream_keeps_lease_through_executor(
     )
 
     class _RecordingSessionState:
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
+
         def persist_turn(self, **_kwargs) -> None:
             return None
 
@@ -2353,6 +2371,9 @@ def test_resume_pending_turn_stream_rebinds_source_run_id_and_blocks_reresume_wh
     )
 
     class _RecordingSessionState:
+        def record_reasoning_delta(self, chunk: str) -> None:
+            del chunk
+
         def persist_turn(self, **_kwargs) -> None:
             return None
 

--- a/tests/application/test_resume_does_not_carry_reasoning.py
+++ b/tests/application/test_resume_does_not_carry_reasoning.py
@@ -1,0 +1,214 @@
+"""resume 链路不携带 reasoning + reconcile-on-write 契约测试。
+
+守住 `#118` 关键契约：
+
+1. ``serialize_prepared_agent_turn_snapshot`` 序列化结果不出现
+   ``assistant_reasoning`` key/字符串。
+2. resume 输出 reconcile（live 存在）：``persist_turn`` 在 live 之上推进，
+   不会用 prepared snapshot 的旧 transcript 覆盖 live。
+3. resume 输出 reconcile（live 缺失）：``persist_turn`` 抛
+   ``ConversationArchiveMissingError``，不静默 ``create_empty``。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from dayu.contracts.agent_execution import AgentCreateArgs
+from dayu.execution.options import ConversationMemorySettings
+from dayu.host import scene_preparer as scene_preparer_module
+from dayu.host.conversation_session_archive import (
+    ConversationArchiveMissingError,
+    ConversationHistoryArchive,
+    ConversationSessionArchive,
+)
+from dayu.host.conversation_store import (
+    ConversationTranscript,
+    ConversationTurnRecord,
+    FileConversationSessionArchiveStore,
+)
+from dayu.host.prepared_turn import (
+    PreparedAgentTurnSnapshot,
+    PreparedConversationSessionSnapshot,
+    serialize_prepared_agent_turn_snapshot,
+)
+from dayu.contracts.host_execution import ConcurrencyAcquirePolicy
+from dayu.contracts.execution_metadata import empty_execution_delivery_context
+from dayu.contracts.agent_execution import ExecutionPermissions
+
+
+def _make_prepared_snapshot(transcript: ConversationTranscript) -> PreparedAgentTurnSnapshot:
+    """构造最小 PreparedAgentTurnSnapshot，绑定 conversation_session。"""
+
+    return PreparedAgentTurnSnapshot(
+        service_name="chat_turn",
+        scene_name="interactive",
+        metadata=empty_execution_delivery_context(),
+        business_concurrency_lane=None,
+        timeout_ms=None,
+        resumable=True,
+        system_prompt="SYS",
+        messages=[],
+        agent_create_args=AgentCreateArgs(runner_type="openai_compatible", model_name="m"),
+        selected_toolsets=(),
+        execution_permissions=ExecutionPermissions(),
+        toolset_configs=(),
+        trace_settings=None,
+        conversation_memory_settings=ConversationMemorySettings(),
+        concurrency_acquire_policy=ConcurrencyAcquirePolicy.use_host_default(),
+        trace_identity=None,
+        conversation_session=PreparedConversationSessionSnapshot(
+            session_id=transcript.session_id,
+            user_message="Q-resume",
+            transcript=transcript,
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_prepared_snapshot_serialization_does_not_carry_reasoning() -> None:
+    """prepared snapshot 序列化中既无 ``assistant_reasoning`` key 也无对应字符串。"""
+
+    transcript = ConversationTranscript.create_empty("sess_resume_serial")
+    transcript = transcript.append_turn(
+        ConversationTurnRecord(
+            turn_id="turn_1",
+            scene_name="interactive",
+            user_text="Q1",
+            assistant_final="A1",
+        )
+    )
+    snapshot = _make_prepared_snapshot(transcript)
+
+    payload = serialize_prepared_agent_turn_snapshot(snapshot)
+    serialized_text = json.dumps(payload, ensure_ascii=False)
+
+    assert "assistant_reasoning" not in serialized_text
+    assert "ConversationHistoryArchive" not in serialized_text
+    assert "ConversationHistoryTurnRecord" not in serialized_text
+
+
+def _build_session_state_from_resume_path(
+    *,
+    archive_store: scene_preparer_module.ConversationSessionArchiveStore,
+    session_id: str,
+    transcript: ConversationTranscript,
+    user_message: str = "Q-resume",
+) -> scene_preparer_module.ConversationSessionState:
+    """直接复用 restore 路径的 placeholder archive 构造逻辑。"""
+
+    placeholder = ConversationSessionArchive(
+        session_id=session_id,
+        revision="",
+        created_at=transcript.created_at,
+        updated_at=transcript.updated_at,
+        runtime_transcript=transcript,
+        history_archive=ConversationHistoryArchive.create_empty(session_id),
+    )
+
+    def _schedule(*, session_id, prepared_scene, transcript, system_prompt) -> None:
+        del session_id, prepared_scene, transcript, system_prompt
+
+    return scene_preparer_module.ConversationSessionState(
+        session_id=session_id,
+        scene_name="interactive",
+        current_archive=placeholder,
+        archive_store=archive_store,
+        memory_manager=cast(
+            scene_preparer_module.DefaultConversationMemoryManager,
+            SimpleNamespace(schedule_compaction=_schedule),
+        ),
+        prepared_scene=cast(
+            scene_preparer_module.PreparedSceneState, SimpleNamespace()
+        ),
+        user_message=user_message,
+        system_prompt="SYS",
+    )
+
+
+@pytest.mark.unit
+def test_resume_persist_turn_reconciles_with_live_archive(tmp_path: Path) -> None:
+    """live 存在时 ``persist_turn`` 把新轮次合并到 live archive 之上，不覆盖。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    # live archive 含一条历史 turn
+    base = ConversationSessionArchive.create_empty("sess_resume_live")
+    seeded_turn = ConversationTurnRecord(
+        turn_id="turn_live_1",
+        scene_name="interactive",
+        user_text="先前",
+        assistant_final="先前回答",
+    )
+    from dayu.host.conversation_session_archive import ConversationHistoryTurnRecord
+
+    seeded_history = ConversationHistoryTurnRecord(
+        turn_id=seeded_turn.turn_id,
+        scene_name=seeded_turn.scene_name,
+        user_text=seeded_turn.user_text,
+        assistant_text=seeded_turn.assistant_final,
+        assistant_reasoning="historical-reasoning",
+        created_at=seeded_turn.created_at,
+    )
+    live = base.with_next_turn(seeded_turn, seeded_history)
+    store.save(live, expected_revision=None)
+
+    # prepared snapshot 中的 transcript 故意只包含旧空 transcript（模拟 prepare 时刻），
+    # 不应把 live 已有的轮次抹掉。
+    prepared_transcript = base.runtime_transcript
+    state = _build_session_state_from_resume_path(
+        archive_store=store,
+        session_id="sess_resume_live",
+        transcript=prepared_transcript,
+    )
+    state.record_reasoning_delta("resume-reasoning")
+
+    state.persist_turn(
+        final_content="resume 回答",
+        degraded=False,
+        tool_uses=(),
+        warnings=(),
+        errors=(),
+    )
+
+    persisted = store.load("sess_resume_live")
+    assert persisted is not None
+    # live 的旧 turn + resume 新 turn 都在
+    assert [t.turn_id for t in persisted.runtime_transcript.turns] == [
+        "turn_live_1",
+        persisted.runtime_transcript.turns[-1].turn_id,
+    ]
+    assert len(persisted.runtime_transcript.turns) == 2
+    # history 同步推进，旧历史 reasoning 保留，新历史 reasoning 落盘
+    assert persisted.history_archive.turns[0].assistant_reasoning == "historical-reasoning"
+    assert persisted.history_archive.turns[-1].assistant_reasoning == "resume-reasoning"
+
+
+@pytest.mark.unit
+def test_resume_persist_turn_raises_when_live_archive_missing(tmp_path: Path) -> None:
+    """live archive 不存在时 ``persist_turn`` 抛 ``ConversationArchiveMissingError``。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    transcript = ConversationTranscript.create_empty("sess_resume_missing")
+
+    state = _build_session_state_from_resume_path(
+        archive_store=store,
+        session_id="sess_resume_missing",
+        transcript=transcript,
+    )
+
+    with pytest.raises(ConversationArchiveMissingError):
+        state.persist_turn(
+            final_content="x",
+            degraded=False,
+            tool_uses=(),
+            warnings=(),
+            errors=(),
+        )
+
+    # 显式契约：不静默 create_empty，磁盘仍无 archive
+    assert store.load("sess_resume_missing") is None

--- a/tests/application/test_scene_execution.py
+++ b/tests/application/test_scene_execution.py
@@ -1516,18 +1516,27 @@ def test_scene_preparer_conversation_session_state_persist_turn_saves_and_schedu
     persisted: list[object] = []
     scheduled: list[object] = []
 
-    def _save(next_transcript, *, expected_revision):
-        persisted.extend([next_transcript, expected_revision])
-        return next_transcript
+    def _save(next_archive, *, expected_revision):
+        persisted.extend([next_archive, expected_revision])
+        return next_archive
 
     def _schedule_compaction(*, session_id, prepared_scene, transcript, system_prompt):
         scheduled.extend([session_id, prepared_scene, transcript, system_prompt])
 
+    from dataclasses import replace as _dc_replace
+    base_archive = scene_preparer_module.ConversationSessionArchive.create_empty("session-1")
+    initial_archive = _dc_replace(
+        base_archive,
+        runtime_transcript=_dc_replace(transcript, revision=base_archive.revision),
+    )
     session_state = scene_preparer_module.ConversationSessionState(
         session_id="session-1",
         scene_name="prompt",
-        transcript=transcript,
-        conversation_store=cast(scene_preparer_module.ConversationStore, SimpleNamespace(save=_save)),
+        current_archive=initial_archive,
+        archive_store=cast(
+            scene_preparer_module.ConversationSessionArchiveStore,
+            SimpleNamespace(save=_save),
+        ),
         memory_manager=cast(scene_preparer_module.DefaultConversationMemoryManager, SimpleNamespace(schedule_compaction=_schedule_compaction)),
         prepared_scene=prepared_scene,
         user_message="hello",
@@ -1542,8 +1551,9 @@ def test_scene_preparer_conversation_session_state_persist_turn_saves_and_schedu
         errors=("err",),
     )
 
-    saved_transcript = cast(scene_preparer_module.ConversationTranscript, persisted[0])
-    assert persisted[1] == transcript.revision
+    saved_archive = cast(scene_preparer_module.ConversationSessionArchive, persisted[0])
+    saved_transcript = saved_archive.runtime_transcript
+    assert persisted[1] == initial_archive.revision
     assert len(saved_transcript.turns) == 1
     assert saved_transcript.turns[0].assistant_final == "done"
     assert saved_transcript.turns[0].warnings == ("warn",)

--- a/tests/application/test_session_state_reasoning_persist.py
+++ b/tests/application/test_session_state_reasoning_persist.py
@@ -1,0 +1,206 @@
+"""ConversationSessionState `record_reasoning_delta` + `persist_turn` 集成测试。
+
+守住 `#118` 关键契约：
+
+1. reasoning 仅以 buffer 形式存活，到 ``persist_turn`` 时才投影进
+   ``history_archive``，**永不**进入 ``runtime_transcript`` / ``ConversationTurnRecord``。
+2. ``persist_turn`` 失败时 buffer 不清空，磁盘旧 archive 完整。
+3. ``persist_turn`` 成功后清空 buffer，下一轮不串味。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from dayu.host import scene_preparer as scene_preparer_module
+from dayu.host.conversation_session_archive import (
+    ConversationSessionArchive,
+)
+from dayu.host.conversation_store import (
+    ConversationToolUseSummary,
+    FileConversationSessionArchiveStore,
+)
+
+
+def _make_session_state(
+    archive_store: scene_preparer_module.ConversationSessionArchiveStore,
+    *,
+    archive: ConversationSessionArchive,
+    user_message: str = "Q1",
+) -> scene_preparer_module.ConversationSessionState:
+    """构造最小 ConversationSessionState 用于单测。"""
+
+    scheduled: list[object] = []
+
+    def _schedule(*, session_id, prepared_scene, transcript, system_prompt) -> None:
+        del prepared_scene, system_prompt
+        scheduled.append((session_id, transcript))
+
+    state = scene_preparer_module.ConversationSessionState(
+        session_id=archive.session_id,
+        scene_name="interactive",
+        current_archive=archive,
+        archive_store=archive_store,
+        memory_manager=cast(
+            scene_preparer_module.DefaultConversationMemoryManager,
+            SimpleNamespace(schedule_compaction=_schedule),
+        ),
+        prepared_scene=cast(
+            scene_preparer_module.PreparedSceneState, SimpleNamespace()
+        ),
+        user_message=user_message,
+        system_prompt="SYS",
+    )
+    return state
+
+
+@pytest.mark.unit
+def test_record_reasoning_delta_persists_to_history_archive_only(tmp_path: Path) -> None:
+    """多次 reasoning_delta 拼接结果只写入 history_archive，runtime 不含。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = store.save(
+        ConversationSessionArchive.create_empty("sess_r1"), expected_revision=None
+    )
+    state = _make_session_state(store, archive=archive, user_message="苹果营收?")
+
+    state.record_reasoning_delta("先")
+    state.record_reasoning_delta("分析")
+    state.record_reasoning_delta("营收")
+
+    state.persist_turn(
+        final_content="100 亿",
+        degraded=False,
+        tool_uses=(ConversationToolUseSummary(name="search"),),
+        warnings=(),
+        errors=(),
+    )
+
+    persisted = store.load("sess_r1")
+    assert persisted is not None
+    runtime_turn = persisted.runtime_transcript.turns[-1]
+    history_turn = persisted.history_archive.turns[-1]
+
+    assert history_turn.assistant_reasoning == "先分析营收"
+    assert history_turn.turn_id == runtime_turn.turn_id
+    assert history_turn.assistant_text == "100 亿"
+    assert not hasattr(runtime_turn, "assistant_reasoning")
+
+
+@pytest.mark.unit
+def test_persist_turn_without_reasoning_yields_empty_string(tmp_path: Path) -> None:
+    """未调用 reasoning_delta 时 history_archive 中 reasoning 为空字符串。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = store.save(
+        ConversationSessionArchive.create_empty("sess_r2"), expected_revision=None
+    )
+    state = _make_session_state(store, archive=archive)
+
+    state.persist_turn(
+        final_content="ok",
+        degraded=False,
+        tool_uses=(),
+        warnings=(),
+        errors=(),
+    )
+    persisted = store.load("sess_r2")
+    assert persisted is not None
+    assert persisted.history_archive.turns[-1].assistant_reasoning == ""
+
+
+@pytest.mark.unit
+def test_persist_turn_failure_keeps_reasoning_buffer_and_old_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """archive_store.save 抛错时 buffer 不清空，磁盘旧 archive 完整。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = store.save(
+        ConversationSessionArchive.create_empty("sess_r3"), expected_revision=None
+    )
+    state = _make_session_state(store, archive=archive)
+    state.record_reasoning_delta("buffered-thought")
+
+    from dayu.host import conversation_store as cs
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cs, "_atomic_write_text", _raise)
+
+    with pytest.raises(OSError):
+        state.persist_turn(
+            final_content="x",
+            degraded=False,
+            tool_uses=(),
+            warnings=(),
+            errors=(),
+        )
+
+    # buffer 未清空（重试不丢内容）
+    assert state._reasoning_buffer == ["buffered-thought"]
+
+    # 磁盘 archive 仍是初始空 archive
+    persisted = store.load("sess_r3")
+    assert persisted is not None
+    assert len(persisted.runtime_transcript.turns) == 0
+    assert len(persisted.history_archive.turns) == 0
+
+
+@pytest.mark.unit
+def test_persist_turn_success_clears_buffer_for_next_turn(tmp_path: Path) -> None:
+    """成功落盘后 buffer 已清空，下一轮 reasoning 不串味。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = store.save(
+        ConversationSessionArchive.create_empty("sess_r4"), expected_revision=None
+    )
+    state = _make_session_state(store, archive=archive)
+
+    state.record_reasoning_delta("first-turn")
+    state.persist_turn(
+        final_content="A1",
+        degraded=False,
+        tool_uses=(),
+        warnings=(),
+        errors=(),
+    )
+    assert state._reasoning_buffer == []
+
+    state.user_message = "Q2"
+    state.record_reasoning_delta("second-turn-only")
+    state.persist_turn(
+        final_content="A2",
+        degraded=False,
+        tool_uses=(),
+        warnings=(),
+        errors=(),
+    )
+
+    persisted = store.load("sess_r4")
+    assert persisted is not None
+    assert [t.assistant_reasoning for t in persisted.history_archive.turns] == [
+        "first-turn",
+        "second-turn-only",
+    ]
+
+
+@pytest.mark.unit
+def test_record_reasoning_delta_ignores_blank_chunks(tmp_path: Path) -> None:
+    """空白/None chunk 不会污染 buffer。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = store.save(
+        ConversationSessionArchive.create_empty("sess_r5"), expected_revision=None
+    )
+    state = _make_session_state(store, archive=archive)
+
+    state.record_reasoning_delta("")
+    state.record_reasoning_delta("real")
+    assert state._reasoning_buffer == ["real"]

--- a/tests/cli/workspace_migrations/test_conversation_archive_init.py
+++ b/tests/cli/workspace_migrations/test_conversation_archive_init.py
@@ -1,0 +1,165 @@
+"""conversation_archive_init 迁移测试。
+
+覆盖 plan 用例 24-28：
+
+- 旧 transcript 全量投影到 history_archive，原地写回原文件路径
+- 单文件每条 ``assistant_reasoning == ""``、其余字段全量保留
+- 二次执行幂等
+- 旧目录不存在 → no-op
+- 单文件 JSON 损坏 → warning 跳过、其余文件继续
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dayu.cli.workspace_migrations.conversation_archive_init import (
+    migrate_conversation_archive_init,
+)
+from dayu.host.conversation_session_archive import ConversationSessionArchive
+from dayu.host.conversation_store import (
+    ConversationTranscript,
+    ConversationTurnRecord,
+    _serialize_transcript,
+)
+from dayu.workspace_paths import CONVERSATION_STORE_RELATIVE_DIR
+
+
+def _make_legacy_transcript(session_id: str) -> ConversationTranscript:
+    """构造含 2 个 turn 的旧 transcript（assistant_reasoning 历史不存在）。"""
+
+    base = ConversationTranscript.create_empty(session_id)
+    t1 = ConversationTurnRecord(
+        turn_id="turn_1",
+        scene_name="interactive",
+        user_text="Q1",
+        assistant_final="A1",
+    )
+    t2 = ConversationTurnRecord(
+        turn_id="turn_2",
+        scene_name="interactive",
+        user_text="Q2",
+        assistant_final="A2",
+    )
+    return base.append_turn(t1).append_turn(t2)
+
+
+def _seed_legacy_file(workspace_root: Path, session_id: str) -> Path:
+    """把 legacy transcript 落到目标路径。"""
+
+    target_dir = workspace_root / CONVERSATION_STORE_RELATIVE_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    transcript = _make_legacy_transcript(session_id)
+    file_path = target_dir / f"{session_id}.json"
+    file_path.write_text(
+        json.dumps(_serialize_transcript(transcript), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return file_path
+
+
+@pytest.mark.unit
+def test_migration_rewrites_legacy_transcript_into_archive(tmp_path: Path) -> None:
+    """旧 transcript 被原地包装成 archive，history_archive 全量投影。"""
+
+    file_path = _seed_legacy_file(tmp_path, "sess_legacy_a")
+
+    rewritten = migrate_conversation_archive_init(tmp_path)
+    assert rewritten == 1
+
+    payload = json.loads(file_path.read_text(encoding="utf-8"))
+    assert "runtime_transcript" in payload
+    assert "history_archive" in payload
+
+    archive = ConversationSessionArchive.from_dict(payload)
+    assert archive.session_id == "sess_legacy_a"
+    assert len(archive.runtime_transcript.turns) == 2
+    assert len(archive.history_archive.turns) == 2
+
+    for runtime_turn, history_turn in zip(
+        archive.runtime_transcript.turns, archive.history_archive.turns
+    ):
+        assert history_turn.turn_id == runtime_turn.turn_id
+        assert history_turn.scene_name == runtime_turn.scene_name
+        assert history_turn.user_text == runtime_turn.user_text
+        assert history_turn.assistant_text == runtime_turn.assistant_final
+        assert history_turn.created_at == runtime_turn.created_at
+        # 老会话当时没有 reasoning，迁移产物必须是空字符串
+        assert history_turn.assistant_reasoning == ""
+
+
+@pytest.mark.unit
+def test_migration_keeps_file_path_unchanged(tmp_path: Path) -> None:
+    """迁移在原路径覆盖，不产生新文件、不更换目录。"""
+
+    file_path = _seed_legacy_file(tmp_path, "sess_legacy_b")
+    target_dir = file_path.parent
+    other_files_before = sorted(p.name for p in target_dir.iterdir())
+
+    migrate_conversation_archive_init(tmp_path)
+
+    other_files_after = sorted(p.name for p in target_dir.iterdir())
+    assert other_files_before == other_files_after
+    assert file_path.exists()
+
+
+@pytest.mark.unit
+def test_migration_is_idempotent_on_new_schema(tmp_path: Path) -> None:
+    """二次运行识别到新 schema → no-op，不动文件。"""
+
+    file_path = _seed_legacy_file(tmp_path, "sess_legacy_c")
+    assert migrate_conversation_archive_init(tmp_path) == 1
+    text_after_first = file_path.read_text(encoding="utf-8")
+    assert migrate_conversation_archive_init(tmp_path) == 0
+    assert file_path.read_text(encoding="utf-8") == text_after_first
+
+
+@pytest.mark.unit
+def test_migration_returns_zero_when_target_dir_missing(tmp_path: Path) -> None:
+    """旧目录不存在直接返回 0。"""
+
+    assert migrate_conversation_archive_init(tmp_path) == 0
+
+
+@pytest.mark.unit
+def test_migration_skips_corrupted_file_and_continues(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """单文件 JSON 损坏只 warning 跳过，不阻塞同目录其他文件。"""
+
+    good_file = _seed_legacy_file(tmp_path, "sess_legacy_good")
+    bad_file = good_file.parent / "sess_legacy_bad.json"
+    bad_file.write_text("{ this is not valid json", encoding="utf-8")
+
+    rewritten = migrate_conversation_archive_init(tmp_path)
+    assert rewritten == 1
+
+    captured = capsys.readouterr()
+    assert "sess_legacy_bad" in captured.err
+
+    # 好文件成功升级
+    good_payload = json.loads(good_file.read_text(encoding="utf-8"))
+    assert "runtime_transcript" in good_payload
+    # 损坏文件保持原样
+    assert bad_file.read_text(encoding="utf-8") == "{ this is not valid json"
+
+
+@pytest.mark.unit
+def test_migration_skips_files_without_legacy_turns_key(tmp_path: Path) -> None:
+    """既无 ``runtime_transcript`` 也无 ``turns`` 的对象不算旧 schema，跳过。"""
+
+    target_dir = tmp_path / CONVERSATION_STORE_RELATIVE_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    odd_file = target_dir / "weird.json"
+    odd_file.write_text(
+        json.dumps({"session_id": "x", "revision": "y"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    rewritten = migrate_conversation_archive_init(tmp_path)
+    assert rewritten == 0
+    payload = json.loads(odd_file.read_text(encoding="utf-8"))
+    assert "runtime_transcript" not in payload

--- a/tests/engine/test_conversation_memory.py
+++ b/tests/engine/test_conversation_memory.py
@@ -46,14 +46,35 @@ from dayu.host.conversation_runtime import (
     ConversationCompactionRequest,
     ConversationCompactionSceneProtocol,
 )
+from dayu.host.conversation_session_archive import (
+    ConversationHistoryArchive,
+    ConversationSessionArchive,
+)
 from dayu.host.conversation_store import (
     ConversationEpisodeSummary,
     ConversationPinnedState,
     ConversationToolUseSummary,
     ConversationTranscript,
     ConversationTurnRecord,
-    FileConversationStore,
+    FileConversationSessionArchiveStore,
 )
+
+
+def _archive_from_transcript(transcript: ConversationTranscript) -> ConversationSessionArchive:
+    """把测试用 transcript 包装成 archive，便于直接 store.save 预置。"""
+
+    from dataclasses import replace
+
+    base = ConversationSessionArchive.create_empty(transcript.session_id)
+    runtime = replace(transcript, revision=base.revision)
+    return ConversationSessionArchive(
+        session_id=base.session_id,
+        revision=base.revision,
+        created_at=base.created_at,
+        updated_at=base.updated_at,
+        runtime_transcript=runtime,
+        history_archive=ConversationHistoryArchive.create_empty(transcript.session_id),
+    )
 
 
 def _build_toolset_configs(
@@ -549,7 +570,7 @@ def test_default_conversation_memory_manager_builds_memory_block_and_raw_tail(tm
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_1")
     for index in range(1, 4):
@@ -596,7 +617,7 @@ def test_compaction_candidate_uses_current_scene_context_budget(tmp_path: Path) 
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_1")
     for index in range(1, 7):
@@ -730,18 +751,18 @@ def test_conversation_memory_manager_compacts_in_background_and_replans(tmp_path
         compaction_trigger_context_ratio=0.001,
         compaction_tail_preserve_turns=1,
     )
-    store = FileConversationStore(tmp_path / "conversations")
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     compressor = _FakeCompressor(delay=0.02)
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=store,
+        archive_store=store,
         episodic_memory_compressor=compressor,
     )
     transcript = ConversationTranscript.create_empty("sess_1")
     for index in range(1, 5):
         transcript = transcript.append_turn(_build_turn(index))
-    store.save(transcript)
+    store.save(_archive_from_transcript(transcript), expected_revision=None)
 
     async def _run() -> None:
         manager.schedule_compaction(
@@ -751,24 +772,30 @@ def test_conversation_memory_manager_compacts_in_background_and_replans(tmp_path
             system_prompt="sys",
         )
         await asyncio.sleep(0)
-        current = store.load("sess_1")
-        assert current is not None
-        updated = current.append_turn(_build_turn(5))
-        store.save(updated, expected_revision=current.revision)
+        current_archive = store.load("sess_1")
+        assert current_archive is not None
+        current_runtime = current_archive.runtime_transcript
+        from dataclasses import replace as _dc_replace
+        updated_runtime = current_runtime.append_turn(_build_turn(5))
+        store.save(
+            _dc_replace(current_archive, runtime_transcript=updated_runtime),
+            expected_revision=current_archive.revision,
+        )
         await manager.cancel_pending_compaction("sess_1")
         manager.schedule_compaction(
             session_id="sess_1",
             prepared_scene=_build_prepared_scene(settings=settings),
-            transcript=updated,
+            transcript=updated_runtime,
             system_prompt="sys",
         )
         await manager.wait_for_session("sess_1")
 
     asyncio.run(_run())
 
-    loaded = store.load("sess_1")
+    loaded_archive = store.load("sess_1")
 
-    assert loaded is not None
+    assert loaded_archive is not None
+    loaded = loaded_archive.runtime_transcript
     assert loaded.compacted_turn_count >= 4
     assert loaded.episodes
     assert loaded.pinned_state.current_goal == "跟踪公司最新变化"
@@ -780,12 +807,12 @@ def test_prepare_transcript_compacts_persisted_tail_before_resumed_turn(tmp_path
     """验证进程重启后恢复同 session 的首轮会先同步压缩已落盘 transcript。"""
 
     settings = ConversationMemorySettings()
-    store = FileConversationStore(tmp_path / "conversations")
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     compressor = _FakeCompressor()
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=store,
+        archive_store=store,
         episodic_memory_compressor=compressor,
     )
     transcript = ConversationTranscript.create_empty("sess_1")
@@ -798,25 +825,28 @@ def test_prepare_transcript_compacts_persisted_tail_before_resumed_turn(tmp_path
                 assistant_final="",
             )
         )
-    store.save(transcript)
+    store.save(_archive_from_transcript(transcript), expected_revision=None)
+    seeded_archive = store.load("sess_1")
+    assert seeded_archive is not None
+    seeded_transcript = seeded_archive.runtime_transcript
 
     prepared = asyncio.run(
         manager.prepare_transcript(
             session_id="sess_1",
             prepared_scene=_build_prepared_scene(settings=settings, max_context_tokens=2048),
-            transcript=transcript,
+            transcript=seeded_transcript,
             system_prompt="sys",
             user_text="hi",
         )
     )
 
-    persisted = store.load("sess_1")
+    persisted_archive = store.load("sess_1")
 
     assert prepared.compacted_turn_count == 2
     assert prepared.episodes
     assert compressor.calls == [("sess_1", ("turn_1", "turn_2"))]
-    assert persisted is not None
-    assert persisted.compacted_turn_count == 2
+    assert persisted_archive is not None
+    assert persisted_archive.runtime_transcript.compacted_turn_count == 2
 
 
 @pytest.mark.unit
@@ -824,12 +854,12 @@ def test_conversation_memory_emits_compaction_logs(tmp_path: Path, monkeypatch: 
     """ConversationMemory 关键 compaction 动作应输出 verbose/debug 日志。"""
 
     settings = ConversationMemorySettings()
-    store = FileConversationStore(tmp_path / "conversations")
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     compressor = _FakeCompressor()
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=store,
+        archive_store=store,
         episodic_memory_compressor=compressor,
     )
     transcript = ConversationTranscript.create_empty("sess_log")
@@ -842,7 +872,10 @@ def test_conversation_memory_emits_compaction_logs(tmp_path: Path, monkeypatch: 
                 assistant_final="",
             )
         )
-    store.save(transcript)
+    store.save(_archive_from_transcript(transcript), expected_revision=None)
+    seeded_archive = store.load("sess_log")
+    assert seeded_archive is not None
+    transcript = seeded_archive.runtime_transcript
 
     verbose_mock = Mock()
     debug_mock = Mock()
@@ -923,7 +956,7 @@ def test_compaction_triggered_by_window_ratio(tmp_path: Path) -> None:
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_trig")
     for index in range(1, 5):
@@ -955,7 +988,7 @@ def test_compaction_not_triggered_below_ratio(tmp_path: Path) -> None:
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_low")
     for index in range(1, 4):
@@ -1048,7 +1081,7 @@ def test_compaction_trigger_does_not_count_episodes(tmp_path: Path) -> None:
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_no_eps")
     transcript = transcript.append_turn(_build_turn(1))
@@ -1096,7 +1129,7 @@ def test_schedule_compaction_passes_system_prompt_token_estimate(tmp_path: Path)
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_wired")
     for index in range(1, 4):
@@ -1164,7 +1197,7 @@ def test_compaction_trigger_counts_actual_episode_in_prompt(tmp_path: Path) -> N
     runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
     manager = DefaultConversationMemoryManager(
         runtime,
-        conversation_store=FileConversationStore(tmp_path / "conversations"),
+        archive_store=FileConversationSessionArchiveStore(tmp_path / "conversations"),
     )
     transcript = ConversationTranscript.create_empty("sess_round2_1")
     # raw turns 体量很小，单独不会触发。
@@ -1224,3 +1257,166 @@ def test_default_conversation_memory_settings_match_runtime_default() -> None:
         == runtime_default.compaction_context_episode_window
     )
     assert dataclass_default.compaction_scene_name == runtime_default.compaction_scene_name
+
+
+@pytest.mark.unit
+def test_prepare_transcript_skips_compaction_write_when_live_runtime_revision_diverged(
+    tmp_path: Path,
+) -> None:
+    """业务层 stale-check：``live.runtime_transcript.revision`` 与
+    ``compaction_input_transcript.revision`` 不一致时丢弃 compaction 结果，
+    既不调用 ``archive_store.save``，也不触碰 ``history_archive``。
+    """
+
+    from unittest.mock import MagicMock
+
+    settings = ConversationMemorySettings()
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    compressor = _FakeCompressor()
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        archive_store=store,
+        episodic_memory_compressor=compressor,
+    )
+    transcript = ConversationTranscript.create_empty("sess_stale")
+    for index in range(1, 7):
+        transcript = transcript.append_turn(
+            ConversationTurnRecord(
+                turn_id=f"turn_{index}",
+                scene_name="interactive",
+                user_text=f"问题-{index}-" + ("x" * 794),
+                assistant_final="",
+            )
+        )
+    store.save(_archive_from_transcript(transcript), expected_revision=None)
+    seeded_archive = store.load("sess_stale")
+    assert seeded_archive is not None
+
+    # 模拟 prepare_transcript 期间外部并发推进 runtime_transcript.revision：
+    # 通过 monkeypatch store.load 让 manager 读到的 live archive 带新 revision
+    # 同时保留原 history_archive，使写入断言能区分两者。
+    from dataclasses import replace
+
+    bumped_runtime = replace(
+        seeded_archive.runtime_transcript, revision="bumped-runtime-rev"
+    )
+    bumped_archive = replace(
+        seeded_archive, runtime_transcript=bumped_runtime, revision="bumped-archive-rev"
+    )
+
+    save_spy = MagicMock(side_effect=AssertionError("save 不应被调用"))
+    store.save = save_spy  # type: ignore[method-assign]
+    store.load = lambda session_id: (  # type: ignore[method-assign]
+        bumped_archive if session_id == "sess_stale" else None
+    )
+
+    asyncio.run(
+        manager.prepare_transcript(
+            session_id="sess_stale",
+            prepared_scene=_build_prepared_scene(
+                settings=settings, max_context_tokens=2048
+            ),
+            transcript=seeded_archive.runtime_transcript,
+            system_prompt="sys",
+            user_text="hi",
+        )
+    )
+
+    # 业务层 stale-check 应触发：save 一次也不应被调用
+    save_spy.assert_not_called()
+    # compaction 仍尝试压缩（_FakeCompressor 被调用），只是结果被丢弃
+    assert compressor.calls, "compaction 应该执行了，但写回被 stale-check 丢弃"
+
+
+@pytest.mark.unit
+def test_compaction_only_replaces_runtime_transcript_subview(tmp_path: Path) -> None:
+    """compaction 写回路径仅替换 runtime_transcript 子视图，``history_archive`` 原样保留。"""
+
+    settings = ConversationMemorySettings()
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    runtime = _FakeRuntime(resolved_options=_build_resolved_options(settings))
+    compressor = _FakeCompressor()
+    manager = DefaultConversationMemoryManager(
+        runtime,
+        archive_store=store,
+        episodic_memory_compressor=compressor,
+    )
+    transcript = ConversationTranscript.create_empty("sess_keep_history")
+    for index in range(1, 7):
+        transcript = transcript.append_turn(
+            ConversationTurnRecord(
+                turn_id=f"turn_{index}",
+                scene_name="interactive",
+                user_text=f"问题-{index}-" + ("x" * 794),
+                assistant_final="",
+            )
+        )
+    store.save(_archive_from_transcript(transcript), expected_revision=None)
+    seeded_archive = store.load("sess_keep_history")
+    assert seeded_archive is not None
+
+    # 在 archive 中预置一条 history（模拟"已有展示历史"）
+    from dayu.host.conversation_session_archive import ConversationHistoryTurnRecord
+
+    history_turn = ConversationHistoryTurnRecord(
+        turn_id="hist_turn_1",
+        scene_name="interactive",
+        user_text="历史问题",
+        assistant_text="历史回答",
+        assistant_reasoning="历史思考片段",
+        created_at=seeded_archive.runtime_transcript.created_at,
+    )
+    archive_with_history = _dc_replace_archive_history(
+        seeded_archive, history_turns=(history_turn,)
+    )
+    store.save(archive_with_history, expected_revision=seeded_archive.revision)
+
+    seeded_archive_with_history = store.load("sess_keep_history")
+    assert seeded_archive_with_history is not None
+
+    asyncio.run(
+        manager.prepare_transcript(
+            session_id="sess_keep_history",
+            prepared_scene=_build_prepared_scene(
+                settings=settings, max_context_tokens=2048
+            ),
+            transcript=seeded_archive_with_history.runtime_transcript,
+            system_prompt="sys",
+            user_text="hi",
+        )
+    )
+
+    persisted = store.load("sess_keep_history")
+    assert persisted is not None
+    # runtime_transcript 已被压缩推进
+    assert persisted.runtime_transcript.compacted_turn_count >= 1
+    # history_archive 完整保留：内容、reasoning 都未被 compaction 触碰
+    assert len(persisted.history_archive.turns) == 1
+    assert persisted.history_archive.turns[0].assistant_reasoning == "历史思考片段"
+    assert persisted.history_archive.turns[0].assistant_text == "历史回答"
+
+
+def _dc_replace_archive_history(
+    archive,
+    *,
+    history_turns,
+):
+    """构造仅替换 history_archive 的 archive 副本，并推进 archive.revision 与 runtime.revision 同步。"""
+
+    from dataclasses import replace
+    import uuid
+
+    from dayu.host.conversation_session_archive import ConversationHistoryArchive
+
+    new_history = ConversationHistoryArchive(
+        session_id=archive.session_id, turns=tuple(history_turns)
+    )
+    new_revision = f"rev_{uuid.uuid4().hex[:8]}"
+    runtime = replace(archive.runtime_transcript, revision=new_revision)
+    return replace(
+        archive,
+        revision=new_revision,
+        runtime_transcript=runtime,
+        history_archive=new_history,
+    )

--- a/tests/engine/test_conversation_store.py
+++ b/tests/engine/test_conversation_store.py
@@ -1,4 +1,4 @@
-"""ConversationStore 测试。"""
+"""ConversationSessionArchiveStore 测试。"""
 
 from __future__ import annotations
 
@@ -9,15 +9,48 @@ from unittest.mock import Mock
 import pytest
 
 from dayu.host._coercion import _coerce_string_tuple
+from dayu.host.conversation_session_archive import (
+    ConversationHistoryArchive,
+    ConversationHistoryTurnRecord,
+    ConversationSessionArchive,
+)
 from dayu.host.conversation_store import (
     ConversationEpisodeSummary,
     ConversationPinnedState,
     ConversationToolUseSummary,
     ConversationTranscript,
     ConversationTurnRecord,
-    FileConversationStore,
+    FileConversationSessionArchiveStore,
 )
 from dayu.log import Log
+
+
+def _make_archive_with_one_turn(session_id: str) -> ConversationSessionArchive:
+    """构造含一条 runtime turn + 同步 history 的 archive。"""
+
+    archive = ConversationSessionArchive.create_empty(session_id)
+    turn = ConversationTurnRecord(
+        turn_id="turn_1",
+        scene_name="interactive",
+        user_text="苹果营收是多少",
+        assistant_final="营收是 100。",
+        tool_uses=(
+            ConversationToolUseSummary(
+                name="list_documents",
+                arguments={"ticker": "AAPL"},
+                result_summary='{"documents": 3}',
+            ),
+        ),
+    )
+    history = ConversationHistoryTurnRecord(
+        turn_id=turn.turn_id,
+        scene_name=turn.scene_name,
+        user_text=turn.user_text,
+        assistant_text=turn.assistant_final,
+        assistant_reasoning="",
+        created_at=turn.created_at,
+    )
+    return archive.with_next_turn(turn, history)
 
 
 @pytest.mark.unit
@@ -29,25 +62,12 @@ def test_coerce_string_tuple_filters_blank_values() -> None:
 
 
 @pytest.mark.unit
-def test_file_conversation_store_roundtrip_keeps_derived_memory(tmp_path: Path) -> None:
-    """验证文件存储可正确保存并读取 transcript 的分层记忆字段。"""
+def test_archive_store_roundtrip_keeps_runtime_and_history(tmp_path: Path) -> None:
+    """archive 存储读写 roundtrip 后两个子视图原样保留。"""
 
-    store = FileConversationStore(tmp_path / "conversations")
-    transcript = ConversationTranscript.create_empty("sess_1").append_turn(
-        ConversationTurnRecord(
-            turn_id="turn_1",
-            scene_name="interactive",
-            user_text="苹果营收是多少",
-            assistant_final="营收是 100。",
-            tool_uses=(
-                ConversationToolUseSummary(
-                    name="list_documents",
-                    arguments={"ticker": "AAPL"},
-                    result_summary='{"documents": 3}',
-                ),
-            ),
-        )
-    ).replace_memory(
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    archive = _make_archive_with_one_turn("sess_1")
+    next_runtime = archive.runtime_transcript.replace_memory(
         pinned_state=ConversationPinnedState(
             current_goal="跟踪苹果最新经营变化",
             confirmed_subjects=("AAPL",),
@@ -66,142 +86,138 @@ def test_file_conversation_store_roundtrip_keeps_derived_memory(tmp_path: Path) 
         ),
         compacted_turn_count=1,
     )
+    next_archive = archive.with_runtime_transcript(next_runtime)
+    store.save(next_archive, expected_revision=archive.revision)
 
-    store.save(transcript)
     loaded = store.load("sess_1")
-
     assert loaded is not None
     assert loaded.session_id == "sess_1"
-    assert loaded.compacted_turn_count == 1
-    assert loaded.pinned_state.current_goal == "跟踪苹果最新经营变化"
-    assert loaded.pinned_state.confirmed_subjects == ("AAPL",)
-    assert loaded.episodes[0].title == "确认分析对象"
-    assert loaded.turns[0].tool_uses[0].name == "list_documents"
+    assert loaded.runtime_transcript.compacted_turn_count == 1
+    assert loaded.runtime_transcript.pinned_state.current_goal == "跟踪苹果最新经营变化"
+    assert loaded.runtime_transcript.episodes[0].title == "确认分析对象"
+    assert loaded.runtime_transcript.turns[0].tool_uses[0].name == "list_documents"
+    assert loaded.history_archive.turns[0].user_text == "苹果营收是多少"
+    assert loaded.history_archive.turns[0].assistant_text == "营收是 100。"
+    assert loaded.history_archive.turns[0].assistant_reasoning == ""
 
 
 @pytest.mark.unit
-def test_file_conversation_store_rejects_revision_conflict(tmp_path: Path) -> None:
-    """验证文件存储会拒绝 revision 冲突。"""
+def test_archive_store_rejects_revision_conflict(tmp_path: Path) -> None:
+    """archive 存储在 expected_revision 不匹配时拒绝写入。"""
 
-    store = FileConversationStore(tmp_path / "conversations")
-    transcript = ConversationTranscript.create_empty("sess_1")
-    store.save(transcript)
-    next_transcript = transcript.append_turn(
-        ConversationTurnRecord(
-            turn_id="turn_1",
-            scene_name="interactive",
-            user_text="Q1",
-            assistant_final="A1",
-        )
-    )
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    archive = ConversationSessionArchive.create_empty("sess_1")
+    store.save(archive, expected_revision=None)
+    next_archive = _make_archive_with_one_turn("sess_1")
 
     with pytest.raises(RuntimeError, match="revision 冲突"):
-        store.save(next_transcript, expected_revision="stale_revision")
+        store.save(next_archive, expected_revision="stale_revision")
 
 
 @pytest.mark.unit
-def test_file_conversation_store_first_save_with_expected_revision_succeeds(tmp_path: Path) -> None:
-    """验证首次保存（文件不存在）时 expected_revision 不触发冲突。
+def test_archive_store_first_save_with_expected_revision_succeeds(tmp_path: Path) -> None:
+    """文件不存在时带 expected_revision 不应被视为冲突。"""
 
-    首轮交互 transcript 仅存在于内存，persist_turn 带着内存 revision 调用 save，
-    此时文件不存在不应被视为冲突。
-    """
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    archive = _make_archive_with_one_turn("sess_first")
 
-    store = FileConversationStore(tmp_path / "conversations")
-    transcript = ConversationTranscript.create_empty("sess_first")
-    next_transcript = transcript.append_turn(
-        ConversationTurnRecord(
-            turn_id="turn_1",
-            scene_name="interactive",
-            user_text="Q1",
-            assistant_final="A1",
-        )
-    )
-
-    # 文件不存在时带 expected_revision 应正常保存
-    result = store.save(next_transcript, expected_revision=transcript.revision)
-    assert result.session_id == "sess_first"
+    saved = store.save(archive, expected_revision="any_initial_revision")
+    assert saved.session_id == "sess_first"
 
     loaded = store.load("sess_first")
     assert loaded is not None
-    assert len(loaded.turns) == 1
+    assert len(loaded.runtime_transcript.turns) == 1
 
 
 @pytest.mark.unit
-def test_file_conversation_store_rejects_unsafe_session_id(tmp_path: Path) -> None:
-    """验证文件存储会拒绝包含路径语义的 session_id。"""
+def test_archive_store_rejects_unsafe_session_id(tmp_path: Path) -> None:
+    """archive 存储拒绝包含路径语义的 session_id。"""
 
-    store = FileConversationStore(tmp_path / "conversations")
-
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
     with pytest.raises(ValueError, match="session_id 只能包含"):
         store.load("../sess_1")
 
 
 @pytest.mark.unit
-def test_file_conversation_store_emits_load_save_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """ConversationStore 读写 transcript 时应输出调试日志。"""
+def test_archive_store_load_legacy_schema_raises(tmp_path: Path) -> None:
+    """加载旧 transcript schema 时显式报错，提示运行迁移。"""
 
-    store = FileConversationStore(tmp_path / "conversations")
+    target_dir = tmp_path / "conversations"
+    target_dir.mkdir(parents=True)
+    legacy_path = target_dir / "sess_legacy.json"
+    legacy_path.write_text(
+        '{"session_id": "sess_legacy", "revision": "rev_x", "turns": []}',
+        encoding="utf-8",
+    )
+
+    store = FileConversationSessionArchiveStore(target_dir)
+    with pytest.raises(RuntimeError, match="dayu-cli init"):
+        store.load("sess_legacy")
+
+
+@pytest.mark.unit
+def test_archive_store_emits_load_save_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """archive 存储读写 archive 时输出调试日志。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
     debug_mock = Mock()
     monkeypatch.setattr(Log, "debug", debug_mock)
 
-    transcript = ConversationTranscript.create_empty("sess_log").append_turn(
-        ConversationTurnRecord(
-            turn_id="turn_1",
-            scene_name="interactive",
-            user_text="Q1",
-            assistant_final="A1",
-        )
-    )
-
+    archive = _make_archive_with_one_turn("sess_log")
     assert store.load("sess_log") is None
-    store.save(transcript)
+    store.save(archive, expected_revision=None)
     loaded = store.load("sess_log")
 
     assert loaded is not None
     debug_messages = [call.args[0] for call in debug_mock.call_args_list]
-    assert any("transcript 不存在" in message for message in debug_messages)
-    assert any("保存 transcript" in message for message in debug_messages)
-    assert any("加载 transcript" in message for message in debug_messages)
+    assert any(
+        "transcript" in message or "archive" in message for message in debug_messages
+    )
 
 
 @pytest.mark.unit
-def test_file_conversation_store_serializes_concurrent_save_and_surfaces_revision_conflict(
+def test_archive_store_serializes_concurrent_save_and_surfaces_revision_conflict(
     tmp_path: Path,
 ) -> None:
-    """并发保存同一 session 时，后写线程必须在锁内看到 revision 冲突。"""
+    """并发保存同一 session 时后写线程在锁内看到 revision 冲突。"""
 
-    store = FileConversationStore(tmp_path / "conversations")
-    base = ConversationTranscript.create_empty("sess_race")
-    store.save(base)
-    first_update = base.append_turn(
-        ConversationTurnRecord(
-            turn_id="turn_1",
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    base = ConversationSessionArchive.create_empty("sess_race")
+    store.save(base, expected_revision=None)
+
+    def _build_update(turn_id: str, text: str) -> ConversationSessionArchive:
+        turn = ConversationTurnRecord(
+            turn_id=turn_id,
             scene_name="interactive",
-            user_text="Q1",
-            assistant_final="A1",
+            user_text=text,
+            assistant_final=text + "_a",
         )
-    )
-    second_update = base.append_turn(
-        ConversationTurnRecord(
-            turn_id="turn_2",
-            scene_name="interactive",
-            user_text="Q2",
-            assistant_final="A2",
+        history = ConversationHistoryTurnRecord(
+            turn_id=turn.turn_id,
+            scene_name=turn.scene_name,
+            user_text=turn.user_text,
+            assistant_text=turn.assistant_final,
+            assistant_reasoning="",
+            created_at=turn.created_at,
         )
-    )
+        return base.with_next_turn(turn, history)
+
+    first_update = _build_update("turn_1", "Q1")
+    second_update = _build_update("turn_2", "Q2")
 
     barrier = threading.Barrier(3)
     results: list[str] = []
     errors: list[str] = []
     result_lock = threading.Lock()
 
-    def _save_worker(transcript: ConversationTranscript) -> None:
+    def _save_worker(target: ConversationSessionArchive) -> None:
         """并发执行保存。"""
 
         barrier.wait()
         try:
-            saved = store.save(transcript, expected_revision=base.revision)
+            saved = store.save(target, expected_revision=base.revision)
         except RuntimeError as exc:
             with result_lock:
                 errors.append(str(exc))
@@ -209,13 +225,15 @@ def test_file_conversation_store_serializes_concurrent_save_and_surfaces_revisio
         with result_lock:
             results.append(saved.revision)
 
-    first_thread = threading.Thread(target=_save_worker, args=(first_update,))
-    second_thread = threading.Thread(target=_save_worker, args=(second_update,))
-    first_thread.start()
-    second_thread.start()
+    threads = [
+        threading.Thread(target=_save_worker, args=(first_update,)),
+        threading.Thread(target=_save_worker, args=(second_update,)),
+    ]
+    for t in threads:
+        t.start()
     barrier.wait()
-    first_thread.join()
-    second_thread.join()
+    for t in threads:
+        t.join()
 
     assert len(results) == 1
     assert len(errors) == 1
@@ -224,4 +242,210 @@ def test_file_conversation_store_serializes_concurrent_save_and_surfaces_revisio
     loaded = store.load("sess_race")
     assert loaded is not None
     assert loaded.revision == results[0]
-    assert len(loaded.turns) == 1
+    assert len(loaded.runtime_transcript.turns) == 1
+
+
+@pytest.mark.unit
+def test_archive_store_append_turn_reconciles_with_live(tmp_path: Path) -> None:
+    """append_turn 在 live archive 之上 reconcile 推进。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    base = _make_archive_with_one_turn("sess_reconcile")
+    store.save(base, expected_revision=None)
+
+    new_turn = ConversationTurnRecord(
+        turn_id="turn_2",
+        scene_name="interactive",
+        user_text="第二轮问题",
+        assistant_final="第二轮回答",
+    )
+    new_history = ConversationHistoryTurnRecord(
+        turn_id=new_turn.turn_id,
+        scene_name=new_turn.scene_name,
+        user_text=new_turn.user_text,
+        assistant_text=new_turn.assistant_final,
+        assistant_reasoning="思考片段",
+        created_at=new_turn.created_at,
+    )
+    persisted = store.append_turn(
+        "sess_reconcile",
+        turn_record=new_turn,
+        history_record=new_history,
+    )
+
+    assert len(persisted.runtime_transcript.turns) == 2
+    assert persisted.history_archive.turns[-1].assistant_reasoning == "思考片段"
+
+
+@pytest.mark.unit
+def test_archive_store_append_turn_raises_when_live_missing(tmp_path: Path) -> None:
+    """live archive 缺失时 append_turn 显式抛错而非自动 create_empty。"""
+
+    from dayu.host.conversation_session_archive import ConversationArchiveMissingError
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    new_turn = ConversationTurnRecord(
+        turn_id="turn_x",
+        scene_name="interactive",
+        user_text="Q",
+        assistant_final="A",
+    )
+    new_history = ConversationHistoryTurnRecord(
+        turn_id=new_turn.turn_id,
+        scene_name=new_turn.scene_name,
+        user_text=new_turn.user_text,
+        assistant_text=new_turn.assistant_final,
+        assistant_reasoning="",
+        created_at=new_turn.created_at,
+    )
+    with pytest.raises(ConversationArchiveMissingError):
+        store.append_turn(
+            "sess_missing", turn_record=new_turn, history_record=new_history
+        )
+
+
+@pytest.mark.unit
+def test_archive_store_delete_returns_correct_status(tmp_path: Path) -> None:
+    """delete 在文件存在/不存在两种情况下返回正确状态。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    assert store.delete("sess_absent") is False
+
+    archive = ConversationSessionArchive.create_empty("sess_delete")
+    store.save(archive, expected_revision=None)
+    assert store.delete("sess_delete") is True
+    assert store.load("sess_delete") is None
+
+
+@pytest.mark.unit
+def test_archive_save_failure_keeps_old_file_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """模拟原子写失败时旧文件保持完整。"""
+
+    from dayu.host import conversation_store as cs
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    base = _make_archive_with_one_turn("sess_keep")
+    store.save(base, expected_revision=None)
+
+    def _raise_on_atomic_write(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cs, "_atomic_write_text", _raise_on_atomic_write)
+
+    next_turn = ConversationTurnRecord(
+        turn_id="turn_2",
+        scene_name="interactive",
+        user_text="Q2",
+        assistant_final="A2",
+    )
+    next_history = ConversationHistoryTurnRecord(
+        turn_id=next_turn.turn_id,
+        scene_name=next_turn.scene_name,
+        user_text=next_turn.user_text,
+        assistant_text=next_turn.assistant_final,
+        assistant_reasoning="",
+        created_at=next_turn.created_at,
+    )
+    next_archive = base.with_next_turn(next_turn, next_history)
+    with pytest.raises(OSError):
+        store.save(next_archive, expected_revision=base.revision)
+
+    loaded = store.load("sess_keep")
+    assert loaded is not None
+    assert loaded.revision == base.revision
+    assert len(loaded.runtime_transcript.turns) == 1
+
+
+def test_history_archive_create_empty_rejects_blank_session_id() -> None:
+    """history archive 拒绝空 session_id。"""
+
+    with pytest.raises(ValueError):
+        ConversationHistoryArchive.create_empty("   ")
+
+
+def test_archive_to_dict_from_dict_roundtrip() -> None:
+    """archive to_dict / from_dict 等价 roundtrip。"""
+
+    archive = _make_archive_with_one_turn("sess_rt")
+    payload = archive.to_dict()
+    restored = ConversationSessionArchive.from_dict(payload)
+    assert restored.session_id == archive.session_id
+    assert restored.revision == archive.revision
+    assert len(restored.runtime_transcript.turns) == 1
+    assert len(restored.history_archive.turns) == 1
+
+
+def test_transcript_legacy_alias_keeps_imports_working() -> None:
+    """ConversationTranscript 仍可以从 conversation_store 导入。"""
+
+    transcript = ConversationTranscript.create_empty("sess_alias")
+    assert transcript.session_id == "sess_alias"
+
+
+def test_archive_from_dict_rejects_missing_history_archive() -> None:
+    """``history_archive`` 缺失时 ``from_dict`` fail-closed，不静默降级为空历史。
+
+    守住硬约束：``history_archive`` 是聚合根的一部分，缺失视为数据损坏，
+    必须显式报错，避免 ``persist_turn`` / compaction 后续写回时把已存的
+    ``assistant_reasoning`` 永久抹掉。
+    """
+
+    archive = _make_archive_with_one_turn("sess_no_history")
+    payload = archive.to_dict()
+    payload.pop("history_archive")
+    with pytest.raises(ValueError, match="history_archive"):
+        ConversationSessionArchive.from_dict(payload)
+
+
+def test_archive_from_dict_rejects_non_object_history_archive() -> None:
+    """``history_archive`` 非对象时同样 fail-closed。"""
+
+    archive = _make_archive_with_one_turn("sess_bad_history")
+    payload = archive.to_dict()
+    payload["history_archive"] = "broken"
+    with pytest.raises(ValueError, match="history_archive"):
+        ConversationSessionArchive.from_dict(payload)
+
+
+def test_load_or_create_returns_existing_archive_without_overwrite(tmp_path: Path) -> None:
+    """磁盘已有 archive 时 ``load_or_create`` 必须返回 live，不写空版本覆盖。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    seeded = _make_archive_with_one_turn("sess_loc1")
+    store.save(seeded, expected_revision=None)
+    before_text = (tmp_path / "conversations" / "sess_loc1.json").read_text("utf-8")
+
+    loaded = store.load_or_create("sess_loc1")
+    assert loaded.revision == seeded.revision
+    assert len(loaded.runtime_transcript.turns) == 1
+    after_text = (tmp_path / "conversations" / "sess_loc1.json").read_text("utf-8")
+    assert before_text == after_text
+
+
+def test_load_or_create_atomically_creates_when_missing(tmp_path: Path) -> None:
+    """磁盘缺失时 ``load_or_create`` 在锁内创建空 archive，文件落盘可读。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    created = store.load_or_create("sess_loc2")
+    assert created.session_id == "sess_loc2"
+    assert created.runtime_transcript.turns == ()
+    assert created.history_archive.turns == ()
+
+    persisted = store.load("sess_loc2")
+    assert persisted is not None
+    assert persisted.revision == created.revision
+
+
+def test_load_or_create_does_not_overwrite_concurrently_written_archive(tmp_path: Path) -> None:
+    """模拟并发：两个进程都先 ``load`` -> ``None``，但只有先到的能在锁内胜出，
+    另一个调用必须读到 live archive，不能用空版本覆盖。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conversations")
+    # 第一个进程已经 ``load_or_create`` 完成（live archive 落盘）
+    first = store.load_or_create("sess_loc3")
+    # 第二个进程紧随其后再调一次 —— 必须读到 live，不写新空版本
+    second = store.load_or_create("sess_loc3")
+    assert second.revision == first.revision
+    assert second.runtime_transcript.turns == ()


### PR DESCRIPTION
引入 ConversationSessionArchive 聚合根：runtime_transcript / history_archive
两个子视图共享单 revision、单文件原子提交。reasoning 仅以 buffer 形式存活到
persist_turn 时投影进 history_archive，永不污染运行态真源（pending turn /
resume / 送模 / memory / compaction）。

- 新增 ConversationSessionArchive + FileConversationSessionArchiveStore，
  支持 load_or_create（消除 prepare 首轮 TOCTOU 覆盖竞态）与 append_turn
  （resume reconcile-on-write，live 缺失抛 ConversationArchiveMissingError）。
- ConversationSessionState 新增 _reasoning_buffer 与 record_reasoning_delta，
  persist_turn 路径分叉：placeholder archive 走 append_turn、正常路径走
  with_next_turn + save(expected_revision=...)。
- compaction 写回保留两层 stale-check（业务层 transcript revision + 物理层
  archive 乐观锁），仅替换 runtime_transcript 子视图。
- executor 在 REASONING_DELTA 上调 session_state.record_reasoning_delta；
  session_state 缺失时静默丢弃。
- ConversationTurnPersistenceProtocol.persist_turn 签名不变；契约模块
  不感知 history_archive。
- ConversationSessionArchive.from_dict 对 history_archive 缺失/非法
  fail-closed，避免静默降级覆盖已存 reasoning。
- 新增 workspace_migrations 插件 conversation_archive_init：旧 transcript
  原地包成 archive，history_archive 全量从旧 turns 投影（reasoning=""）。
- README 增补 §10.9 "会话存储 (ConversationSessionArchive)"。

测试：4819 passed；pyright 零新增报错。

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>
