### PR TITLE
feat: Host 历史读 read model 切到 history_archive 并扩 reasoning_text (#116)

### DIFF
--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -502,6 +502,8 @@ Compaction 有两条触发路径，职责分离：
 - `history_archive` 内容**不进入** prepared snapshot / `resume_source_json` / `restore_prepared_execution` / `to_messages` / compaction 输入；它纯粹是展示侧字段。
 - 模块结构隔离由 `tests/application/test_history_archive_isolation.py` 反射式回归——`dayu/host/conversation_memory.py` / `pending_turn_store.py` / `prepared_turn.py` / `dayu/contracts/agent_execution.py` / `agent_execution_serialization.py` / `agent_types.py` 六处源码不得出现 `assistant_reasoning` / `ConversationHistoryTurnRecord` / `ConversationHistoryArchive` 三个 token。
 
+**历史读 read model（`#116`）**：`Host.list_conversation_session_turn_excerpts(session_id, *, limit)` 是历史展示的**唯一**对外读入口，返回 `ConversationSessionTurnExcerpt(user_text, assistant_text, reasoning_text, created_at)`，按时间从旧到新排列。读源**只**是 `archive.history_archive.turns`——禁止从 `runtime_transcript` 投影"近似历史"。`reasoning_text` 映射自 `assistant_reasoning`，无 reasoning 的轮次为空字符串；archive 缺失 / JSON 损坏 / schema 非法（含旧 transcript 未迁移） / `limit <= 0` 一律降级返回空列表（损坏路径同时打 warning）。`Host.get_conversation_session_digest` 共享同一 fail-soft 加载入口（`_safe_load_archive_for_read`），异常一律按"无 archive"语义处理。**写路径不受此降级影响**，仍走 `archive_store.load` 的 fail-closed 行为，避免静默覆盖损坏数据。`reasoning_text` 命名上刻意区别于内部 `assistant_reasoning`，提示上层这是展示视图，绝不流回送模 / resume / memory / compaction。回归用例见 `tests/application/test_host_list_conversation_excerpts.py`。
+
 **reasoning 的采集与落盘**（`#118` 关键链路）：
 
 1. Engine 层流式产出 `EventType.REASONING_DELTA`。

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -440,12 +440,12 @@ class Host:
         if self._archive_store is None:
             return _empty_conversation_session_digest()
         archive = self._safe_load_archive_for_read(session_id)
-        if archive is None or not archive.runtime_transcript.turns:
+        if archive is None or not archive.history_archive.turns:
             return _empty_conversation_session_digest()
-        first_turn = archive.runtime_transcript.turns[0]
-        last_turn = archive.runtime_transcript.turns[-1]
+        first_turn = archive.history_archive.turns[0]
+        last_turn = archive.history_archive.turns[-1]
         return ConversationSessionDigest(
-            turn_count=len(archive.runtime_transcript.turns),
+            turn_count=len(archive.history_archive.turns),
             first_question_preview=_truncate_conversation_preview(first_turn.user_text),
             last_question_preview=_truncate_conversation_preview(last_turn.user_text),
         )
@@ -516,7 +516,7 @@ class Host:
             return None
         try:
             return self._archive_store.load(session_id)
-        except (ValueError, RuntimeError, json.JSONDecodeError, OSError) as exc:
+        except (ValueError, RuntimeError, KeyError, TypeError, json.JSONDecodeError, OSError) as exc:
             Log.warning(
                 f"历史读 archive 损坏或不可读，按空历史降级: session_id={session_id}, error={exc}",
                 module=MODULE,

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -20,6 +20,7 @@ from dayu.contracts.session import SessionRecord, SessionSource, SessionState
 from dayu.execution.options import ResolvedExecutionOptions
 from dayu.engine.tool_registry import ToolRegistry
 from dayu.host.concurrency import SQLiteConcurrencyGovernor
+from dayu.host.conversation_session_archive import ConversationSessionArchive
 from dayu.host.conversation_store import (
     ConversationSessionArchiveStore,
     FileConversationSessionArchiveStore,
@@ -438,7 +439,7 @@ class Host:
 
         if self._archive_store is None:
             return _empty_conversation_session_digest()
-        archive = self._archive_store.load(session_id)
+        archive = self._safe_load_archive_for_read(session_id)
         if archive is None or not archive.runtime_transcript.turns:
             return _empty_conversation_session_digest()
         first_turn = archive.runtime_transcript.turns[0]
@@ -457,12 +458,18 @@ class Host:
     ) -> list[ConversationSessionTurnExcerpt]:
         """读取指定 session 的最近 conversation 单轮摘录。
 
+        历史真源是 ``archive.history_archive.turns``（``#116`` 共享设计 §1.1）。
+        本接口仅消费 history 子视图，**不**从 ``runtime_transcript`` 投影历史，
+        ``assistant_reasoning`` 透出为 read model 的 ``reasoning_text`` 字段
+        但绝不流回运行态。
+
         Args:
             session_id: 目标 session ID。
             limit: 最多返回的 turn 数量。
 
         Returns:
-            最近单轮摘录列表，按时间从旧到新排列；若 transcript 不存在则返回空列表。
+            最近单轮摘录列表，按时间从旧到新排列；若 archive 不存在或 history
+            为空则返回空列表（``#116`` 共享设计 §1.5）。
 
         Raises:
             无。
@@ -470,18 +477,51 @@ class Host:
 
         if self._archive_store is None or limit <= 0:
             return []
-        archive = self._archive_store.load(session_id)
-        if archive is None or not archive.runtime_transcript.turns:
+        archive = self._safe_load_archive_for_read(session_id)
+        if archive is None or not archive.history_archive.turns:
             return []
-        recent_turns = archive.runtime_transcript.turns[-limit:]
+        recent_turns = archive.history_archive.turns[-limit:]
         return [
             ConversationSessionTurnExcerpt(
                 user_text=turn.user_text,
-                assistant_text=turn.assistant_final,
+                assistant_text=turn.assistant_text,
+                reasoning_text=turn.assistant_reasoning,
                 created_at=turn.created_at,
             )
             for turn in recent_turns
         ]
+
+    def _safe_load_archive_for_read(
+        self,
+        session_id: str,
+    ) -> ConversationSessionArchive | None:
+        """历史读专用 fail-soft archive 加载。
+
+        ``#116`` 共享设计 §1.7 读路径列：archive 文件不存在 / JSON 损坏 /
+        schema 非法（含旧 transcript 未迁移）一律返回 ``None`` 并 warn，
+        避免把 ``ValueError`` / ``RuntimeError`` 抛给 Service / UI。写路径
+        仍走 ``_archive_store.load`` 的 fail-closed 行为，不受此降级影响。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Returns:
+            archive 或 ``None``。
+
+        Raises:
+            无：所有异常都被记入 warning 日志后吞掉，调用方按"无 archive"语义处理。
+        """
+
+        if self._archive_store is None:
+            return None
+        try:
+            return self._archive_store.load(session_id)
+        except (ValueError, RuntimeError, json.JSONDecodeError, OSError) as exc:
+            Log.warning(
+                f"历史读 archive 损坏或不可读，按空历史降级: session_id={session_id}, error={exc}",
+                module=MODULE,
+            )
+            return None
 
     def run_operation_stream(
         self,

--- a/dayu/host/protocols.py
+++ b/dayu/host/protocols.py
@@ -747,14 +747,29 @@ class ConversationSessionDigest:
 
 @dataclass(frozen=True)
 class ConversationSessionTurnExcerpt:
-    """Host 暴露给管理面的 conversation 单轮摘录。
+    """Host 暴露给管理面的 conversation 单轮摘录（历史读 read model）。
 
     该对象只承载可安全展示的单轮对话文本，不暴露完整
     ``ConversationTranscript`` 与 derived memory 结构。
+
+    字段语义遵循 ``#116`` 共享设计 §1.3 层 B 契约：
+
+    - ``user_text``：用户输入文本。
+    - ``assistant_text``：助手最终回复文本（与 ``runtime_transcript`` 中
+      ``assistant_final`` 同源同值）。
+    - ``reasoning_text``：助手 reasoning 文本，**仅展示**。映射自
+      ``history_archive.turns[*].assistant_reasoning``；无 reasoning 的轮次
+      为 ``""``。命名上刻意用 ``reasoning_text`` 而非 ``assistant_reasoning``，
+      强调其展示视图属性，避免上层误认作运行态字段。
+    - ``created_at``：ISO 8601 时间字符串，与对应 ``ConversationTurnRecord.created_at``
+      一致。
+
+    不暴露 ``turn_id`` / ``scene_name`` 等内部标识；如需新字段需另立 issue。
     """
 
     user_text: str
     assistant_text: str
+    reasoning_text: str
     created_at: str
 
 

--- a/tests/application/test_host_admin_service.py
+++ b/tests/application/test_host_admin_service.py
@@ -556,6 +556,7 @@ def test_host_admin_service_lists_session_recent_turns() -> None:
                 ConversationSessionTurnExcerpt(
                     user_text="上一轮问题",
                     assistant_text="上一轮回答",
+                    reasoning_text="上一轮思考",
                     created_at="2026-04-21T00:01:00+00:00",
                 )
             ]

--- a/tests/application/test_host_list_conversation_excerpts.py
+++ b/tests/application/test_host_list_conversation_excerpts.py
@@ -421,3 +421,23 @@ def test_session_digest_returns_empty_for_corrupt_archive(tmp_path: Path) -> Non
     assert digest.turn_count == 0
     assert digest.first_question_preview == ""
     assert digest.last_question_preview == ""
+
+
+@pytest.mark.unit
+def test_session_digest_reads_from_history_archive(tmp_path: Path) -> None:
+    """``get_conversation_session_digest`` 与历史读共享 ``history_archive``
+    真源（§1.1：运行态子视图不得被任何"读历史"代码路径直接消费）。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_dg_hist",
+        turns=[("第一问", "第一答", ""), ("第二问", "第二答", "")],
+    )
+    host = _build_host(store)
+
+    digest = host.get_conversation_session_digest("sess_dg_hist")
+
+    assert digest.turn_count == 2
+    assert digest.first_question_preview == "第一问"
+    assert digest.last_question_preview == "第二问"

--- a/tests/application/test_host_list_conversation_excerpts.py
+++ b/tests/application/test_host_list_conversation_excerpts.py
@@ -1,0 +1,423 @@
+"""``Host.list_conversation_session_turn_excerpts`` 历史读 read model 契约测试。
+
+Phase 1（``#116``）：
+
+- 历史真源切到 ``archive.history_archive.turns``，**不**从 ``runtime_transcript``
+  投影；
+- read model ``ConversationSessionTurnExcerpt`` 含 ``reasoning_text``，映射自
+  ``history_archive.turns[*].assistant_reasoning``，无 reasoning 的轮次为空字符串；
+- 顺序稳定（旧 → 新）；
+- 空值语义：archive 缺失 / 空 history → 返回 ``[]``；
+- limit 边界：``<= 0`` / 大于 turn 数 / 等于 turn 数。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dayu.host.conversation_session_archive import (
+    ConversationHistoryTurnRecord,
+    ConversationSessionArchive,
+)
+from dayu.host.conversation_store import (
+    ConversationTurnRecord,
+    FileConversationSessionArchiveStore,
+)
+from dayu.host.host import Host
+from dayu.host.reply_outbox_store import InMemoryReplyOutboxStore
+from tests.application.conftest import (
+    StubHostExecutor,
+    StubRunRegistry,
+    StubSessionRegistry,
+)
+
+
+def _build_host(archive_store: FileConversationSessionArchiveStore) -> Host:
+    """构造仅注入历史读所需依赖的 Host。"""
+
+    return Host(
+        executor=StubHostExecutor(),
+        session_registry=StubSessionRegistry(),
+        run_registry=StubRunRegistry(),
+        reply_outbox_store=InMemoryReplyOutboxStore(),
+        archive_store=archive_store,
+    )
+
+
+def _seed_archive_with_turns(
+    store: FileConversationSessionArchiveStore,
+    *,
+    session_id: str,
+    turns: list[tuple[str, str, str]],
+) -> ConversationSessionArchive:
+    """以 ``(user, assistant, reasoning)`` 列表种入若干轮历史。
+
+    runtime/history 子视图同步推进，``turn_id`` 一一对应。
+    """
+
+    archive = ConversationSessionArchive.create_empty(session_id)
+    archive = store.save(archive, expected_revision=None)
+    for idx, (user_text, assistant_text, reasoning) in enumerate(turns):
+        prev_revision = archive.revision
+        runtime_turn = ConversationTurnRecord(
+            turn_id=f"turn_{idx}",
+            scene_name="interactive",
+            user_text=user_text,
+            assistant_final=assistant_text,
+        )
+        history_turn = ConversationHistoryTurnRecord(
+            turn_id=runtime_turn.turn_id,
+            scene_name=runtime_turn.scene_name,
+            user_text=user_text,
+            assistant_text=assistant_text,
+            assistant_reasoning=reasoning,
+            created_at=runtime_turn.created_at,
+        )
+        archive = archive.with_next_turn(runtime_turn, history_turn)
+        archive = store.save(archive, expected_revision=prev_revision)
+    return archive
+
+
+@pytest.mark.unit
+def test_list_excerpts_reads_from_history_archive_with_reasoning(tmp_path: Path) -> None:
+    """读源是 ``history_archive``，``reasoning_text`` 透出 ``assistant_reasoning``。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_a",
+        turns=[
+            ("Q1", "A1", "R1"),
+            ("Q2", "A2", "R2"),
+        ],
+    )
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_a", limit=10)
+
+    assert [(e.user_text, e.assistant_text, e.reasoning_text) for e in excerpts] == [
+        ("Q1", "A1", "R1"),
+        ("Q2", "A2", "R2"),
+    ]
+
+
+@pytest.mark.unit
+def test_list_excerpts_order_is_old_to_new(tmp_path: Path) -> None:
+    """顺序契约：旧 → 新。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_order",
+        turns=[("Q1", "A1", ""), ("Q2", "A2", ""), ("Q3", "A3", "")],
+    )
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_order", limit=10)
+
+    assert [e.user_text for e in excerpts] == ["Q1", "Q2", "Q3"]
+
+
+@pytest.mark.unit
+def test_list_excerpts_empty_reasoning_yields_empty_string(tmp_path: Path) -> None:
+    """无 reasoning 的轮次 ``reasoning_text == ""``。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_empty_r",
+        turns=[("Q1", "A1", "")],
+    )
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_empty_r", limit=1)
+
+    assert len(excerpts) == 1
+    assert excerpts[0].reasoning_text == ""
+
+
+@pytest.mark.unit
+def test_list_excerpts_returns_empty_for_missing_archive(tmp_path: Path) -> None:
+    """archive 文件缺失时按 §1.5 返回空列表。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+
+    assert host.list_conversation_session_turn_excerpts("missing", limit=5) == []
+
+
+@pytest.mark.unit
+def test_list_excerpts_returns_empty_for_empty_history(tmp_path: Path) -> None:
+    """archive 存在但 history 为空时返回空列表。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    store.save(ConversationSessionArchive.create_empty("sess_empty"), expected_revision=None)
+    host = _build_host(store)
+
+    assert host.list_conversation_session_turn_excerpts("sess_empty", limit=5) == []
+
+
+@pytest.mark.unit
+def test_list_excerpts_limit_non_positive_returns_empty(tmp_path: Path) -> None:
+    """``limit <= 0`` 直接返回空列表，不读 archive。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_limit",
+        turns=[("Q1", "A1", "R1")],
+    )
+    host = _build_host(store)
+
+    assert host.list_conversation_session_turn_excerpts("sess_limit", limit=0) == []
+    assert host.list_conversation_session_turn_excerpts("sess_limit", limit=-1) == []
+
+
+@pytest.mark.unit
+def test_list_excerpts_limit_larger_than_turn_count_returns_all(tmp_path: Path) -> None:
+    """``limit`` 超过总轮次时返回全部。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_lim_lg",
+        turns=[("Q1", "A1", ""), ("Q2", "A2", "")],
+    )
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_lim_lg", limit=100)
+
+    assert [e.user_text for e in excerpts] == ["Q1", "Q2"]
+
+
+@pytest.mark.unit
+def test_list_excerpts_limit_equals_turn_count(tmp_path: Path) -> None:
+    """``limit`` 等于总轮次时返回全部。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_lim_eq",
+        turns=[("Q1", "A1", ""), ("Q2", "A2", "")],
+    )
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_lim_eq", limit=2)
+
+    assert len(excerpts) == 2
+    assert [e.user_text for e in excerpts] == ["Q1", "Q2"]
+
+
+@pytest.mark.unit
+def test_list_excerpts_limit_smaller_takes_most_recent(tmp_path: Path) -> None:
+    """``limit`` 小于总轮次时取最近 N 条，仍按旧 → 新。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_lim_sm",
+        turns=[("Q1", "A1", ""), ("Q2", "A2", ""), ("Q3", "A3", "")],
+    )
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_lim_sm", limit=2)
+
+    assert [e.user_text for e in excerpts] == ["Q2", "Q3"]
+
+
+@pytest.mark.unit
+def test_list_excerpts_does_not_consume_runtime_transcript(tmp_path: Path) -> None:
+    """``runtime_transcript`` 不再是历史真源：人为构造 history 与 runtime 不同
+    的 ``user_text`` / ``assistant_text``，验证返回值来自 history 子视图。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    archive = ConversationSessionArchive.create_empty("sess_split")
+    archive = store.save(archive, expected_revision=None)
+    prev_revision = archive.revision
+    runtime_turn = ConversationTurnRecord(
+        turn_id="t1",
+        scene_name="interactive",
+        user_text="runtime-only-user",
+        assistant_final="runtime-only-assistant",
+    )
+    history_turn = ConversationHistoryTurnRecord(
+        turn_id="t1",
+        scene_name="interactive",
+        user_text="history-user",
+        assistant_text="history-assistant",
+        assistant_reasoning="history-reason",
+        created_at=runtime_turn.created_at,
+    )
+    archive = archive.with_next_turn(runtime_turn, history_turn)
+    store.save(archive, expected_revision=prev_revision)
+
+    host = _build_host(store)
+    excerpts = host.list_conversation_session_turn_excerpts("sess_split", limit=5)
+
+    assert len(excerpts) == 1
+    assert excerpts[0].user_text == "history-user"
+    assert excerpts[0].assistant_text == "history-assistant"
+    assert excerpts[0].reasoning_text == "history-reason"
+
+
+@pytest.mark.unit
+def test_list_excerpts_repeat_reads_are_stable(tmp_path: Path) -> None:
+    """重复读取相同 archive 字段顺序稳定（旧 → 新），多次结果相等。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    _seed_archive_with_turns(
+        store,
+        session_id="sess_stable",
+        turns=[("Q1", "A1", "R1"), ("Q2", "A2", "")],
+    )
+    host = _build_host(store)
+
+    first = host.list_conversation_session_turn_excerpts("sess_stable", limit=10)
+    second = host.list_conversation_session_turn_excerpts("sess_stable", limit=10)
+
+    assert first == second
+
+
+@pytest.mark.unit
+def test_list_excerpts_supports_migrated_legacy_session(tmp_path: Path) -> None:
+    """老会话经 ``conversation_archive_init`` 迁移后能完整读出，
+    ``reasoning_text == ""``、其他字段齐全。"""
+
+    import json
+
+    from dayu.cli.workspace_migrations.conversation_archive_init import (
+        migrate_conversation_archive_init,
+    )
+    from dayu.workspace_paths import CONVERSATION_STORE_RELATIVE_DIR
+
+    workspace_root = tmp_path / "workspace"
+    target_dir = workspace_root / CONVERSATION_STORE_RELATIVE_DIR
+    target_dir.mkdir(parents=True)
+
+    legacy_payload = {
+        "schema": "conversation_transcript/v1",
+        "session_id": "sess_legacy",
+        "revision": "rev0",
+        "created_at": "2026-04-01T00:00:00+00:00",
+        "turns": [
+            {
+                "turn_id": "t1",
+                "scene_name": "interactive",
+                "user_text": "老问题",
+                "assistant_final": "老回答",
+                "created_at": "2026-04-01T00:01:00+00:00",
+                "tool_uses": [],
+                "warnings": [],
+                "errors": [],
+                "degraded": False,
+            }
+        ],
+    }
+    legacy_path = target_dir / "sess_legacy.json"
+    legacy_path.write_text(json.dumps(legacy_payload, ensure_ascii=False), encoding="utf-8")
+
+    rewritten = migrate_conversation_archive_init(workspace_root)
+    assert rewritten == 1
+
+    store = FileConversationSessionArchiveStore(target_dir)
+    host = _build_host(store)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess_legacy", limit=10)
+
+    assert len(excerpts) == 1
+    assert excerpts[0].user_text == "老问题"
+    assert excerpts[0].assistant_text == "老回答"
+    assert excerpts[0].reasoning_text == ""
+    assert excerpts[0].created_at == "2026-04-01T00:01:00+00:00"
+
+
+@pytest.mark.unit
+def test_list_excerpts_returns_empty_for_corrupt_json(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """JSON 损坏的 archive 文件按 §1.7 读路径列降级为空列表 + warning。"""
+
+    conv_dir = tmp_path / "conv"
+    conv_dir.mkdir()
+    (conv_dir / "sess_corrupt.json").write_text("{not-json", encoding="utf-8")
+    store = FileConversationSessionArchiveStore(conv_dir)
+    host = _build_host(store)
+
+    with caplog.at_level("WARNING"):
+        result = host.list_conversation_session_turn_excerpts("sess_corrupt", limit=5)
+
+    assert result == []
+    assert any("历史读 archive 损坏" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.unit
+def test_list_excerpts_returns_empty_for_invalid_schema(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """schema 非法（缺 ``runtime_transcript`` 等）时降级为空列表 + warning。"""
+
+    import json as _json
+
+    conv_dir = tmp_path / "conv"
+    conv_dir.mkdir()
+    bad_payload = {"schema": "conversation_session_archive/v1", "session_id": "sess_bad"}
+    (conv_dir / "sess_bad.json").write_text(_json.dumps(bad_payload), encoding="utf-8")
+    store = FileConversationSessionArchiveStore(conv_dir)
+    host = _build_host(store)
+
+    with caplog.at_level("WARNING"):
+        result = host.list_conversation_session_turn_excerpts("sess_bad", limit=5)
+
+    assert result == []
+    assert any("历史读 archive 损坏" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.unit
+def test_list_excerpts_returns_empty_for_unmigrated_legacy_schema(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """旧 transcript schema 未迁移时降级为空列表 + warning（不抛 RuntimeError）。"""
+
+    import json as _json
+
+    conv_dir = tmp_path / "conv"
+    conv_dir.mkdir()
+    legacy_payload = {
+        "schema": "conversation_transcript/v1",
+        "session_id": "sess_legacy_no_mig",
+        "revision": "rev0",
+        "created_at": "2026-04-01T00:00:00+00:00",
+        "turns": [],
+    }
+    (conv_dir / "sess_legacy_no_mig.json").write_text(
+        _json.dumps(legacy_payload), encoding="utf-8"
+    )
+    store = FileConversationSessionArchiveStore(conv_dir)
+    host = _build_host(store)
+
+    with caplog.at_level("WARNING"):
+        result = host.list_conversation_session_turn_excerpts(
+            "sess_legacy_no_mig", limit=5
+        )
+
+    assert result == []
+    assert any("历史读 archive 损坏" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.unit
+def test_session_digest_returns_empty_for_corrupt_archive(tmp_path: Path) -> None:
+    """``get_conversation_session_digest`` 同样对损坏 archive 降级为空摘要。"""
+
+    conv_dir = tmp_path / "conv"
+    conv_dir.mkdir()
+    (conv_dir / "sess_dg.json").write_text("{not-json", encoding="utf-8")
+    store = FileConversationSessionArchiveStore(conv_dir)
+    host = _build_host(store)
+
+    digest = host.get_conversation_session_digest("sess_dg")
+
+    assert digest.turn_count == 0
+    assert digest.first_question_preview == ""
+    assert digest.last_question_preview == ""


### PR DESCRIPTION
- ConversationSessionTurnExcerpt 增 reasoning_text 字段，映射 history_archive.assistant_reasoning。
- list_conversation_session_turn_excerpts 读源切到 archive.history_archive.turns，禁止从 runtime_transcript 投影。
- 新增 _safe_load_archive_for_read 兜底：archive 缺失 / JSON 损坏 / schema 非法 / 旧 transcript 未迁移一律降级为空 + warning，写路径仍 fail-closed。
- get_conversation_session_digest 共享同一 fail-soft 加载。
- 补 16 个回归用例 + 更新 dayu/host/README.md。
- 未破坏 #118 §4 任一禁项（reasoning 不入 runtime / prepared snapshot / memory / compaction）。

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>
