### PR TITLE
feat: Host.clear_session_history 原子清空五真源 + 屏障吸收链路扩展 (#117)

### DIFF
--- a/dayu/contracts/session.py
+++ b/dayu/contracts/session.py
@@ -26,9 +26,22 @@ class SessionSource(str, Enum):
 
 
 class SessionState(str, Enum):
-    """Session 状态枚举。"""
+    """Session 状态枚举。
+
+    - ``ACTIVE``：默认活跃状态，允许全部写入路径（pending turn / reply outbox /
+      新 run / archive 写）。
+    - ``CLEARING``：``Host.clear_session_history`` 正在进行的临时屏障状态。
+      所有写入路径被拒绝；清空成功后自动回到 ``ACTIVE``，清空内部失败则升级为
+      ``CLEARING_FAILED``。
+    - ``CLEARING_FAILED``：清空动作 archive 写已生效但补偿性 delete 在有界
+      retry 后仍未收敛，session 进入持久锁定屏障。所有写入路径继续被拒绝，
+      退出该状态需要范围外的人工修复路径（reopen / cancel）。
+    - ``CLOSED``：终态，不可逆。
+    """
 
     ACTIVE = "active"
+    CLEARING = "clearing"
+    CLEARING_FAILED = "clearing_failed"
     CLOSED = "closed"
 
 

--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -86,9 +86,9 @@ lane 合并顺序（后者覆盖前者）：
                                         （pending turn / reply outbox / run 新建）
 ```
 
-- `SessionState` 仅两态：`ACTIVE` / `CLOSED`。
+- `SessionState` 四态：`ACTIVE` / `CLEARING` / `CLEARING_FAILED` / `CLOSED`（详见 §10.10）。
 - `SessionSource` 标识来源（CLI / WEB / WECHAT / GUI / API / INTERNAL），语义上是"谁是这条会话的主使者"。
-- **活性屏障**：所有依赖 session 的写入路径（pending turn 写、reply outbox 写、run 新建）统一经过"会话必须处于 ACTIVE"检查，违反即抛 `SessionClosedError`。这把 session 从 TOCTOU 竞态里抽出来，由持久层做一致性保证。
+- **活性屏障**：所有依赖 session 的写入路径（pending turn 写、reply outbox 写、`run_registry.register_run`）统一经过 `_session_barrier.ensure_session_active`——"会话必须处于 ACTIVE"检查；违反即抛 `SessionWriteBlockedError` 子类（`SessionClosedError` / `SessionClearingError` / `SessionClearingFailedError`）。这把 session 从 TOCTOU 竞态里抽出来，由持久层做一致性保证。
 - **cancel_session 顺序（稳定契约）**：
   1. 先把 session 置 CLOSED（关门）；
   2. 再批量 cancel 关联的 active run（不再接新活）；
@@ -527,6 +527,34 @@ Compaction 有两条触发路径，职责分离：
 - compaction 任何路径**不修改** `history_archive`，仅通过 `with_runtime_transcript` 替换运行态子视图。
 
 **旧 schema 迁移**：`dayu-cli init` 走 `dayu/cli/workspace_migrations/conversation_archive_init.py`：识别"顶层缺 `runtime_transcript` 但含 `turns`"的旧 transcript 文件，原地包成 archive；`history_archive.turns` 全量从旧 turns 投影（`assistant_reasoning=""`）。损坏文件 warning 跳过、新 schema 文件 no-op。`FileConversationSessionArchiveStore.load` 遇到旧 schema 直接抛 `RuntimeError` 提示运行迁移，**不**做兼容读取。
+
+### 10.10 清空会话历史（`#117`）
+
+`Host.clear_session_history(session_id)` 在不关闭 session 的前提下原子清空"五真源"——`history_archive.turns` / `runtime_transcript.turns` + memory / `pending_turn_store` / `reply_outbox_store` / executor replay stash——清完后 session 仍 `ACTIVE`，下一轮可继续；`#116` 历史读返回 `[]`。
+
+**`SessionState` 状态机扩展**：`{ACTIVE, CLEARING, CLEARING_FAILED, CLOSED}`。`is_session_active` 收紧为"仅 ACTIVE"，三类写入路径——`pending_turn_store` / `reply_outbox_store` 写入、以及 **`run_registry.register_run`**——统一经 `_session_barrier.ensure_session_active` 检查：`CLEARING` 抛 `SessionClearingError`、`CLEARING_FAILED` 抛 `SessionClearingFailedError`、`CLOSED` 抛 `SessionClosedError`。三者共享基类 **`SessionWriteBlockedError(RuntimeError)`**，便于上层用单条 `except` 统一吸收，同时 `type()` / `isinstance()` 仍可区分子类用于 observability。
+
+**屏障吸收链路**：executor 的 `_register_accepted_pending_turn` / `_register_prepared_pending_turn` 在 scene prepare 与 cancel 时间窗内的迟到登记统一 `except SessionWriteBlockedError`，降级为 no-op（日志携带 `barrier=type(exc).__name__` 区分子类）；Host 的 `resume_pending_turn_stream` 在 lease acquire / lease 回退两处也统一 `except SessionWriteBlockedError`，对外收敛为 `ValueError("...session 已不再接受写入...")`，`__cause__` 保留原始屏障异常便于诊断。这条链路是"清空 / 关停期间防止 executor 迟到写入产生孤儿数据"的最终防线，不依赖 archive 文件锁。
+
+**写入顺序（强约束）**：
+
+1. `SessionRegistry.begin_clearing` — `ACTIVE → CLEARING`；非 `ACTIVE` 直接 `ConversationClearRejectedError`。
+2. 锁内拒绝预检：active run / pending turn / reply outbox 任一非空 → `ConversationClearRejectedError`，**不**自动 cancel。
+3. `archive_store.save(empty, expected_revision=live.revision)`；`with_runtime_transcript` 与 `history_archive.create_empty` 共用同一 revision。`save` 抛"revision 冲突" → `ConversationClearStaleError`（场景 b：compaction 写回竞速）。**这是清空成功的唯一切点**。
+4. archive 写成功后，对 pending turn / reply outbox / replay stash 做幂等 `delete_by_session_id` / `discard_replay_state_for_session`；任一失败进入有界 retry（3 次、固定 50ms 间隔）。
+5. retry 仍未收敛 → `mark_clearing_failed`（`CLEARING → CLEARING_FAILED`，**持久锁定**），抛 `ConversationClearPartiallyAppliedError`，错误体携带 `residual_sources`；session 写入面持续锁定直至外部修复路径（reopen / cancel）触发，不在 `#117` 范围。
+6. 全部收敛 → `end_clearing`（`CLEARING → ACTIVE`，释放屏障）。
+
+**失败语义（分层契约）**：
+
+| 时间窗 | 失败类型 | 五真源状态 | session 状态 |
+| --- | --- | --- | --- |
+| archive 写之前 | `ConversationClearRejectedError` / `ConversationClearStaleError` | 全部不变 | `CLEARING → ACTIVE`（屏障释放） |
+| archive 写之后、其他真源未收敛 | `ConversationClearPartiallyAppliedError` | archive 已空，其余可能残留 | `CLEARING → CLEARING_FAILED`（持久锁定） |
+
+**调用方契约**：`ConversationClearPartiallyAppliedError` **不可重试**——清空内部已尽力 retry，再调一次会被 `CLEARING_FAILED` 屏障拒；上层应升级观测告警 / 人工介入。
+
+回归用例见 `tests/application/test_host_clear_session_history.py`、`tests/application/test_session_registry.py::TestClearingBarrier`、`tests/application/test_session_barrier.py`、`tests/application/test_run_registry.py::TestRegisterRunSessionBarrier`。
 
 ---
 

--- a/dayu/host/_session_barrier.py
+++ b/dayu/host/_session_barrier.py
@@ -49,7 +49,9 @@ def ensure_session_active(
 
     if session_activity is None:
         return
-    if session_activity.is_session_active(session_id):
+
+    state = session_activity.get_session_state(session_id)
+    if state == SessionState.ACTIVE:
         return
 
     # 延迟 import 避免 Host 私有模块与 protocols 形成包级循环。
@@ -59,7 +61,6 @@ def ensure_session_active(
         SessionClosedError,
     )
 
-    state = session_activity.get_session_state(session_id)
     if state == SessionState.CLEARING:
         Log.verbose(
             f"session 处于 CLEARING 屏障，拒绝 {target_name} 写入: "
@@ -75,6 +76,8 @@ def ensure_session_active(
         )
         raise SessionClearingFailedError(session_id)
 
+    # state is None（session 不存在）或 SessionState.CLOSED：统一按"已关闭"
+    # 语义拒绝写入，保持与 SessionClosedError 文案一致。
     Log.verbose(
         f"session 已关闭或不存在，拒绝 {target_name} 写入: "
         f"session_id={session_id}, operation={operation}",

--- a/dayu/host/_session_barrier.py
+++ b/dayu/host/_session_barrier.py
@@ -1,14 +1,19 @@
 """Host 仓储写入前的 session 活性屏障辅助函数。
 
 该模块集中承载 pending turn / reply outbox 等 Host 内部真源仓储共用的
-session 活性校验逻辑，避免重复实现同一套“session 已关闭则拒绝写入”的
+session 活性校验逻辑，避免重复实现同一套"session 已关闭则拒绝写入"的
 屏障分支。
+
+屏障识别遵循 ``#117`` 共享设计 §3.3：仅 ``ACTIVE`` 状态允许写入；
+``CLEARING`` / ``CLEARING_FAILED`` / ``CLOSED`` 任一状态都拒绝写入，
+并按 session 当前状态抛出对应异常以便观测面区分原因。
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from dayu.contracts.session import SessionState
 from dayu.log import Log
 
 
@@ -38,6 +43,8 @@ def ensure_session_active(
 
     Raises:
         SessionClosedError: session 不存在或已 ``CLOSED`` 时抛出。
+        SessionClearingError: session 处于 ``CLEARING`` 临时屏障时抛出。
+        SessionClearingFailedError: session 处于 ``CLEARING_FAILED`` 持久锁定屏障时抛出。
     """
 
     if session_activity is None:
@@ -46,7 +53,27 @@ def ensure_session_active(
         return
 
     # 延迟 import 避免 Host 私有模块与 protocols 形成包级循环。
-    from dayu.host.protocols import SessionClosedError
+    from dayu.host.protocols import (
+        SessionClearingError,
+        SessionClearingFailedError,
+        SessionClosedError,
+    )
+
+    state = session_activity.get_session_state(session_id)
+    if state == SessionState.CLEARING:
+        Log.verbose(
+            f"session 处于 CLEARING 屏障，拒绝 {target_name} 写入: "
+            f"session_id={session_id}, operation={operation}",
+            module=module,
+        )
+        raise SessionClearingError(session_id)
+    if state == SessionState.CLEARING_FAILED:
+        Log.verbose(
+            f"session 处于 CLEARING_FAILED 锁定，拒绝 {target_name} 写入: "
+            f"session_id={session_id}, operation={operation}",
+            module=module,
+        )
+        raise SessionClearingFailedError(session_id)
 
     Log.verbose(
         f"session 已关闭或不存在，拒绝 {target_name} 写入: "

--- a/dayu/host/conversation_store.py
+++ b/dayu/host/conversation_store.py
@@ -536,7 +536,7 @@ class ConversationSessionArchiveStore(Protocol):
             实际保存后的 archive。
 
         Raises:
-            RuntimeError: revision 冲突时抛出。
+            ConversationArchiveRevisionConflictError: revision 冲突时抛出。
         """
         ...
 
@@ -674,7 +674,7 @@ class FileConversationSessionArchiveStore:
             实际保存后的 archive。
 
         Raises:
-            RuntimeError: revision 冲突时抛出。
+            ConversationArchiveRevisionConflictError: revision 冲突时抛出。
         """
 
         file_path = self._resolve_file_path(archive.session_id)
@@ -691,9 +691,16 @@ class FileConversationSessionArchiveStore:
                         f"session_id={archive.session_id}, expected={expected_revision}, actual={existing.revision}",
                         module=MODULE,
                     )
-                    raise RuntimeError(
-                        "conversation session archive revision 冲突："
-                        f"session_id={archive.session_id}, expected={expected_revision}, actual={existing.revision}"
+                    # 延迟 import 规避 conversation_store -> protocols -> host_execution
+                    # -> prepared_turn -> conversation_store 的包级循环导入。
+                    from dayu.host.protocols import (
+                        ConversationArchiveRevisionConflictError,
+                    )
+
+                    raise ConversationArchiveRevisionConflictError(
+                        archive.session_id,
+                        expected_revision=expected_revision,
+                        actual_revision=existing.revision,
                     )
             # 文件不存在时直接写入：首轮 archive 仅存在于内存，不构成并发冲突
             _atomic_write_text(

--- a/dayu/host/executor.py
+++ b/dayu/host/executor.py
@@ -35,7 +35,7 @@ from dayu.host.protocols import (
     PendingConversationTurnStoreProtocol,
     RunEventBusProtocol,
     RunRegistryProtocol,
-    SessionClosedError,
+    SessionWriteBlockedError,
 )
 from dayu.contracts.agent_execution import (
     AgentInput,
@@ -770,12 +770,15 @@ class DefaultHostExecutor(HostExecutorProtocol):
                 resume_source_json=accepted_turn_json,
                 metadata=_extract_pending_turn_metadata(execution_contract.metadata),
             )
-        except SessionClosedError:
-            # cancel_session 已在仓储层屏障处关闭 session，executor 必须放弃登记
-            # 以避免生成孤儿 pending turn。
+        except SessionWriteBlockedError as exc:
+            # cancel_session / clear_session_history 已在仓储层屏障处使 session
+            # 进入非 ACTIVE 状态，executor 必须放弃登记以避免生成孤儿 pending
+            # turn。三个具体子类（CLOSED / CLEARING / CLEARING_FAILED）共享同一
+            # 吸收语义，统一捕获基类。
             Log.verbose(
-                f"[{run_id}] session 已关闭，跳过 accepted pending turn 登记: "
-                f"session_id={session_id}, scene_name={scene_name}",
+                f"[{run_id}] session 写入屏障已立，跳过 accepted pending turn 登记: "
+                f"session_id={session_id}, scene_name={scene_name}, "
+                f"barrier={type(exc).__name__}",
                 module=MODULE,
             )
             return None
@@ -831,12 +834,14 @@ class DefaultHostExecutor(HostExecutorProtocol):
                 resume_source_json=prepared_turn_json,
                 metadata=metadata,
             )
-        except SessionClosedError:
-            # cancel_session 已在仓储层屏障处关闭 session，executor 必须放弃登记
-            # 以避免生成孤儿 pending turn。
+        except SessionWriteBlockedError as exc:
+            # cancel_session / clear_session_history 已在仓储层屏障处使 session
+            # 进入非 ACTIVE 状态，executor 必须放弃登记以避免生成孤儿 pending
+            # turn。三个具体子类共享同一吸收语义，统一捕获基类。
             Log.verbose(
-                f"[{run_id}] session 已关闭，跳过 prepared pending turn 登记: "
-                f"session_id={session_id}, scene_name={scene_name}",
+                f"[{run_id}] session 写入屏障已立，跳过 prepared pending turn 登记: "
+                f"session_id={session_id}, scene_name={scene_name}, "
+                f"barrier={type(exc).__name__}",
                 module=MODULE,
             )
             return None

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -58,9 +58,11 @@ from dayu.host.protocols import (
     RunRegistryProtocol,
     SessionRegistryProtocol,
     SessionWriteBlockedError,
+    ConversationArchiveRevisionConflictError,
     ConversationClearRejectedError,
     ConversationClearStaleError,
     ConversationClearPartiallyAppliedError,
+    SessionStateTransitionError,
 )
 from dayu.log import Log
 from dayu.host.run_registry import SQLiteRunRegistry
@@ -919,13 +921,13 @@ class Host:
             raise KeyError(f"session 不存在: {session_id}")
 
         # 步骤 1：立屏障。begin_clearing 仅允许从 ACTIVE 进入 CLEARING；
-        # CLOSED / 已 CLEARING / CLEARING_FAILED 一律抛 RuntimeError，转换为
-        # 业务级 RejectedError 上抛，五真源完全不变。
+        # CLOSED / 已 CLEARING / CLEARING_FAILED 一律抛 SessionStateTransitionError，
+        # 转换为业务级 RejectedError 上抛，五真源完全不变。基础设施级 RuntimeError
+        # （如 SQLite ``database locked``）不会被这里吞掉，会沿原异常上冒。
         try:
             self._session_registry.begin_clearing(session_id)
-        except RuntimeError as exc:
-            current = self._session_registry.get_session_state(session_id)
-            reason = f"session_state={current.value if current else 'unknown'}"
+        except SessionStateTransitionError as exc:
+            reason = f"session_state={exc.current_state.value}"
             Log.info(
                 f"clear_session_history 屏障拒绝: session_id={session_id}, {reason}, error={exc}",
                 module=MODULE,
@@ -969,17 +971,14 @@ class Host:
             empty_archive = ConversationSessionArchive.create_empty(session_id)
             try:
                 self._archive_store.save(empty_archive, expected_revision=live.revision)
-            except RuntimeError as exc:
-                # 与 ``conversation_store`` 的 revision 冲突错误类型对齐：
-                # 仍是 RuntimeError，依据消息片段映射为 StaleError。
-                msg = str(exc)
-                if "revision 冲突" in msg:
-                    raise ConversationClearStaleError(
-                        session_id,
-                        expected_revision=live.revision,
-                        actual_revision=msg,
-                    ) from exc
-                raise
+            except ConversationArchiveRevisionConflictError as exc:
+                # 与 ``conversation_store`` 的类型化 revision 冲突异常对齐：
+                # 编译期映射到业务级 StaleError，避免依赖错误消息字串匹配。
+                raise ConversationClearStaleError(
+                    session_id,
+                    expected_revision=exc.expected_revision or "",
+                    actual_revision=exc.actual_revision,
+                ) from exc
 
             # 步骤 4：同锁同屏障内做有界 retry 的补偿性 delete。
             residual: tuple[str, ...] = ()

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -57,7 +57,10 @@ from dayu.host.protocols import (
     RunEventBusProtocol,
     RunRegistryProtocol,
     SessionRegistryProtocol,
-    SessionClosedError,
+    SessionWriteBlockedError,
+    ConversationClearRejectedError,
+    ConversationClearStaleError,
+    ConversationClearPartiallyAppliedError,
 )
 from dayu.log import Log
 from dayu.host.run_registry import SQLiteRunRegistry
@@ -67,6 +70,12 @@ from dayu.workspace_paths import build_conversation_store_dir
 
 
 MODULE = "HOST"
+
+# `#117` 共享设计 §3.5 / §3.6 契约 B：archive 写成功后补偿性 delete 失败时
+# 在同锁同屏障内做有界 retry。当前选择 3 次固定间隔 50ms（总尾延迟 ≤150ms），
+# SQLite 写锁瞬态冲突通常 ≤几十 ms，足以覆盖；超过则升级 ``CLEARING_FAILED``。
+_CLEAR_HISTORY_MAX_RETRY = 3
+_CLEAR_HISTORY_RETRY_INTERVAL_SEC = 0.05
 # 会话预览截断长度：控制 session 摘要、日志输出等场景下的 user_message 预览宽度，
 # 48 字符能覆盖常见一行标题，同时避免日志中占用过多宽度。
 _CONVERSATION_PREVIEW_MAX_CHARS = 48
@@ -870,6 +879,175 @@ class Host:
         )
         return updated, cancelled_ids
 
+    def clear_session_history(self, session_id: str) -> None:
+        """清空指定 session 的对话历史与五真源。
+
+        实现遵循 ``#117`` 共享设计 §3.2 ~ §3.6：
+
+        1. 立 ``CLEARING`` 临时屏障 → pending turn / reply outbox / 新 run 写入
+           被 ``_session_barrier`` 拒绝；
+        2. 取 archive 文件锁、做拒绝预检（active run / pending turn / outbox /
+           CLOSED / 已 CLEARING / CLEARING_FAILED）；
+        3. ``save(empty_archive, expected_revision=live.revision)``——清空成功的唯一切点；
+        4. 同锁同屏障内幂等 delete pending turn / reply outbox / replay stash，
+           失败则有界 retry（``_CLEAR_HISTORY_MAX_RETRY`` 次、固定间隔
+           ``_CLEAR_HISTORY_RETRY_INTERVAL_SEC`` 秒）；
+        5. 全部收敛 → ``end_clearing`` 释放屏障；retry 仍未收敛 →
+           ``mark_clearing_failed`` 升级持久锁定 + ``ConversationClearPartiallyAppliedError``。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Raises:
+            KeyError: session 不存在时抛出。
+            ConversationClearRejectedError: 预检命中拒绝条件，五真源不变。
+            ConversationClearStaleError: archive 乐观锁冲突（场景 b 时间窗），
+                五真源不变。
+            ConversationClearPartiallyAppliedError: archive 已清但补偿 delete
+                在有界 retry 后仍未收敛，session 进入 ``CLEARING_FAILED``。
+        """
+
+        import time
+
+        if self._archive_store is None:
+            raise RuntimeError(
+                f"Host 未装配 archive_store，无法清空对话历史: session_id={session_id}"
+            )
+
+        session = self.get_session(session_id)
+        if session is None:
+            raise KeyError(f"session 不存在: {session_id}")
+
+        # 步骤 1：立屏障。begin_clearing 仅允许从 ACTIVE 进入 CLEARING；
+        # CLOSED / 已 CLEARING / CLEARING_FAILED 一律抛 RuntimeError，转换为
+        # 业务级 RejectedError 上抛，五真源完全不变。
+        try:
+            self._session_registry.begin_clearing(session_id)
+        except RuntimeError as exc:
+            current = self._session_registry.get_session_state(session_id)
+            reason = f"session_state={current.value if current else 'unknown'}"
+            Log.info(
+                f"clear_session_history 屏障拒绝: session_id={session_id}, {reason}, error={exc}",
+                module=MODULE,
+            )
+            raise ConversationClearRejectedError(session_id, reason=reason) from exc
+
+        try:
+            # 步骤 2：archive 文件锁 + 预检（active run / pending turn / outbox）。
+            # 三类查询都走 store / registry 高层接口，禁止跨层 SQL。
+            active_runs = [
+                run
+                for run in self._run_registry.list_runs(session_id=session_id)
+                if run.is_active()
+            ]
+            if active_runs:
+                raise ConversationClearRejectedError(
+                    session_id,
+                    reason=f"active_runs={len(active_runs)}",
+                )
+            pending_records = self._pending_turn_store.list_pending_turns(
+                session_id=session_id,
+            )
+            if pending_records:
+                raise ConversationClearRejectedError(
+                    session_id,
+                    reason=f"pending_turns={len(pending_records)}",
+                )
+            outbox_records = self._reply_outbox_store.list_replies(
+                session_id=session_id,
+            )
+            if outbox_records:
+                raise ConversationClearRejectedError(
+                    session_id,
+                    reason=f"reply_outbox={len(outbox_records)}",
+                )
+
+            # archive 写：load_or_create → save(empty, expected_revision=live.revision)
+            # archive 缺失时 load_or_create 在锁内创建空 archive，本身已等价"清空"，
+            # 但仍要把空状态显式 save 一次推进 revision，便于上游观察清空切点。
+            live = self._archive_store.load_or_create(session_id)
+            empty_archive = ConversationSessionArchive.create_empty(session_id)
+            try:
+                self._archive_store.save(empty_archive, expected_revision=live.revision)
+            except RuntimeError as exc:
+                # 与 ``conversation_store`` 的 revision 冲突错误类型对齐：
+                # 仍是 RuntimeError，依据消息片段映射为 StaleError。
+                msg = str(exc)
+                if "revision 冲突" in msg:
+                    raise ConversationClearStaleError(
+                        session_id,
+                        expected_revision=live.revision,
+                        actual_revision=msg,
+                    ) from exc
+                raise
+
+            # 步骤 4：同锁同屏障内做有界 retry 的补偿性 delete。
+            residual: tuple[str, ...] = ()
+            last_exc: Exception | None = None
+            for attempt in range(_CLEAR_HISTORY_MAX_RETRY):
+                residual_buf: list[str] = []
+                last_exc = None
+                try:
+                    self._pending_turn_store.delete_by_session_id(session_id)
+                except Exception as exc:  # noqa: BLE001
+                    residual_buf.append("pending_turn_store")
+                    last_exc = exc
+                try:
+                    self._reply_outbox_store.delete_by_session_id(session_id)
+                except Exception as exc:  # noqa: BLE001
+                    residual_buf.append("reply_outbox_store")
+                    last_exc = exc
+                try:
+                    self._executor.discard_replay_state_for_session(session_id)
+                except Exception as exc:  # noqa: BLE001
+                    residual_buf.append("executor_replay_stash")
+                    last_exc = exc
+
+                if not residual_buf:
+                    residual = ()
+                    break
+
+                residual = tuple(residual_buf)
+                if attempt < _CLEAR_HISTORY_MAX_RETRY - 1:
+                    time.sleep(_CLEAR_HISTORY_RETRY_INTERVAL_SEC)
+
+            if residual:
+                # 契约 B：archive 已清，session 升级为 CLEARING_FAILED 持久锁定。
+                self._session_registry.mark_clearing_failed(session_id)
+                Log.error(
+                    f"clear_session_history 补偿 delete 仍未收敛，session 进入 CLEARING_FAILED: "
+                    f"session_id={session_id}, residual={list(residual)}, last_error={last_exc}",
+                    module=MODULE,
+                )
+                raise ConversationClearPartiallyAppliedError(
+                    session_id,
+                    residual_sources=residual,
+                )
+        except (
+            ConversationClearRejectedError,
+            ConversationClearStaleError,
+            ConversationClearPartiallyAppliedError,
+        ):
+            # RejectedError / StaleError：archive 写未发生，释放临时屏障；
+            # PartiallyAppliedError：已 mark_clearing_failed，无需再 end_clearing。
+            current_state = self._session_registry.get_session_state(session_id)
+            if current_state == SessionState.CLEARING:
+                self._session_registry.end_clearing(session_id)
+            raise
+        except Exception:
+            # 未预料异常：保守释放临时屏障，避免误把 session 锁死在 CLEARING。
+            current_state = self._session_registry.get_session_state(session_id)
+            if current_state == SessionState.CLEARING:
+                self._session_registry.end_clearing(session_id)
+            raise
+        else:
+            # 步骤 7a：补偿 delete 全收敛 → 退出 CLEARING 屏障，session 重新对正常写入开放。
+            self._session_registry.end_clearing(session_id)
+            Log.info(
+                f"Host 清空会话历史: session_id={session_id}",
+                module=MODULE,
+            )
+
     def get_run(self, run_id: str) -> RunRecord | None:
         """查询单个 run。
 
@@ -1351,13 +1529,15 @@ class Host:
                 "pending conversation turn 正被其他 resumer 持有，拒绝并发恢复: "
                 f"pending_turn_id={pending_turn_id}, session_id={session_id}"
             ) from exc
-        except SessionClosedError as exc:
-            # acquire lease 阶段的仓储写入屏障：session 已在 acquire 前后一刻被关闭；
-            # 此时 lease 尚未落地，直接按"session 已关闭"契约对外暴露 ValueError，
+        except SessionWriteBlockedError as exc:
+            # acquire lease 阶段的仓储写入屏障：session 已在 acquire 前后一刻进入
+            # 非 ACTIVE 状态（CLOSED / CLEARING / CLEARING_FAILED）。lease 尚未
+            # 落地，统一按"session 不再接受新写入"契约对外暴露 ValueError，
             # 避免把 RuntimeError 子类泄漏给 Service / UI。
             raise ValueError(
-                "pending conversation turn 所属 session 已关闭，拒绝恢复: "
-                f"pending_turn_id={pending_turn_id}, session_id={session_id}"
+                "pending conversation turn 所属 session 已不再接受写入，拒绝恢复: "
+                f"pending_turn_id={pending_turn_id}, session_id={session_id}, "
+                f"barrier={type(exc).__name__}"
             ) from exc
         except ValueError as exc:
             # record_resume_attempt 内部已在达上限时原子删除记录；此处不再重复 DELETE，避免无意义 SQL 与模糊的代码意图。
@@ -1425,11 +1605,11 @@ class Host:
                 if current_record.resume_attempt_count >= self._pending_turn_resume_max_attempts:
                     try:
                         self._delete_pending_turn(pending_turn_id)
-                    except SessionClosedError as delete_exc:
+                    except SessionWriteBlockedError as delete_exc:
                         Log.warning(
                             "pending conversation turn 达到最大恢复次数但删除被 session 屏障拒绝: "
                             f"pending_turn_id={pending_turn_id}, session_id={session_id}, "
-                            f"error={delete_exc}",
+                            f"barrier={type(delete_exc).__name__}, error={delete_exc}",
                             module=MODULE,
                         )
                     raise ValueError(
@@ -1441,23 +1621,26 @@ class Host:
                         pending_turn_id,
                         error_message=str(exc),
                     )
-                except SessionClosedError as failure_exc:
-                    # session 已关闭，lease 回退将由 cleanup_stale_pending_turns 兜底；
-                    # 此时不得再抛 SessionClosedError 覆盖原因异常。
+                except SessionWriteBlockedError as failure_exc:
+                    # session 已不再接受写入（CLOSED / CLEARING / CLEARING_FAILED），
+                    # lease 回退将由 cleanup_stale_pending_turns 兜底；
+                    # 此时不得再抛屏障异常覆盖原因异常。
                     Log.warning(
                         "pending conversation turn lease 回退被 session 屏障拒绝，"
                         f"依赖 cleanup 兜底: pending_turn_id={pending_turn_id}, "
-                        f"session_id={session_id}, error={failure_exc}",
+                        f"session_id={session_id}, barrier={type(failure_exc).__name__}, "
+                        f"error={failure_exc}",
                         module=MODULE,
                     )
             # Host 对外只暴露业务语义异常：把仓储写入屏障抛出的
-            # SessionClosedError（session 不存在或已 CLOSED）统一转成 ValueError，
-            # 避免将内部 RuntimeError 子类泄漏给 Service / UI，保持 docstring
-            # 声明的 "KeyError | ValueError" 契约。
-            if isinstance(exc, SessionClosedError):
+            # SessionWriteBlockedError（CLOSED / CLEARING / CLEARING_FAILED 任一）
+            # 统一转成 ValueError，避免将内部 RuntimeError 子类泄漏给
+            # Service / UI，保持 docstring 声明的 "KeyError | ValueError" 契约。
+            if isinstance(exc, SessionWriteBlockedError):
                 raise ValueError(
-                    "pending conversation turn 所属 session 已关闭，拒绝恢复: "
-                    f"pending_turn_id={pending_turn_id}, session_id={session_id}"
+                    "pending conversation turn 所属 session 已不再接受写入，拒绝恢复: "
+                    f"pending_turn_id={pending_turn_id}, session_id={session_id}, "
+                    f"barrier={type(exc).__name__}"
                 ) from exc
             raise
 
@@ -1782,7 +1965,7 @@ def _build_default_host_components(
     host_store = HostStore(host_store_path)
     host_store.initialize_schema()
     session_registry = SQLiteSessionRegistry(host_store)
-    run_registry = SQLiteRunRegistry(host_store)
+    run_registry = SQLiteRunRegistry(host_store, session_activity=session_registry)
     concurrency_governor = SQLiteConcurrencyGovernor(host_store, lane_config=lane_config)
     # 注入 session_registry 作为 session activity 查询源，让仓储层可以在 session
     # 已关闭时以 SessionClosedError 屏障 executor 的迟到写入。

--- a/dayu/host/protocols.py
+++ b/dayu/host/protocols.py
@@ -231,6 +231,93 @@ class ConversationClearPartiallyAppliedError(RuntimeError):
         self.residual_sources = residual_sources
 
 
+class SessionStateTransitionError(RuntimeError):
+    """``SessionRegistry`` 状态机迁移因前置状态不满足而失败。
+
+    `#117` review 反馈：原实现 ``_transition_state`` 抛裸 ``RuntimeError``，
+    与 SQLite ``database locked`` 等基础设施 ``RuntimeError`` 不可区分。
+    引入专用类型让 ``host.clear_session_history`` 的 ``begin_clearing``
+    捕获分支可以收窄到该类型，避免吞掉真正的基础设施错误。
+
+    仅由 ``_transition_state`` 抛出，调用方不应直接构造。
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        operation: str,
+        current_state: SessionState,
+        expected_states: tuple[SessionState, ...],
+    ) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发迁移失败的 session ID。
+            operation: 触发迁移的操作名（如 ``进入 CLEARING 屏障``）。
+            current_state: session 当前状态。
+            expected_states: 操作期望的合法前置状态集合。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        expected_values = ",".join(state.value for state in expected_states)
+        super().__init__(
+            f"{operation} 前置状态不满足: session_id={session_id}, "
+            f"current_state={current_state.value}, expected={expected_values}"
+        )
+        self.session_id = session_id
+        self.operation = operation
+        self.current_state = current_state
+        self.expected_states = expected_states
+
+
+class ConversationArchiveRevisionConflictError(RuntimeError):
+    """``ConversationSessionArchiveStore.save`` 乐观锁冲突。
+
+    `#117` review 反馈：原 ``conversation_store`` 在 revision 冲突时抛
+    裸 ``RuntimeError`` + 消息字串 ``"revision 冲突"``，调用方（如
+    ``host.clear_session_history``）只能用子串匹配辨认，文案变动会静默
+    穿透。引入专用类型让所有冲突捕获分支编译期对齐。
+
+    仅由 archive store 实现抛出；与现有 ``RuntimeError`` 协议契约兼容
+    （子类继承 ``RuntimeError``，旧调用点的 ``except RuntimeError`` 仍能命中）。
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        expected_revision: str | None,
+        actual_revision: str,
+    ) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发冲突的 session ID。
+            expected_revision: ``save`` 调用方期望的旧 archive revision。
+            actual_revision: archive 实际 revision。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(
+            "conversation session archive revision 冲突: "
+            f"session_id={session_id}, expected={expected_revision}, actual={actual_revision}"
+        )
+        self.session_id = session_id
+        self.expected_revision = expected_revision
+        self.actual_revision = actual_revision
+
+
 class SessionActivityQueryProtocol(Protocol):
     """面向仓储层的 session 活性查询协议。
 
@@ -1362,6 +1449,8 @@ __all__ = [
     "ConversationClearRejectedError",
     "ConversationClearStaleError",
     "ConversationClearPartiallyAppliedError",
+    "ConversationArchiveRevisionConflictError",
+    "SessionStateTransitionError",
     "SessionOperationsProtocol",
     "SessionRegistryProtocol",
 ]

--- a/dayu/host/protocols.py
+++ b/dayu/host/protocols.py
@@ -25,12 +25,41 @@ from dayu.host.pending_turn_store import PendingConversationTurn, PendingConvers
 # ---------------------------------------------------------------------------
 
 
-class SessionClosedError(RuntimeError):
+class SessionWriteBlockedError(RuntimeError):
+    """session 写入屏障基类——三个具体屏障异常的共同祖先。
+
+    Host 内部仓储 / run_registry / executor 在 session 不再 ``ACTIVE`` 时抛出。
+    存在三种具体子类（``SessionClosedError`` / ``SessionClearingError`` /
+    ``SessionClearingFailedError``）以便观测面区分"已关闭""正在清空"
+    "清空失败锁定"，但**调用方降级路径应统一捕获本基类**——它们在语义上
+    都表示"session 已不再接受新写入"，吸收策略相同（迟到写入降级为
+    no-op，避免产生孤儿数据）。
+    """
+
+    def __init__(self, session_id: str, message: str) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发屏障的 session ID。
+            message: 由子类提供的具体描述文本。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(message)
+        self.session_id = session_id
+
+
+class SessionClosedError(SessionWriteBlockedError):
     """尝试对不存在或已 CLOSED 的 session 执行写入时抛出。
 
-    该异常由 Host 内部写入屏障（pending turn / reply outbox 仓储）在检测到
-    session 不存在或已进入 ``CLOSED`` 终态时抛出，用于阻断
-    ``cancel_session`` 窗口期内的并发写入，防止产生孤儿数据。
+    该异常由 Host 内部写入屏障（pending turn / reply outbox 仓储 /
+    run_registry）在检测到 session 不存在或已进入 ``CLOSED`` 终态时抛出，
+    用于阻断 ``cancel_session`` 窗口期内的并发写入，防止产生孤儿数据。
     """
 
     def __init__(self, session_id: str) -> None:
@@ -46,8 +75,160 @@ class SessionClosedError(RuntimeError):
             无。
         """
 
-        super().__init__(f"session 不存在或已关闭，拒绝写入: session_id={session_id}")
+        super().__init__(
+            session_id,
+            f"session 不存在或已关闭，拒绝写入: session_id={session_id}",
+        )
+
+
+class SessionClearingError(SessionWriteBlockedError):
+    """session 处于 ``CLEARING`` 临时屏障期间尝试写入时抛出。
+
+    该异常由 Host 内部写入屏障在检测到 session 当前状态为 ``CLEARING``
+    （``#117`` 共享设计 §3.3 的临时屏障窗口）时抛出，调用方语义上应当
+    与 ``SessionClosedError`` 同侧降级（拒绝写入），但单独命名以便观测面
+    区分"会话已关闭"与"会话正在清空"。
+    """
+
+    def __init__(self, session_id: str) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发屏障的 session ID。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(
+            session_id,
+            f"session 正在清空中，拒绝写入: session_id={session_id}",
+        )
+
+
+class SessionClearingFailedError(SessionWriteBlockedError):
+    """session 处于 ``CLEARING_FAILED`` 持久锁定屏障时尝试写入时抛出。
+
+    清空动作 archive 写已生效但补偿性 delete 在有界 retry 后仍未收敛，
+    session 进入持久锁定屏障。任何新 run / pending turn / reply outbox 写入
+    都必须被拒绝，避免"已知不一致 + 新写入混杂"恶化恢复成本。
+    退出该状态需 ``#117`` 范围外的人工修复路径（reopen / cancel）。
+    """
+
+    def __init__(self, session_id: str) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发屏障的 session ID。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(
+            session_id,
+            f"session 处于 clearing_failed 锁定状态，拒绝写入: session_id={session_id}",
+        )
+
+
+class ConversationClearRejectedError(RuntimeError):
+    """``Host.clear_session_history`` 在 archive 写之前因预检条件未满足而拒绝。
+
+    `#117` 共享设计 §3.5 契约 A：archive 写之前的失败必为 RejectedError，
+    五真源完整保留。命中条件：session 不存在 / 已 ``CLOSED`` / 处于
+    ``CLEARING`` / 处于 ``CLEARING_FAILED`` / 存在 active run / 存在 pending
+    turn / 存在待投递 reply outbox。
+    """
+
+    def __init__(self, session_id: str, *, reason: str) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发拒绝的 session ID。
+            reason: 拒绝原因（活跃 run / pending turn / reply outbox / 屏障）。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(
+            f"clear_session_history 拒绝清空: session_id={session_id}, reason={reason}"
+        )
         self.session_id = session_id
+        self.reason = reason
+
+
+class ConversationClearStaleError(RuntimeError):
+    """``Host.clear_session_history`` 在 archive 写阶段命中乐观锁冲突。
+
+    `#117` 共享设计 §3.4 场景 b 时间窗：清空在锁内拿到的 ``live.revision``
+    被另一写者（典型来源是 ``ConversationMemory`` 的 compaction 写回）推进，
+    archive 乐观锁拒绝写入；仍属契约 A，五真源不变。
+    """
+
+    def __init__(self, session_id: str, *, expected_revision: str, actual_revision: str) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发冲突的 session ID。
+            expected_revision: 清空预期的 archive revision。
+            actual_revision: archive 实际 revision。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(
+            f"clear_session_history archive 乐观锁冲突: session_id={session_id}, "
+            f"expected={expected_revision}, actual={actual_revision}"
+        )
+        self.session_id = session_id
+        self.expected_revision = expected_revision
+        self.actual_revision = actual_revision
+
+
+class ConversationClearPartiallyAppliedError(RuntimeError):
+    """``Host.clear_session_history`` archive 写已生效但补偿 delete 仍未收敛。
+
+    `#117` 共享设计 §3.5 契约 B：archive 已成功 ``save(empty)``，
+    ``history_archive`` 与 ``runtime_transcript`` 已清空、revision 已推进；
+    但后续 pending turn / reply outbox / replay stash 中至少一项在有界 retry
+    后仍 delete 失败。session 已被推入 ``CLEARING_FAILED`` 持久锁定屏障，
+    调用方**不应再调** ``clear_session_history``，应升级为人工介入告警。
+    """
+
+    def __init__(self, session_id: str, *, residual_sources: tuple[str, ...]) -> None:
+        """初始化异常。
+
+        Args:
+            session_id: 触发部分应用的 session ID。
+            residual_sources: 仍未清干净的真源名称（如 ``pending_turn_store``）。
+
+        Returns:
+            无。
+
+        Raises:
+            无。
+        """
+
+        super().__init__(
+            f"clear_session_history 已部分生效: session_id={session_id}, "
+            f"residual_sources={list(residual_sources)}"
+        )
+        self.session_id = session_id
+        self.residual_sources = residual_sources
 
 
 class SessionActivityQueryProtocol(Protocol):
@@ -56,18 +237,38 @@ class SessionActivityQueryProtocol(Protocol):
     仅暴露仓储写入屏障所需的最小查询能力，避免把 ``SessionRegistryProtocol``
     的完整生命周期接口泄漏给 pending turn / reply outbox 仓储。
 
-    查询语义：``True`` 表示 session 存在且当前不是 ``CLOSED``；
-    ``False`` 表示 session 不存在或已 ``CLOSED``。
+    查询语义：
+
+    - ``is_session_active``：``True`` 表示 session 存在且当前为 ``ACTIVE``；
+      ``False`` 表示 session 不存在或处于 ``CLEARING`` / ``CLEARING_FAILED``
+      / ``CLOSED`` 任一非 ACTIVE 状态。
+    - ``get_session_state``：返回 session 当前 ``SessionState``，不存在返回
+      ``None``。屏障辅助函数据此区分异常类型。
     """
 
     def is_session_active(self, session_id: str) -> bool:
-        """查询指定 session 是否仍处于非 CLOSED 状态。
+        """查询指定 session 是否处于 ``ACTIVE`` 状态。
 
         Args:
             session_id: 目标 session ID。
 
         Returns:
-            session 存在且非 CLOSED 时返回 ``True``，否则返回 ``False``。
+            session 存在且为 ``ACTIVE`` 时返回 ``True``；不存在或处于
+            ``CLEARING`` / ``CLEARING_FAILED`` / ``CLOSED`` 时返回 ``False``。
+
+        Raises:
+            无。
+        """
+        ...
+
+    def get_session_state(self, session_id: str) -> SessionState | None:
+        """查询指定 session 的当前状态。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Returns:
+            session 当前 ``SessionState``；session 不存在返回 ``None``。
 
         Raises:
             无。
@@ -191,17 +392,70 @@ class SessionRegistryProtocol(Protocol):
         ...
 
     def is_session_active(self, session_id: str) -> bool:
-        """查询指定 session 是否仍处于非 CLOSED 状态。
+        """查询指定 session 是否处于 ``ACTIVE`` 状态。
 
         仓储写入屏障会在每次写入前调用本方法，若返回 ``False`` 则拒绝写入，
-        确保 ``cancel_session`` 关闭 session 后不会再产生孤儿 pending turn /
-        reply outbox 记录。
+        确保 ``cancel_session`` 关闭 session、或 ``clear_session_history``
+        进入 ``CLEARING`` / ``CLEARING_FAILED`` 屏障后不会再产生孤儿
+        pending turn / reply outbox 记录。
 
         Args:
             session_id: 目标 session ID。
 
         Returns:
-            session 存在且状态非 ``CLOSED`` 时返回 ``True``；否则返回 ``False``。
+            session 存在且为 ``ACTIVE`` 时返回 ``True``；不存在或处于任一非
+            ACTIVE 状态时返回 ``False``。
+        """
+        ...
+
+    def get_session_state(self, session_id: str) -> SessionState | None:
+        """查询指定 session 的当前状态。
+
+        屏障辅助函数据此区分异常类型（``SessionClosedError`` /
+        ``SessionClearingError`` / ``SessionClearingFailedError``）。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Returns:
+            session 当前 ``SessionState``；不存在返回 ``None``。
+        """
+        ...
+
+    def begin_clearing(self, session_id: str) -> None:
+        """把 session 从 ``ACTIVE`` 推进到 ``CLEARING`` 临时屏障状态。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Raises:
+            KeyError: session 不存在时抛出。
+            RuntimeError: session 当前不是 ``ACTIVE``（已 ``CLEARING`` /
+                ``CLEARING_FAILED`` / ``CLOSED``）时抛出。
+        """
+        ...
+
+    def end_clearing(self, session_id: str) -> None:
+        """把 session 从 ``CLEARING`` 退出回 ``ACTIVE``。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Raises:
+            KeyError: session 不存在时抛出。
+            RuntimeError: session 当前不是 ``CLEARING`` 时抛出。
+        """
+        ...
+
+    def mark_clearing_failed(self, session_id: str) -> None:
+        """把 session 从 ``CLEARING`` 升级为 ``CLEARING_FAILED`` 持久锁定。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Raises:
+            KeyError: session 不存在时抛出。
+            RuntimeError: session 当前不是 ``CLEARING`` 时抛出。
         """
         ...
 
@@ -1048,6 +1302,36 @@ class HostAdminOperationsProtocol(
         """读取指定 session 的最近 conversation 单轮摘录。"""
         ...
 
+    def clear_session_history(self, session_id: str) -> None:
+        """清空指定 session 的对话历史与运行态送模子视图。
+
+        语义遵循 ``#117`` 共享设计 §3.2 ~ §3.6：
+
+        - 清五真源：archive ``history_archive`` 与 ``runtime_transcript``、
+          pending_turn_store、reply_outbox_store、executor replay stash；
+        - 写屏障：进入 ``CLEARING`` 临时屏障，拒绝并发写入；archive 写在
+          文件锁与屏障内执行；
+        - 拒绝预检：session 不存在 / 已 ``CLOSED`` / 处于
+          ``CLEARING`` / ``CLEARING_FAILED`` / 存在 active run / pending turn /
+          待投递 reply outbox 时直接拒绝；
+        - 失败回报：分层契约。Contract A（archive 写之前）→
+          ``ConversationClearRejectedError`` / ``ConversationClearStaleError``，
+          五真源不变；Contract B（archive 写之后补偿失败）→
+          ``ConversationClearPartiallyAppliedError``，session 进入
+          ``CLEARING_FAILED`` 持久锁定。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Raises:
+            KeyError: session 不存在时抛出。
+            ConversationClearRejectedError: 预检命中拒绝条件。
+            ConversationClearStaleError: archive 乐观锁冲突。
+            ConversationClearPartiallyAppliedError: archive 写已生效但补偿
+                delete 仍未收敛。
+        """
+        ...
+
 
 __all__ = [
     "ConversationSessionDigest",
@@ -1071,7 +1355,13 @@ __all__ = [
     "RunAdministrationProtocol",
     "RunRegistryProtocol",
     "SessionActivityQueryProtocol",
+    "SessionWriteBlockedError",
     "SessionClosedError",
+    "SessionClearingError",
+    "SessionClearingFailedError",
+    "ConversationClearRejectedError",
+    "ConversationClearStaleError",
+    "ConversationClearPartiallyAppliedError",
     "SessionOperationsProtocol",
     "SessionRegistryProtocol",
 ]

--- a/dayu/host/run_registry.py
+++ b/dayu/host/run_registry.py
@@ -11,8 +11,9 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any
 
+from dayu.host._session_barrier import ensure_session_active
 from dayu.host.host_store import HostStore, write_transaction
-from dayu.host.protocols import RunRegistryProtocol
+from dayu.host.protocols import RunRegistryProtocol, SessionActivityQueryProtocol
 from dayu.contracts.execution_metadata import (
     ExecutionDeliveryContext,
     empty_execution_delivery_context,
@@ -145,14 +146,24 @@ class SQLiteRunRegistry(RunRegistryProtocol):
     状态机校验使用 contracts.run 中的转换表。
     """
 
-    def __init__(self, host_store: HostStore) -> None:
+    def __init__(
+        self,
+        host_store: HostStore,
+        *,
+        session_activity: SessionActivityQueryProtocol | None = None,
+    ) -> None:
         """初始化 RunRegistry。
 
         Args:
             host_store: 共享 SQLite 存储。
+            session_activity: 可选的 session 活性查询源；装配后 ``register_run``
+                会在 session 不再 ``ACTIVE`` 时拒绝新 run 写入，与 #117
+                ``CLEARING`` / ``CLEARING_FAILED`` 屏障语义一致。装配为
+                ``None`` 时退化为不做屏障的旧行为，仅用于独立 store 单元测试。
         """
 
         self._host_store = host_store
+        self._session_activity: SessionActivityQueryProtocol | None = session_activity
 
     def register_run(
         self,
@@ -163,6 +174,15 @@ class SQLiteRunRegistry(RunRegistryProtocol):
         metadata: ExecutionDeliveryContext | None = None,
     ) -> RunRecord:
         """注册一个新 run。"""
+
+        if session_id is not None:
+            ensure_session_active(
+                self._session_activity,
+                session_id=session_id,
+                operation="register_run",
+                module=MODULE,
+                target_name="run",
+            )
 
         run_id = f"run_{uuid.uuid4().hex[:12]}"
         now = _now_utc()

--- a/dayu/host/session_registry.py
+++ b/dayu/host/session_registry.py
@@ -13,7 +13,7 @@ from typing import Any
 from dayu.contracts.execution_metadata import ExecutionDeliveryContext, normalize_execution_delivery_context
 from dayu.contracts.session import SessionRecord, SessionSource, SessionState
 from dayu.host.host_store import HostStore, write_transaction
-from dayu.host.protocols import SessionRegistryProtocol
+from dayu.host.protocols import SessionRegistryProtocol, SessionStateTransitionError
 from dayu.log import Log
 
 MODULE = "HOST.SESSION_REGISTRY"
@@ -309,9 +309,11 @@ class SQLiteSessionRegistry(SessionRegistryProtocol):
         existing_state = self.get_session_state(normalized)
         if existing_state is None:
             raise KeyError(f"session 不存在: {normalized}")
-        raise RuntimeError(
-            f"{operation} 前置状态不满足: session_id={normalized}, "
-            f"current_state={existing_state.value}, expected={','.join(expected_values)}"
+        raise SessionStateTransitionError(
+            normalized,
+            operation=operation,
+            current_state=existing_state,
+            expected_states=expected_states,
         )
 
     def begin_clearing(self, session_id: str) -> None:

--- a/dayu/host/session_registry.py
+++ b/dayu/host/session_registry.py
@@ -217,13 +217,15 @@ class SQLiteSessionRegistry(SessionRegistryProtocol):
         Log.debug(f"关闭 session: session_id={session_id}", module=MODULE)
 
     def is_session_active(self, session_id: str) -> bool:
-        """查询 session 是否仍处于非 CLOSED 状态。
+        """查询 session 是否处于 ``ACTIVE`` 状态。
 
         Args:
             session_id: 目标 session ID。
 
         Returns:
-            session 存在且状态非 ``CLOSED`` 时返回 ``True``；否则返回 ``False``。
+            session 存在且状态为 ``ACTIVE`` 时返回 ``True``；不存在或处于
+            ``CLEARING`` / ``CLEARING_FAILED`` / ``CLOSED`` 任一非 ACTIVE
+            状态时返回 ``False``。
 
         Raises:
             无。
@@ -239,7 +241,108 @@ class SQLiteSessionRegistry(SessionRegistryProtocol):
         ).fetchone()
         if row is None:
             return False
-        return str(row["state"]) != SessionState.CLOSED.value
+        return str(row["state"]) == SessionState.ACTIVE.value
+
+    def get_session_state(self, session_id: str) -> SessionState | None:
+        """查询 session 当前状态。
+
+        Args:
+            session_id: 目标 session ID。
+
+        Returns:
+            session 当前 ``SessionState``；不存在返回 ``None``。
+
+        Raises:
+            无。
+        """
+
+        normalized = str(session_id or "").strip()
+        if not normalized:
+            return None
+        conn = self._host_store.get_connection()
+        row = conn.execute(
+            "SELECT state FROM sessions WHERE session_id = ?",
+            (normalized,),
+        ).fetchone()
+        if row is None:
+            return None
+        return SessionState(str(row["state"]))
+
+    def _transition_state(
+        self,
+        session_id: str,
+        *,
+        expected_states: tuple[SessionState, ...],
+        target_state: SessionState,
+        operation: str,
+    ) -> None:
+        """通用状态机迁移：仅当当前状态在 ``expected_states`` 集合内时切换。
+
+        SQL 直接用 ``WHERE state IN (...)`` 做条件 update，rowcount=0 表示
+        前置条件不满足。session 不存在时通过额外查询区分 ``KeyError`` 与
+        ``RuntimeError``。
+        """
+
+        normalized = str(session_id or "").strip()
+        if not normalized:
+            raise KeyError(f"session 不存在: {session_id}")
+
+        expected_values = tuple(state.value for state in expected_states)
+        placeholders = ",".join("?" for _ in expected_values)
+        conn = self._host_store.get_connection()
+        with write_transaction(conn):
+            cursor = conn.execute(
+                f"""
+                UPDATE sessions SET state = ?
+                WHERE session_id = ? AND state IN ({placeholders})
+                """,  # noqa: S608
+                (target_state.value, normalized, *expected_values),
+            )
+            rowcount = cursor.rowcount
+        if rowcount > 0:
+            Log.debug(
+                f"{operation}: session_id={normalized}, target_state={target_state.value}",
+                module=MODULE,
+            )
+            return
+
+        existing_state = self.get_session_state(normalized)
+        if existing_state is None:
+            raise KeyError(f"session 不存在: {normalized}")
+        raise RuntimeError(
+            f"{operation} 前置状态不满足: session_id={normalized}, "
+            f"current_state={existing_state.value}, expected={','.join(expected_values)}"
+        )
+
+    def begin_clearing(self, session_id: str) -> None:
+        """从 ``ACTIVE`` 推进到 ``CLEARING``。"""
+
+        self._transition_state(
+            session_id,
+            expected_states=(SessionState.ACTIVE,),
+            target_state=SessionState.CLEARING,
+            operation="进入 CLEARING 屏障",
+        )
+
+    def end_clearing(self, session_id: str) -> None:
+        """从 ``CLEARING`` 退出回 ``ACTIVE``。"""
+
+        self._transition_state(
+            session_id,
+            expected_states=(SessionState.CLEARING,),
+            target_state=SessionState.ACTIVE,
+            operation="退出 CLEARING 屏障",
+        )
+
+    def mark_clearing_failed(self, session_id: str) -> None:
+        """从 ``CLEARING`` 升级为 ``CLEARING_FAILED`` 持久锁定。"""
+
+        self._transition_state(
+            session_id,
+            expected_states=(SessionState.CLEARING,),
+            target_state=SessionState.CLEARING_FAILED,
+            operation="升级 CLEARING_FAILED 锁定",
+        )
 
     def close_idle_sessions(self, idle_threshold: timedelta) -> list[str]:
         """关闭超过空闲阈值的活跃 session。"""

--- a/tests/application/conftest.py
+++ b/tests/application/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as dataclass_replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, AsyncIterator, Callable, TypeVar
 
@@ -141,15 +141,7 @@ class StubSessionRegistry:
         existing = self._sessions.get(session_id)
         if existing is None:
             raise KeyError(f"session 不存在: {session_id}")
-        replaced = SessionRecord(
-            session_id=existing.session_id,
-            source=existing.source,
-            state=target,
-            scene_name=existing.scene_name,
-            created_at=existing.created_at,
-            last_activity_at=existing.last_activity_at,
-            metadata=existing.metadata,
-        )
+        replaced = dataclass_replace(existing, state=target)
         self._sessions[session_id] = replaced
         return replaced
 
@@ -159,8 +151,13 @@ class StubSessionRegistry:
         if existing is None:
             raise KeyError(f"session 不存在: {session_id}")
         if existing.state != SessionState.ACTIVE:
-            raise RuntimeError(
-                f"begin_clearing 前置状态不满足: session_id={session_id}, current={existing.state.value}"
+            from dayu.host.protocols import SessionStateTransitionError
+
+            raise SessionStateTransitionError(
+                session_id,
+                operation="begin_clearing",
+                current_state=existing.state,
+                expected_states=(SessionState.ACTIVE,),
             )
         self._replace_state(session_id, SessionState.CLEARING)
 
@@ -170,8 +167,13 @@ class StubSessionRegistry:
         if existing is None:
             raise KeyError(f"session 不存在: {session_id}")
         if existing.state != SessionState.CLEARING:
-            raise RuntimeError(
-                f"end_clearing 前置状态不满足: session_id={session_id}, current={existing.state.value}"
+            from dayu.host.protocols import SessionStateTransitionError
+
+            raise SessionStateTransitionError(
+                session_id,
+                operation="end_clearing",
+                current_state=existing.state,
+                expected_states=(SessionState.CLEARING,),
             )
         self._replace_state(session_id, SessionState.ACTIVE)
 
@@ -181,8 +183,13 @@ class StubSessionRegistry:
         if existing is None:
             raise KeyError(f"session 不存在: {session_id}")
         if existing.state != SessionState.CLEARING:
-            raise RuntimeError(
-                f"mark_clearing_failed 前置状态不满足: session_id={session_id}, current={existing.state.value}"
+            from dayu.host.protocols import SessionStateTransitionError
+
+            raise SessionStateTransitionError(
+                session_id,
+                operation="mark_clearing_failed",
+                current_state=existing.state,
+                expected_states=(SessionState.CLEARING,),
             )
         self._replace_state(session_id, SessionState.CLEARING_FAILED)
 

--- a/tests/application/conftest.py
+++ b/tests/application/conftest.py
@@ -122,12 +122,69 @@ class StubSessionRegistry:
         return []
 
     def is_session_active(self, session_id: str) -> bool:
-        """查询 session 是否仍处于非 CLOSED 状态。"""
+        """查询 session 是否处于 ACTIVE 状态。"""
 
         existing = self._sessions.get(str(session_id or "").strip())
         if existing is None:
             return False
-        return existing.state != SessionState.CLOSED
+        return existing.state == SessionState.ACTIVE
+
+    def get_session_state(self, session_id: str) -> SessionState | None:
+        """查询 session 当前状态。"""
+
+        existing = self._sessions.get(str(session_id or "").strip())
+        if existing is None:
+            return None
+        return existing.state
+
+    def _replace_state(self, session_id: str, target: SessionState) -> SessionRecord:
+        existing = self._sessions.get(session_id)
+        if existing is None:
+            raise KeyError(f"session 不存在: {session_id}")
+        replaced = SessionRecord(
+            session_id=existing.session_id,
+            source=existing.source,
+            state=target,
+            scene_name=existing.scene_name,
+            created_at=existing.created_at,
+            last_activity_at=existing.last_activity_at,
+            metadata=existing.metadata,
+        )
+        self._sessions[session_id] = replaced
+        return replaced
+
+    def begin_clearing(self, session_id: str) -> None:
+        """从 ACTIVE 进入 CLEARING。"""
+        existing = self._sessions.get(session_id)
+        if existing is None:
+            raise KeyError(f"session 不存在: {session_id}")
+        if existing.state != SessionState.ACTIVE:
+            raise RuntimeError(
+                f"begin_clearing 前置状态不满足: session_id={session_id}, current={existing.state.value}"
+            )
+        self._replace_state(session_id, SessionState.CLEARING)
+
+    def end_clearing(self, session_id: str) -> None:
+        """从 CLEARING 退出回 ACTIVE。"""
+        existing = self._sessions.get(session_id)
+        if existing is None:
+            raise KeyError(f"session 不存在: {session_id}")
+        if existing.state != SessionState.CLEARING:
+            raise RuntimeError(
+                f"end_clearing 前置状态不满足: session_id={session_id}, current={existing.state.value}"
+            )
+        self._replace_state(session_id, SessionState.ACTIVE)
+
+    def mark_clearing_failed(self, session_id: str) -> None:
+        """从 CLEARING 升级到 CLEARING_FAILED。"""
+        existing = self._sessions.get(session_id)
+        if existing is None:
+            raise KeyError(f"session 不存在: {session_id}")
+        if existing.state != SessionState.CLEARING:
+            raise RuntimeError(
+                f"mark_clearing_failed 前置状态不满足: session_id={session_id}, current={existing.state.value}"
+            )
+        self._replace_state(session_id, SessionState.CLEARING_FAILED)
 
 
 class StubRunRegistry:

--- a/tests/application/test_host_clear_session_history.py
+++ b/tests/application/test_host_clear_session_history.py
@@ -287,7 +287,7 @@ def test_clear_stale_when_archive_revision_advanced(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """场景 b：clear 在锁内拿到 live.revision 后，模拟 compaction 写回推进 archive
-    revision。``archive_store.save`` 应抛 RuntimeError（revision 冲突），
+    revision。``archive_store.save`` 应抛 ``ConversationArchiveRevisionConflictError``，
     ``clear_session_history`` 转化为 ``ConversationClearStaleError``，五真源不变。"""
 
     store = FileConversationSessionArchiveStore(tmp_path / "conv")
@@ -301,9 +301,12 @@ def test_clear_stale_when_archive_revision_advanced(
     def conflicting_save(archive, *, expected_revision=None):  # type: ignore[no-untyped-def]
         # 第一次（清空空 archive）注入冲突，后续放行。
         if len(archive.history_archive.turns) == 0 and expected_revision is not None:
-            raise RuntimeError(
-                "conversation session archive revision 冲突："
-                f"session_id={archive.session_id}, expected={expected_revision}, actual=rev_other"
+            from dayu.host.protocols import ConversationArchiveRevisionConflictError
+
+            raise ConversationArchiveRevisionConflictError(
+                archive.session_id,
+                expected_revision=expected_revision,
+                actual_revision="rev_other",
             )
         return real_save(archive, expected_revision=expected_revision)
 

--- a/tests/application/test_host_clear_session_history.py
+++ b/tests/application/test_host_clear_session_history.py
@@ -1,0 +1,548 @@
+"""``Host.clear_session_history`` (#117) 验收测试。
+
+覆盖 ``#117`` 共享设计 §3.7 验收点：
+
+1. 五真源全清 happy path；
+2. 四类拒绝（active run / pending turn / outbox / closed）→ ``Rejected`` 且全保留；
+3. 场景 a（active run）→ ``Rejected``；
+4. 场景 b（compaction 写回竞速 → archive revision 推进）→ ``Stale``；
+5. archive 写失败 → 其他四真源不动；
+6. archive 写成功后 delete 有界 retry 仍失败 → ``PartiallyApplied`` +
+   ``CLEARING_FAILED`` 持久锁定（包含 6a 再次 clear 被拒、6b 新写入被拒、
+   6c 屏障保持）；
+7. 并发：屏障期间新建 pending turn / outbox / run 一律拒绝；
+8. 契约联动：清完后历史读返回 ``[]``；
+9. 清完后下一轮 ``persist_turn`` 不复活旧历史；
+10. 幂等：连续两次清空第二次也按预检 no-op；
+11. 历史读 read model 字段集合不退化（`#118` 结构性反射通过）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dayu.contracts.reply_outbox import ReplyOutboxSubmitRequest
+from dayu.contracts.session import SessionSource, SessionState
+from dayu.host.conversation_session_archive import (
+    ConversationHistoryTurnRecord,
+    ConversationSessionArchive,
+)
+from dayu.host.conversation_store import (
+    ConversationTurnRecord,
+    FileConversationSessionArchiveStore,
+)
+from dayu.host.host import Host
+from dayu.host.pending_turn_store import (
+    InMemoryPendingConversationTurnStore,
+    PendingConversationTurnState,
+)
+from dayu.host.protocols import (
+    ConversationClearPartiallyAppliedError,
+    ConversationClearRejectedError,
+    ConversationClearStaleError,
+    SessionClearingError,
+    SessionClearingFailedError,
+)
+from dayu.host.reply_outbox_store import InMemoryReplyOutboxStore
+from tests.application.conftest import (
+    StubHostExecutor,
+    StubRunRegistry,
+    StubSessionRegistry,
+)
+
+
+def _build_host(
+    archive_store: FileConversationSessionArchiveStore,
+    *,
+    session_registry: StubSessionRegistry | None = None,
+    run_registry: StubRunRegistry | None = None,
+    pending_turn_store: InMemoryPendingConversationTurnStore | None = None,
+    reply_outbox_store: InMemoryReplyOutboxStore | None = None,
+    executor: StubHostExecutor | None = None,
+) -> Host:
+    """构造 #117 验收用 Host：所有内部仓储均装配 session 屏障。"""
+
+    sr = session_registry or StubSessionRegistry()
+    rr = run_registry or StubRunRegistry()
+    pts = pending_turn_store or InMemoryPendingConversationTurnStore(session_activity=sr)
+    ros = reply_outbox_store or InMemoryReplyOutboxStore(session_activity=sr)
+    return Host(
+        executor=executor or StubHostExecutor(),
+        session_registry=sr,
+        run_registry=rr,
+        pending_turn_store=pts,
+        reply_outbox_store=ros,
+        archive_store=archive_store,
+    )
+
+
+def _seed_session_with_archive(
+    host: Host,
+    store: FileConversationSessionArchiveStore,
+    *,
+    session_id: str,
+    turns: list[tuple[str, str, str]],
+) -> ConversationSessionArchive:
+    """创建活跃 session + 落盘若干轮 archive。"""
+
+    host.create_session(SessionSource.CLI, session_id=session_id)
+    archive = ConversationSessionArchive.create_empty(session_id)
+    archive = store.save(archive, expected_revision=None)
+    for idx, (user_text, assistant_text, reasoning) in enumerate(turns):
+        prev_revision = archive.revision
+        runtime_turn = ConversationTurnRecord(
+            turn_id=f"turn_{idx}",
+            scene_name="interactive",
+            user_text=user_text,
+            assistant_final=assistant_text,
+        )
+        history_turn = ConversationHistoryTurnRecord(
+            turn_id=runtime_turn.turn_id,
+            scene_name=runtime_turn.scene_name,
+            user_text=user_text,
+            assistant_text=assistant_text,
+            assistant_reasoning=reasoning,
+            created_at=runtime_turn.created_at,
+        )
+        archive = archive.with_next_turn(runtime_turn, history_turn)
+        archive = store.save(archive, expected_revision=prev_revision)
+    return archive
+
+
+def _enqueue_outbox(host: Host, *, session_id: str, key: str = "k1") -> None:
+    """向 reply_outbox_store 注入一条 PENDING_DELIVERY 记录。"""
+
+    host._reply_outbox_store.submit_reply(
+        ReplyOutboxSubmitRequest(
+            delivery_key=key,
+            session_id=session_id,
+            scene_name="interactive",
+            source_run_id="run_seed",
+            reply_content="seeded",
+        )
+    )
+
+
+def _enqueue_pending_turn(host: Host, *, session_id: str) -> None:
+    """向 pending_turn_store 注入一条 ACCEPTED pending turn。"""
+
+    host._pending_turn_store.upsert_pending_turn(
+        session_id=session_id,
+        scene_name="interactive",
+        user_text="hello",
+        source_run_id="run_seed",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+
+
+# ---------------------------------------------------------------------------
+# §3.7.1 happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_session_history_clears_all_truth_sources(tmp_path: Path) -> None:
+    """五真源全清：archive history+runtime / pending / outbox / replay stash。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host,
+        store,
+        session_id="sess",
+        turns=[("Q1", "A1", "R1"), ("Q2", "A2", "R2")],
+    )
+
+    host.clear_session_history("sess")
+
+    archive = store.load("sess")
+    assert archive is not None
+    assert archive.history_archive.turns == ()
+    assert archive.runtime_transcript.turns == ()
+    assert host._pending_turn_store.list_pending_turns(session_id="sess") == []
+    assert host._reply_outbox_store.list_replies(session_id="sess") == []
+    # session 仍 ACTIVE，下一轮可继续。
+    assert host._session_registry.get_session_state("sess") == SessionState.ACTIVE
+
+
+@pytest.mark.unit
+def test_clear_then_history_read_returns_empty(tmp_path: Path) -> None:
+    """契约联动：清完后 ``list_conversation_session_turn_excerpts`` 返回 []。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "R1")]
+    )
+
+    host.clear_session_history("sess")
+
+    assert host.list_conversation_session_turn_excerpts("sess", limit=10) == []
+    digest = host.get_conversation_session_digest("sess")
+    assert digest.turn_count == 0
+
+
+# ---------------------------------------------------------------------------
+# §3.7.2 / §3.7.3 拒绝预检（含场景 a）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_rejected_when_session_missing(tmp_path: Path) -> None:
+    """session 不存在 → KeyError，五真源不变。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+
+    with pytest.raises(KeyError, match="session 不存在"):
+        host.clear_session_history("missing")
+
+
+@pytest.mark.unit
+def test_clear_rejected_when_session_closed(tmp_path: Path) -> None:
+    """session 已 CLOSED → Rejected，archive 完整保留。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+    host._session_registry.close_session("sess")
+
+    with pytest.raises(ConversationClearRejectedError):
+        host.clear_session_history("sess")
+
+    archive = store.load("sess")
+    assert archive is not None
+    assert len(archive.history_archive.turns) == 1
+
+
+@pytest.mark.unit
+def test_clear_rejected_when_active_run(tmp_path: Path) -> None:
+    """场景 a：存在 active run → Rejected，五真源完整保留。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    sr = StubSessionRegistry()
+    rr = StubRunRegistry()
+    host = _build_host(store, session_registry=sr, run_registry=rr)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+    run = rr.register_run(session_id="sess", service_type="conversational")
+    rr.start_run(run.run_id)  # RUNNING ∈ ACTIVE_STATES
+
+    with pytest.raises(ConversationClearRejectedError) as exc:
+        host.clear_session_history("sess")
+    assert "active_runs" in exc.value.reason
+
+    # 屏障已释放回 ACTIVE，archive 完整保留。
+    assert host._session_registry.get_session_state("sess") == SessionState.ACTIVE
+    archive = store.load("sess")
+    assert archive is not None
+    assert len(archive.history_archive.turns) == 1
+
+
+@pytest.mark.unit
+def test_clear_rejected_when_pending_turn_present(tmp_path: Path) -> None:
+    """存在 pending turn → Rejected。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+    _enqueue_pending_turn(host, session_id="sess")
+
+    with pytest.raises(ConversationClearRejectedError) as exc:
+        host.clear_session_history("sess")
+    assert "pending_turns" in exc.value.reason
+
+
+@pytest.mark.unit
+def test_clear_rejected_when_reply_outbox_present(tmp_path: Path) -> None:
+    """存在待投递 reply outbox → Rejected。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+    _enqueue_outbox(host, session_id="sess")
+
+    with pytest.raises(ConversationClearRejectedError) as exc:
+        host.clear_session_history("sess")
+    assert "reply_outbox" in exc.value.reason
+
+
+# ---------------------------------------------------------------------------
+# §3.7.4 场景 b：archive 乐观锁冲突 → Stale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_stale_when_archive_revision_advanced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """场景 b：clear 在锁内拿到 live.revision 后，模拟 compaction 写回推进 archive
+    revision。``archive_store.save`` 应抛 RuntimeError（revision 冲突），
+    ``clear_session_history`` 转化为 ``ConversationClearStaleError``，五真源不变。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "R1")]
+    )
+
+    real_save = store.save
+
+    def conflicting_save(archive, *, expected_revision=None):  # type: ignore[no-untyped-def]
+        # 第一次（清空空 archive）注入冲突，后续放行。
+        if len(archive.history_archive.turns) == 0 and expected_revision is not None:
+            raise RuntimeError(
+                "conversation session archive revision 冲突："
+                f"session_id={archive.session_id}, expected={expected_revision}, actual=rev_other"
+            )
+        return real_save(archive, expected_revision=expected_revision)
+
+    monkeypatch.setattr(store, "save", conflicting_save)
+
+    with pytest.raises(ConversationClearStaleError):
+        host.clear_session_history("sess")
+
+    # 屏障释放、archive 内容完整保留。
+    assert host._session_registry.get_session_state("sess") == SessionState.ACTIVE
+    archive = store.load("sess")
+    assert archive is not None
+    assert len(archive.history_archive.turns) == 1
+
+
+# ---------------------------------------------------------------------------
+# §3.7.6 contract B：补偿 retry 失败 → PartiallyApplied + CLEARING_FAILED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_partially_applied_locks_session_in_clearing_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """archive 写已生效但 pending turn delete 始终失败 → PartiallyApplied，
+    session 进入 CLEARING_FAILED 持久锁定，且：
+    - 再次 clear_session_history 因屏障被 Rejected 拒（不会死循环）；
+    - 新 pending turn / outbox 写入被 ``SessionClearingFailedError`` 拒。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+
+    # 注入 pending turn delete 始终失败。
+    def always_fail(session_id: str) -> int:
+        del session_id
+        raise OSError("simulated delete failure")
+
+    monkeypatch.setattr(host._pending_turn_store, "delete_by_session_id", always_fail)
+
+    with pytest.raises(ConversationClearPartiallyAppliedError) as exc:
+        host.clear_session_history("sess")
+    assert "pending_turn_store" in exc.value.residual_sources
+
+    # archive 已被清空（切点已过）。
+    archive = store.load("sess")
+    assert archive is not None
+    assert archive.history_archive.turns == ()
+
+    # 6a：session 进入 CLEARING_FAILED 持久锁定。
+    assert (
+        host._session_registry.get_session_state("sess")
+        == SessionState.CLEARING_FAILED
+    )
+
+    # 6b：再次 clear 因屏障被拒（begin_clearing 检查 ACTIVE 失败 → Rejected）。
+    with pytest.raises(ConversationClearRejectedError):
+        host.clear_session_history("sess")
+
+    # 6c：新 pending turn / outbox 写入被 SessionClearingFailedError 拒。
+    with pytest.raises(SessionClearingFailedError):
+        _enqueue_pending_turn(host, session_id="sess")
+    with pytest.raises(SessionClearingFailedError):
+        _enqueue_outbox(host, session_id="sess", key="k2")
+
+
+@pytest.mark.unit
+def test_clear_recovers_when_retry_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """补偿 delete 第一次失败、第二次成功 → 仍走 happy path（不抛错）。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+
+    real_delete = host._pending_turn_store.delete_by_session_id
+    call_count = {"n": 0}
+
+    def flaky_delete(session_id: str) -> int:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("simulated transient")
+        return real_delete(session_id)
+
+    monkeypatch.setattr(host._pending_turn_store, "delete_by_session_id", flaky_delete)
+
+    host.clear_session_history("sess")
+
+    assert call_count["n"] >= 2
+    assert host._session_registry.get_session_state("sess") == SessionState.ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# §3.7.7 屏障期间并发写入被拒
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_writes_during_clearing_are_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """屏障期间任一新写入路径都应抛 SessionClearingError。
+
+    通过在 archive_store.save 时验证当前屏障状态来观测：在清空进行中，
+    pending turn / outbox 写入应抛 SessionClearingError。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+
+    real_save = store.save
+    observed_in_clearing: list[bool] = []
+
+    def save_with_concurrent_check(archive, *, expected_revision=None):  # type: ignore[no-untyped-def]
+        # archive 写发生时屏障已立起 → 此刻 pending turn 写入应该被屏障拒绝。
+        try:
+            _enqueue_pending_turn(host, session_id="sess")
+        except SessionClearingError:
+            observed_in_clearing.append(True)
+        else:
+            observed_in_clearing.append(False)
+        # 同步检查：outbox 写入也应被屏障拒绝。
+        try:
+            _enqueue_outbox(host, session_id="sess", key="kc")
+        except SessionClearingError:
+            observed_in_clearing.append(True)
+        else:
+            observed_in_clearing.append(False)
+        return real_save(archive, expected_revision=expected_revision)
+
+    monkeypatch.setattr(store, "save", save_with_concurrent_check)
+
+    host.clear_session_history("sess")
+
+    assert observed_in_clearing == [True, True]
+
+
+# ---------------------------------------------------------------------------
+# §3.7.9 / §3.7.10 后续状态：下一轮不复活旧历史；幂等
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_then_next_persist_does_not_revive_old_history(tmp_path: Path) -> None:
+    """清完后下一轮 ``with_next_turn`` 在空 archive 上推进，不复活旧历史。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "R1")]
+    )
+
+    host.clear_session_history("sess")
+
+    # 模拟下一轮：load_or_create 拿到空 archive，推进一轮。
+    live = store.load_or_create("sess")
+    assert live.history_archive.turns == ()
+
+    runtime_turn = ConversationTurnRecord(
+        turn_id="turn_new",
+        scene_name="interactive",
+        user_text="Q-new",
+        assistant_final="A-new",
+    )
+    history_turn = ConversationHistoryTurnRecord(
+        turn_id="turn_new",
+        scene_name="interactive",
+        user_text="Q-new",
+        assistant_text="A-new",
+        assistant_reasoning="",
+        created_at=runtime_turn.created_at,
+    )
+    next_archive = live.with_next_turn(runtime_turn, history_turn)
+    store.save(next_archive, expected_revision=live.revision)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess", limit=10)
+    assert [e.user_text for e in excerpts] == ["Q-new"]
+
+
+@pytest.mark.unit
+def test_clear_is_idempotent(tmp_path: Path) -> None:
+    """连续两次 clear 中间无写入 → 第二次也按 happy path 通过（archive 已空）。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "")]
+    )
+
+    host.clear_session_history("sess")
+    host.clear_session_history("sess")  # 不抛错
+
+    assert host._session_registry.get_session_state("sess") == SessionState.ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# §3.7.11 历史读 read model 字段集合不退化（守 #118 / #116 边界）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_does_not_alter_read_model_contract(tmp_path: Path) -> None:
+    """清空后再播一轮，read model 仍含 reasoning_text 字段（#116 契约不退化）。"""
+
+    store = FileConversationSessionArchiveStore(tmp_path / "conv")
+    host = _build_host(store)
+    _seed_session_with_archive(
+        host, store, session_id="sess", turns=[("Q1", "A1", "old-reason")]
+    )
+
+    host.clear_session_history("sess")
+
+    live = store.load_or_create("sess")
+    runtime_turn = ConversationTurnRecord(
+        turn_id="turn_after",
+        scene_name="interactive",
+        user_text="Q2",
+        assistant_final="A2",
+    )
+    history_turn = ConversationHistoryTurnRecord(
+        turn_id="turn_after",
+        scene_name="interactive",
+        user_text="Q2",
+        assistant_text="A2",
+        assistant_reasoning="new-reason",
+        created_at=runtime_turn.created_at,
+    )
+    next_archive = live.with_next_turn(runtime_turn, history_turn)
+    store.save(next_archive, expected_revision=live.revision)
+
+    excerpts = host.list_conversation_session_turn_excerpts("sess", limit=10)
+    assert len(excerpts) == 1
+    assert excerpts[0].user_text == "Q2"
+    assert excerpts[0].assistant_text == "A2"
+    assert excerpts[0].reasoning_text == "new-reason"

--- a/tests/application/test_host_executor.py
+++ b/tests/application/test_host_executor.py
@@ -2615,9 +2615,9 @@ def test_resume_pending_turn_stream_rebind_failure_finishes_run_without_leak(
         ):
             pass
 
-    # Host 必须把内部仓储屏障异常 (SessionClosedError) 收敛为业务语义
+    # Host 必须把内部仓储屏障异常 (SessionWriteBlockedError 子类) 收敛为业务语义
     # ValueError，避免把 RuntimeError 子类泄漏到 Service / UI。
-    with pytest.raises(ValueError, match="session 已关闭"):
+    with pytest.raises(ValueError, match="session 已不再接受写入"):
         asyncio.run(_resume())
 
     # 关键断言 1：不泄漏活跃 run —— rebind 抛异常后 executor 的 try/except/finally
@@ -2734,7 +2734,7 @@ def test_resume_pending_turn_stream_translates_session_closed_error_at_acquire()
         ):
             pass
 
-    with pytest.raises(ValueError, match="session 已关闭") as exc_info:
+    with pytest.raises(ValueError, match="session 已不再接受写入") as exc_info:
         asyncio.run(_resume())
     # 保留诊断链路：原始仓储屏障异常应挂在 __cause__ 上。
     assert isinstance(exc_info.value.__cause__, SessionClosedError)
@@ -2969,3 +2969,77 @@ def test_accepted_turn_snapshot_rejects_missing_concurrency_policy() -> None:
 
     with pytest.raises(ValueError, match="host_policy.concurrency_acquire_policy"):
         deserialize_accepted_agent_turn_snapshot(payload)
+
+
+# ---------------------------------------------------------------------------
+# Review 缺口回归：CLEARING / CLEARING_FAILED 屏障下 executor 必须吸收抛错，
+# 不能升级为未预期失败。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_register_accepted_pending_turn_absorbs_clearing_error() -> None:
+    """``CLEARING`` 屏障期间 ``_register_accepted_pending_turn`` 抛 ``SessionClearingError``
+    必须被吸收为 ``None`` 返回（与 ``SessionClosedError`` 同侧降级）。"""
+
+    from dayu.host.protocols import SessionClearingError
+
+    class _ClearingPendingTurnStore:
+        """无条件抛 SessionClearingError 的最小 stub。"""
+
+        def upsert_pending_turn(self, **kwargs):  # type: ignore[no-untyped-def]
+            del kwargs
+            raise SessionClearingError("s-x")
+
+    executor = DefaultHostExecutor(
+        run_registry=None,  # type: ignore[arg-type]
+        pending_turn_store=_ClearingPendingTurnStore(),  # type: ignore[arg-type]
+    )
+    contract = ExecutionContract(
+        service_name="chat_turn",
+        scene_name="interactive",
+        host_policy=ExecutionHostPolicy(session_key="s-x", resumable=True),
+        preparation_spec=ScenePreparationSpec(),
+        message_inputs=ExecutionMessageInputs(user_message="hi"),
+        accepted_execution_spec=_minimal_accepted_execution_spec(),
+        execution_options=ExecutionOptions(),
+        metadata={"delivery_channel": "interactive"},
+    )
+    result = executor._register_accepted_pending_turn(  # type: ignore[attr-defined]
+        execution_contract=contract,
+        run_id="run_test",
+    )
+    assert result is None  # 异常被吸收，返回 None
+
+
+@pytest.mark.unit
+def test_register_accepted_pending_turn_absorbs_clearing_failed_error() -> None:
+    """``CLEARING_FAILED`` 持久锁定下迟到 accepted 登记同样降级为 no-op。"""
+
+    from dayu.host.protocols import SessionClearingFailedError
+
+    class _ClearingFailedPendingTurnStore:
+        def upsert_pending_turn(self, **kwargs):  # type: ignore[no-untyped-def]
+            del kwargs
+            raise SessionClearingFailedError("s-y")
+
+    executor = DefaultHostExecutor(
+        run_registry=None,  # type: ignore[arg-type]
+        pending_turn_store=_ClearingFailedPendingTurnStore(),  # type: ignore[arg-type]
+    )
+    contract = ExecutionContract(
+        service_name="chat_turn",
+        scene_name="interactive",
+        host_policy=ExecutionHostPolicy(session_key="s-y", resumable=True),
+        preparation_spec=ScenePreparationSpec(),
+        message_inputs=ExecutionMessageInputs(user_message="hi"),
+        accepted_execution_spec=_minimal_accepted_execution_spec(),
+        execution_options=ExecutionOptions(),
+        metadata={"delivery_channel": "interactive"},
+    )
+    result = executor._register_accepted_pending_turn(  # type: ignore[attr-defined]
+        execution_contract=contract,
+        run_id="run_test",
+    )
+    assert result is None
+

--- a/tests/application/test_run_registry.py
+++ b/tests/application/test_run_registry.py
@@ -462,3 +462,98 @@ class TestCleanupOrphanRuns:
         assert persisted is not None
         assert persisted.pending_turn_id == pending_turn.pending_turn_id
         assert persisted.source_run_id == run.run_id
+
+
+class TestRegisterRunSessionBarrier:
+    """``register_run`` 在 session 屏障下的拒绝测试（``#117`` 设计 §3.3）。"""
+
+    @pytest.mark.unit
+    def test_register_run_blocked_when_session_clearing(self, tmp_path: Path) -> None:
+        """``CLEARING`` 期间 ``register_run`` 抛 ``SessionClearingError``。"""
+
+        from dayu.host.protocols import SessionClearingError
+        from dayu.host.session_registry import SQLiteSessionRegistry
+        from dayu.contracts.session import SessionSource
+
+        store = HostStore(tmp_path / "test.db")
+        store.initialize_schema()
+        session_registry = SQLiteSessionRegistry(store)
+        run_registry = SQLiteRunRegistry(store, session_activity=session_registry)
+
+        session = session_registry.create_session(SessionSource.CLI, session_id="s1")
+        session_registry.begin_clearing(session.session_id)
+
+        with pytest.raises(SessionClearingError):
+            run_registry.register_run(session_id=session.session_id, service_type="chat_turn")
+
+    @pytest.mark.unit
+    def test_register_run_blocked_when_session_clearing_failed(self, tmp_path: Path) -> None:
+        """``CLEARING_FAILED`` 持久锁定下 ``register_run`` 抛 ``SessionClearingFailedError``。"""
+
+        from dayu.host.protocols import SessionClearingFailedError
+        from dayu.host.session_registry import SQLiteSessionRegistry
+        from dayu.contracts.session import SessionSource
+
+        store = HostStore(tmp_path / "test.db")
+        store.initialize_schema()
+        session_registry = SQLiteSessionRegistry(store)
+        run_registry = SQLiteRunRegistry(store, session_activity=session_registry)
+
+        session = session_registry.create_session(SessionSource.CLI, session_id="s2")
+        session_registry.begin_clearing(session.session_id)
+        session_registry.mark_clearing_failed(session.session_id)
+
+        with pytest.raises(SessionClearingFailedError):
+            run_registry.register_run(session_id=session.session_id, service_type="chat_turn")
+
+    @pytest.mark.unit
+    def test_register_run_blocked_when_session_closed(self, tmp_path: Path) -> None:
+        """``CLOSED`` 状态下 ``register_run`` 抛 ``SessionClosedError``。"""
+
+        from dayu.host.protocols import SessionClosedError
+        from dayu.host.session_registry import SQLiteSessionRegistry
+        from dayu.contracts.session import SessionSource
+
+        store = HostStore(tmp_path / "test.db")
+        store.initialize_schema()
+        session_registry = SQLiteSessionRegistry(store)
+        run_registry = SQLiteRunRegistry(store, session_activity=session_registry)
+
+        session = session_registry.create_session(SessionSource.CLI, session_id="s3")
+        session_registry.close_session(session.session_id)
+
+        with pytest.raises(SessionClosedError):
+            run_registry.register_run(session_id=session.session_id, service_type="chat_turn")
+
+    @pytest.mark.unit
+    def test_register_run_passes_when_session_active(self, tmp_path: Path) -> None:
+        """``ACTIVE`` 状态正常注册。"""
+
+        from dayu.host.session_registry import SQLiteSessionRegistry
+        from dayu.contracts.session import SessionSource
+
+        store = HostStore(tmp_path / "test.db")
+        store.initialize_schema()
+        session_registry = SQLiteSessionRegistry(store)
+        run_registry = SQLiteRunRegistry(store, session_activity=session_registry)
+
+        session = session_registry.create_session(SessionSource.CLI, session_id="s4")
+        run = run_registry.register_run(
+            session_id=session.session_id, service_type="chat_turn"
+        )
+        assert run.session_id == session.session_id
+
+    @pytest.mark.unit
+    def test_register_run_no_barrier_when_session_id_none(self, tmp_path: Path) -> None:
+        """``session_id`` 为 ``None`` 时跳过屏障校验（无 session 归属的 run 不受屏障约束）。"""
+
+        from dayu.host.session_registry import SQLiteSessionRegistry
+
+        store = HostStore(tmp_path / "test.db")
+        store.initialize_schema()
+        session_registry = SQLiteSessionRegistry(store)
+        run_registry = SQLiteRunRegistry(store, session_activity=session_registry)
+
+        run = run_registry.register_run(service_type="maintenance")
+        assert run.session_id is None
+

--- a/tests/application/test_session_barrier.py
+++ b/tests/application/test_session_barrier.py
@@ -22,13 +22,19 @@ from dayu.host.pending_turn_store import (
     PendingConversationTurnState,
     SQLitePendingConversationTurnStore,
 )
-from dayu.host.protocols import SessionActivityQueryProtocol, SessionClosedError
+from dayu.host.protocols import (
+    SessionActivityQueryProtocol,
+    SessionClearingError,
+    SessionClearingFailedError,
+    SessionClosedError,
+    SessionWriteBlockedError,
+)
 from dayu.host.reply_outbox_store import (
     InMemoryReplyOutboxStore,
     SQLiteReplyOutboxStore,
 )
 from dayu.host.session_registry import SQLiteSessionRegistry
-from dayu.contracts.session import SessionSource
+from dayu.contracts.session import SessionSource, SessionState
 
 from tests.application.conftest import (
     StubHostExecutor,
@@ -48,6 +54,14 @@ class _StaticActivity:
 
         del session_id
         return self._active
+
+    def get_session_state(self, session_id: str) -> SessionState | None:
+        """非活跃路径上仅区分 ``CLOSED`` 与不存在；本桩按"已 CLOSED"返回。"""
+
+        del session_id
+        if self._active:
+            return SessionState.ACTIVE
+        return SessionState.CLOSED
 
 
 def _assert_protocol(activity: _StaticActivity) -> SessionActivityQueryProtocol:
@@ -219,3 +233,85 @@ def test_explicit_injected_host_cancel_session_blocks_late_pending_turn_writes()
                 reply_content="late",
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# `SessionWriteBlockedError` 基类 / 三子类的契约：observability 区分 + 吸收统一
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_session_barrier_errors_share_common_base() -> None:
+    """三类屏障异常都继承 ``SessionWriteBlockedError`` 以便上层统一吸收。"""
+
+    assert issubclass(SessionClosedError, SessionWriteBlockedError)
+    assert issubclass(SessionClearingError, SessionWriteBlockedError)
+    assert issubclass(SessionClearingFailedError, SessionWriteBlockedError)
+
+
+@pytest.mark.unit
+def test_executor_absorbs_clearing_error_for_accepted_pending_turn() -> None:
+    """``_register_accepted_pending_turn`` 在 ``CLEARING`` 屏障下降级为 no-op。
+
+    回归 Review 缺口：原实现仅 ``except SessionClosedError``，
+    ``clear_session_history`` 屏障期间 executor 迟到登记会未被吸收，
+    抛出 ``SessionClearingError`` 把 run 升级为未预期失败。
+    扩 ``SessionWriteBlockedError`` 后三子类共享同一吸收链路。
+    """
+
+    from dayu.host.pending_turn_store import InMemoryPendingConversationTurnStore
+
+    class _ClearingActivity:
+        def is_session_active(self, session_id: str) -> bool:
+            del session_id
+            return False
+
+        def get_session_state(self, session_id: str):
+            del session_id
+            return SessionState.CLEARING
+
+    pending = InMemoryPendingConversationTurnStore(session_activity=_ClearingActivity())
+    # 直接验证仓储抛 SessionClearingError，且它是 SessionWriteBlockedError 的子类。
+    with pytest.raises(SessionClearingError) as excinfo:
+        pending.upsert_pending_turn(
+            session_id="s-clearing",
+            scene_name="interactive",
+            user_text="late",
+            source_run_id="run_late",
+            resumable=True,
+            state=PendingConversationTurnState.PREPARED_BY_HOST,
+            resume_source_json="{}",
+        )
+    assert isinstance(excinfo.value, SessionWriteBlockedError)
+
+
+@pytest.mark.unit
+def test_executor_absorbs_clearing_failed_error_for_accepted_pending_turn() -> None:
+    """``CLEARING_FAILED`` 持久锁定下迟到 pending turn 写入抛出可被基类吸收。"""
+
+    from dayu.host.pending_turn_store import InMemoryPendingConversationTurnStore
+
+    class _ClearingFailedActivity:
+        def is_session_active(self, session_id: str) -> bool:
+            del session_id
+            return False
+
+        def get_session_state(self, session_id: str):
+            del session_id
+            return SessionState.CLEARING_FAILED
+
+    pending = InMemoryPendingConversationTurnStore(
+        session_activity=_ClearingFailedActivity()
+    )
+    with pytest.raises(SessionClearingFailedError) as excinfo:
+        pending.upsert_pending_turn(
+            session_id="s-failed",
+            scene_name="interactive",
+            user_text="late",
+            source_run_id="run_late",
+            resumable=True,
+            state=PendingConversationTurnState.PREPARED_BY_HOST,
+            resume_source_json="{}",
+        )
+    assert isinstance(excinfo.value, SessionWriteBlockedError)
+

--- a/tests/application/test_session_registry.py
+++ b/tests/application/test_session_registry.py
@@ -196,6 +196,85 @@ class TestCloseSession:
             registry.close_session("nonexistent")
 
 
+class TestClearingBarrier:
+    """``#117`` ``CLEARING`` / ``CLEARING_FAILED`` 屏障状态机测试。"""
+
+    @pytest.mark.unit
+    def test_begin_clearing_from_active(self, registry: SQLiteSessionRegistry) -> None:
+        """ACTIVE → CLEARING：is_session_active 收紧为 ACTIVE-only。"""
+
+        session = registry.create_session(SessionSource.CLI)
+        assert registry.is_session_active(session.session_id) is True
+
+        registry.begin_clearing(session.session_id)
+
+        assert registry.get_session_state(session.session_id) == SessionState.CLEARING
+        assert registry.is_session_active(session.session_id) is False
+
+    @pytest.mark.unit
+    def test_end_clearing_returns_to_active(self, registry: SQLiteSessionRegistry) -> None:
+        """CLEARING → ACTIVE：屏障释放后写入恢复。"""
+
+        session = registry.create_session(SessionSource.CLI)
+        registry.begin_clearing(session.session_id)
+        registry.end_clearing(session.session_id)
+
+        assert registry.get_session_state(session.session_id) == SessionState.ACTIVE
+        assert registry.is_session_active(session.session_id) is True
+
+    @pytest.mark.unit
+    def test_mark_clearing_failed_locks_session(self, registry: SQLiteSessionRegistry) -> None:
+        """CLEARING → CLEARING_FAILED：持久锁定，不被 is_session_active 视为活跃。"""
+
+        session = registry.create_session(SessionSource.CLI)
+        registry.begin_clearing(session.session_id)
+        registry.mark_clearing_failed(session.session_id)
+
+        assert registry.get_session_state(session.session_id) == SessionState.CLEARING_FAILED
+        assert registry.is_session_active(session.session_id) is False
+
+    @pytest.mark.unit
+    def test_begin_clearing_rejects_non_active(self, registry: SQLiteSessionRegistry) -> None:
+        """已 CLOSED / CLEARING / CLEARING_FAILED 不允许再 begin_clearing。"""
+
+        session = registry.create_session(SessionSource.CLI)
+        registry.close_session(session.session_id)
+        with pytest.raises(RuntimeError, match="进入 CLEARING"):
+            registry.begin_clearing(session.session_id)
+
+        s2 = registry.create_session(SessionSource.CLI)
+        registry.begin_clearing(s2.session_id)
+        with pytest.raises(RuntimeError, match="进入 CLEARING"):
+            registry.begin_clearing(s2.session_id)
+
+        registry.mark_clearing_failed(s2.session_id)
+        with pytest.raises(RuntimeError, match="进入 CLEARING"):
+            registry.begin_clearing(s2.session_id)
+
+    @pytest.mark.unit
+    def test_end_clearing_rejects_non_clearing(self, registry: SQLiteSessionRegistry) -> None:
+        """ACTIVE / CLEARING_FAILED / CLOSED 不允许 end_clearing。"""
+
+        session = registry.create_session(SessionSource.CLI)
+        with pytest.raises(RuntimeError, match="退出 CLEARING"):
+            registry.end_clearing(session.session_id)
+
+    @pytest.mark.unit
+    def test_mark_failed_rejects_non_clearing(self, registry: SQLiteSessionRegistry) -> None:
+        """ACTIVE 状态直接 mark_clearing_failed 必须报错。"""
+
+        session = registry.create_session(SessionSource.CLI)
+        with pytest.raises(RuntimeError, match="升级 CLEARING_FAILED"):
+            registry.mark_clearing_failed(session.session_id)
+
+    @pytest.mark.unit
+    def test_clearing_state_blocks_nonexistent(self, registry: SQLiteSessionRegistry) -> None:
+        """begin_clearing 不存在的 session 抛 KeyError。"""
+
+        with pytest.raises(KeyError, match="session 不存在"):
+            registry.begin_clearing("nonexistent")
+
+
 class TestCloseIdleSessions:
     """close_idle_sessions 测试。"""
 


### PR DESCRIPTION
## Summary

按共享设计 plan `/Users/leo/.claude/plans/a-workspace-dayu-host-conversation-sessi-misty-volcano.md` §1 / §3 / §4 实施 Phase 2（#117），在 Phase 1（#116/#120）合并基础上新增"清空会话历史"能力，并修复 review 报告指出的两处缺口。

- **`SessionState` 状态机扩展**：`{ACTIVE, CLEARING, CLEARING_FAILED, CLOSED}`；`is_session_active` 收紧为仅 `ACTIVE`。
- **`Host.clear_session_history(session_id)`** 在不关闭 session 的前提下原子清空五真源（`history_archive` / `runtime_transcript` + memory / `pending_turn_store` / `reply_outbox_store` / executor replay stash），按 §3.6 写入顺序：`begin_clearing` → 锁内拒绝预检 → `archive_store.save(empty, expected_revision=live.revision)` → 五真源幂等 `delete_by_session_id` / `discard_replay_state_for_session` → 有界 retry → `end_clearing` 或 `mark_clearing_failed`。
- **失败分层契约**：archive 写之前 → `ConversationClearRejectedError` / `ConversationClearStaleError`，五真源不变、`CLEARING → ACTIVE`；archive 写之后未收敛 → `ConversationClearPartiallyAppliedError`，archive 已空、`CLEARING → CLEARING_FAILED` 持久锁定。`PartiallyApplied` **不可重试**，等外部修复路径（reopen / cancel，#121 后续承接）。
- **屏障基类 `SessionWriteBlockedError(RuntimeError)`**：`SessionClosedError` / `SessionClearingError` / `SessionClearingFailedError` 共享继承，便于上层用单条 `except` 统一吸收，同时 `type()` / `isinstance()` 仍可区分子类用于 observability。
- **`run_registry.register_run` 接屏障**（review 报告 Gap 1）：`SQLiteRunRegistry` 注入 `session_activity`，新 run 注册路径走 `_session_barrier.ensure_session_active`，`CLEARING` / `CLEARING_FAILED` / `CLOSED` 命中即拒，覆盖"清空 / 关停期间禁止新 run"语义。
- **吸收链路扩到三类屏障**（review 报告 Gap 2）：executor 的 `_register_accepted_pending_turn` / `_register_prepared_pending_turn` 与 Host 的 `resume_pending_turn_stream`（lease acquire / lease 回退 / 终态判定）统一 `except SessionWriteBlockedError`，对外收敛为 `ValueError("...session 已不再接受写入...")`，`__cause__` 保留原始屏障异常。
- README §3 / §10.10 同步说明屏障覆盖列表、`SessionWriteBlockedError` 基类语义、吸收链路；补回归用例索引。

未破坏 plan §4 任一禁项：未把 `assistant_reasoning` 加回运行态、未让历史读流回送模、未改 resume 真源、未引入兼容 / re-export / 隐式联动。

## 设计文档

- 共享计划：`/Users/leo/.claude/plans/a-workspace-dayu-host-conversation-sessi-misty-volcano.md` §1（历史真源契约） / §3（清空能力契约） / §4（不可触碰边界）
- 后续 issue：#121（reopen 接口，承接 `CLEARING_FAILED` 退出语义）

## Test plan

- [x] `pytest tests/application -q` → 881 passed
- [x] `pyright`（全仓） → 0 errors / 0 warnings
- [x] `tests/application/test_host_clear_session_history.py`（happy + 4 类拒绝 + 场景 a/b 并发 + 契约 B + 幂等 + 联动）
- [x] `tests/application/test_session_registry.py::TestClearingBarrier`
- [x] `tests/application/test_session_barrier.py`（屏障基类继承 + 三类异常吸收）
- [x] `tests/application/test_run_registry.py::TestRegisterRunSessionBarrier`（CLEARING / CLEARING_FAILED / CLOSED 拒绝、ACTIVE 通过、`session_id is None` 跳过屏障）
- [x] `tests/application/test_history_archive_isolation.py`（#118 边界未退化）
- [x] `tests/application/test_host_executor.py`（执行器迟到登记吸收三类屏障 + resume 路径文案更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)