### PR TITLE
feat: CancellationBridge 失败降级阈值改为可配置时间窗口（#96）

### DIFF
--- a/dayu/config/README.md
+++ b/dayu/config/README.md
@@ -485,6 +485,7 @@ Agent 行为控制：
 - `lane`
 - `pending_turn_resume`
 - `pending_turn_retention`
+- `cancellation_bridge`
 
 说明:
 - `host_config.store.path` 是宿主层 SQLite 数据库文件路径。相对路径按 `workspace` 根目录解析；绝对路径则直接使用。当前默认值是 `.dayu/host/dayu_host.db`。
@@ -492,6 +493,8 @@ Agent 行为控制：
 - `host_config.lane` 是宿主层并发 lane 配置，内容为 `lane_name: max_concurrent` 键值对；未显式填写的 lane 回退到 Host 默认（`llm_api`）与 Service 业务默认（`write_chapter`、`sec_download`）的合并值。`llm_api` 是 Host 自治 lane，用户可在此下调/上调运维抓手；`write_chapter` 控制真实章节 scene 的同时写作数（写作 pipeline 的 ThreadPoolExecutor worker 上限与本值同源，顶层 `write_pipeline` orchestration 本身不占这个 lane）；`sec_download` 控制 SEC 下载的跨进程串行度。
 - `host_config.pending_turn_resume.max_attempts` 控制单条 pending turn 的最大恢复次数。当前默认值是 `3`；达到上限后 Host 会删除该 pending turn，避免同一 `session + scene` 槽位被坏记录永久卡死。
 - `host_config.pending_turn_retention.retention_hours` 控制 pending turn 在 `ACCEPTED_BY_HOST` / `PREPARED_BY_HOST` 状态下的最长保留时间（小时）。当前默认值是 `168`（7 天）；`Host.cleanup_stale_pending_turns` 会在启动 / 维护阶段把超过保留期的记录兜底删除，避免 UI 层长期未询问用户"是否重发"时库无限累积。该值是 UI 询问窗口的上限，典型 UI 会在 <72 小时内完成询问。
+- `host_config.cancellation_bridge.poll_interval_seconds` 控制 `CancellationBridge` 轮询 SQLite run 状态的间隔（秒），默认 `0.5`。该值同时是跨进程取消信号的最大探测时延量级。
+- `host_config.cancellation_bridge.failure_grace_period_seconds` 控制 bridge 容忍底层 `get_run` 连续失败的时间窗口（秒），默认 `5.0`。bridge 内部按 `failure_grace_period_seconds / poll_interval_seconds` 推导连续失败次数阈值（至少 1）：超出窗口后通过 `Log.error` 告知并停止轮询线程，避免在系统性异常下空转。一旦成功查询一次失败计数即清零。把 `poll_interval_seconds` 改小可降低取消时延、但同时也会缩短同等次数下的容忍窗口；如果希望保持原有容忍窗口，需要按比例同步上调 `failure_grace_period_seconds`。
 
 ### 5.7 `tool_trace_config`
 

--- a/dayu/config/run.json
+++ b/dayu/config/run.json
@@ -63,6 +63,10 @@
     },
     "pending_turn_retention": {
       "retention_hours": 168
+    },
+    "cancellation_bridge": {
+      "poll_interval_seconds": 0.5,
+      "failure_grace_period_seconds": 5.0
     }
   },
   "tool_trace_config": {

--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -61,6 +61,9 @@ host_config:
   lane:  { default: 1, writer: 2, ... }               # UI 级 lane 覆盖
   pending_turn_resume:    { max_attempts: 3 }         # resume 尝试次数上限
   pending_turn_retention: { retention_hours: 168 }    # UI 未询问窗口的兜底删除阈值（7 天）
+  cancellation_bridge:                                 # 跨进程取消桥配置
+    poll_interval_seconds: 0.5                         # 轮询 SQLite run 状态的间隔
+    failure_grace_period_seconds: 5.0                  # 连续失败容忍窗口；超出后 bridge 停止
 ```
 
 lane 合并顺序（后者覆盖前者）：
@@ -127,6 +130,12 @@ SUCCEEDED FAILED    CANCELLED       UNSETTLED
 - **取消终态**：`Run.state = CANCELLED` 被落库。两者时间点可分离——intent 可以立即设置，但终态由实际退出路径写入。
 
 `CancellationBridge` 桥接引擎回调与 Host 取消链；`RunDeadlineWatcher` 在 timeout 到点时设置 intent，然后依赖同一路径走到终态。
+
+**Bridge 失败降级**：底层 `RunRegistry.get_run` 持续抛出非预期异常时，bridge 会按
+`failure_grace_period_seconds / poll_interval_seconds` 推导连续失败阈值（至少为 1），
+超过阈值后通过 `Log.error` 告知并停止轮询线程，避免在系统性异常下空转。一旦成功
+查询一次，失败计数立即清零。两个参数均可在 `host_config.cancellation_bridge` 配置，
+默认 `0.5s` / `5.0s`。
 
 **终态守门**：Run 一旦进入 `TERMINAL_STATES`（SUCCEEDED/FAILED/CANCELLED/UNSETTLED）不再接受任何状态转移，也不再触发事件。转移表在 `dayu/contracts/run.py` 中集中。
 

--- a/dayu/host/cancellation_bridge.py
+++ b/dayu/host/cancellation_bridge.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 import threading
 from typing import TYPE_CHECKING
 
@@ -18,9 +19,6 @@ if TYPE_CHECKING:
 
 _MODULE = "HOST.CANCELLATION_BRIDGE"
 
-# 连续轮询失败次数达到该阈值后停止轮询，避免在持续性异常下空转消耗资源。
-_MAX_CONSECUTIVE_POLL_FAILURES = 10
-
 
 class CancellationBridge:
     """跨进程取消桥接器。
@@ -30,6 +28,12 @@ class CancellationBridge:
     当 run 进入其他终态（SUCCEEDED/FAILED）时自动停止轮询。
 
     线程安全，stop() 可重入。
+
+    失败降级策略：
+        若底层 ``run_registry.get_run`` 持续抛非预期异常，bridge 会按
+        ``failure_grace_period_seconds`` 估算可接受的取消探测空窗，连续失败
+        超出该窗口后停止轮询并通过 ``Log.error`` 告知，避免在系统性异常
+        下空转消耗资源。一旦成功查询一次，失败计数立即清零。
     """
 
     def __init__(
@@ -38,6 +42,7 @@ class CancellationBridge:
         run_id: str,
         token: CancellationToken,
         poll_interval: float = 0.5,
+        failure_grace_period_seconds: float = 5.0,
     ) -> None:
         """初始化 CancellationBridge。
 
@@ -45,13 +50,31 @@ class CancellationBridge:
             run_registry: 用于查询 run 状态的注册表。
             run_id: 监听的 run ID。
             token: 进程内取消令牌。
-            poll_interval: 轮询间隔（秒）。
+            poll_interval: 轮询间隔（秒），必须为正数。
+            failure_grace_period_seconds: 容忍底层连续失败的时间窗口（秒），
+                轮询连续失败累计超过该窗口后停止线程。必须为正数。
+
+        Raises:
+            ValueError: 当 ``poll_interval`` 或 ``failure_grace_period_seconds``
+                非正数时抛出。
         """
+
+        if poll_interval <= 0.0:
+            raise ValueError("poll_interval 必须为正数")
+        if failure_grace_period_seconds <= 0.0:
+            raise ValueError("failure_grace_period_seconds 必须为正数")
 
         self._run_registry = run_registry
         self._run_id = run_id
         self._token = token
         self._poll_interval = poll_interval
+        self._failure_grace_period_seconds = failure_grace_period_seconds
+        # 由「时间窗口 / 轮询间隔」推导的连续失败阈值，至少为 1，避免出现
+        # grace 比 poll_interval 还小的边界配置导致永不退出。
+        self._max_consecutive_failures = max(
+            1,
+            math.ceil(failure_grace_period_seconds / poll_interval),
+        )
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -108,14 +131,19 @@ class CancellationBridge:
                     "CancellationBridge 轮询失败: "
                     f"run_id={self._run_id}, "
                     f"consecutive_failures={consecutive_failures}, "
+                    f"max_consecutive_failures={self._max_consecutive_failures}, "
+                    f"poll_interval_seconds={self._poll_interval}, "
+                    f"failure_grace_period_seconds={self._failure_grace_period_seconds}, "
                     f"error={exc}",
                     module=_MODULE,
                 )
-                if consecutive_failures >= _MAX_CONSECUTIVE_POLL_FAILURES:
+                if consecutive_failures >= self._max_consecutive_failures:
                     Log.error(
-                        "CancellationBridge 连续轮询失败已达阈值，停止轮询: "
+                        "CancellationBridge 连续轮询失败已超出容忍窗口，停止轮询: "
                         f"run_id={self._run_id}, "
-                        f"max_consecutive_failures={_MAX_CONSECUTIVE_POLL_FAILURES}",
+                        f"max_consecutive_failures={self._max_consecutive_failures}, "
+                        f"poll_interval_seconds={self._poll_interval}, "
+                        f"failure_grace_period_seconds={self._failure_grace_period_seconds}",
                         module=_MODULE,
                     )
                     break

--- a/dayu/host/executor.py
+++ b/dayu/host/executor.py
@@ -383,6 +383,10 @@ class DefaultHostExecutor(HostExecutorProtocol):
     concurrency_governor: ConcurrencyGovernorProtocol | None = None
     event_bus: RunEventBusProtocol | None = None
     scene_preparation: ScenePreparationProtocol | None = None
+    # CancellationBridge 配置：默认值与 ``CancellationBridge.__init__`` 默认值
+    # 保持一致；调用方需要更精细的失败降级策略时由 Host 装配链路透传。
+    cancellation_bridge_poll_interval_seconds: float = 0.5
+    cancellation_bridge_failure_grace_period_seconds: float = 5.0
     _replay_stash: dict[str, _ReplayState] = field(default_factory=dict, init=False, repr=False)
     _replay_stash_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
     _run_resources: dict[str, _RunResources] = field(default_factory=dict, init=False, repr=False)
@@ -1352,7 +1356,13 @@ class DefaultHostExecutor(HostExecutorProtocol):
             token.cancel()
             self._finalize_cancelled(run_id)
             raise CancelledError("run 已在启动前收到取消请求")
-        bridge = CancellationBridge(self.run_registry, run_id, token)
+        bridge = CancellationBridge(
+            self.run_registry,
+            run_id,
+            token,
+            poll_interval=self.cancellation_bridge_poll_interval_seconds,
+            failure_grace_period_seconds=self.cancellation_bridge_failure_grace_period_seconds,
+        )
         deadline_watcher = RunDeadlineWatcher(
             self.run_registry,
             run_id,

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -37,6 +37,8 @@ from dayu.host.pending_turn_store import (
     SQLitePendingConversationTurnStore,
 )
 from dayu.host.startup_preparation import (
+    DEFAULT_CANCELLATION_BRIDGE_FAILURE_GRACE_PERIOD_SECONDS,
+    DEFAULT_CANCELLATION_BRIDGE_POLL_INTERVAL_SECONDS,
     DEFAULT_PENDING_TURN_RESUME_MAX_ATTEMPTS,
     DEFAULT_PENDING_TURN_RETENTION_HOURS,
 )
@@ -231,6 +233,12 @@ class Host:
         lane_config: dict[str, int] | None = None,
         pending_turn_resume_max_attempts: int = DEFAULT_PENDING_TURN_RESUME_MAX_ATTEMPTS,
         pending_turn_retention_hours: int = DEFAULT_PENDING_TURN_RETENTION_HOURS,
+        cancellation_bridge_poll_interval_seconds: float = (
+            DEFAULT_CANCELLATION_BRIDGE_POLL_INTERVAL_SECONDS
+        ),
+        cancellation_bridge_failure_grace_period_seconds: float = (
+            DEFAULT_CANCELLATION_BRIDGE_FAILURE_GRACE_PERIOD_SECONDS
+        ),
         event_bus: RunEventBusProtocol | None = None,
         executor: HostExecutorProtocol | None = None,
         session_registry: SessionRegistryProtocol | None = None,
@@ -295,6 +303,10 @@ class Host:
             lane_config=lane_config,
             event_bus=event_bus,
             archive_store=shared_archive_store,
+            cancellation_bridge_poll_interval_seconds=cancellation_bridge_poll_interval_seconds,
+            cancellation_bridge_failure_grace_period_seconds=(
+                cancellation_bridge_failure_grace_period_seconds
+            ),
         )
         self._executor = executor or default_components._executor
         self._session_registry = session_registry or default_components._session_registry
@@ -1941,6 +1953,12 @@ def _build_default_host_components(
     lane_config: dict[str, int] | None,
     event_bus: RunEventBusProtocol | None,
     archive_store: ConversationSessionArchiveStore | None,
+    cancellation_bridge_poll_interval_seconds: float = (
+        DEFAULT_CANCELLATION_BRIDGE_POLL_INTERVAL_SECONDS
+    ),
+    cancellation_bridge_failure_grace_period_seconds: float = (
+        DEFAULT_CANCELLATION_BRIDGE_FAILURE_GRACE_PERIOD_SECONDS
+    ),
 ) -> _DefaultHostComponents:
     """构造 Host 默认内部子组件。
 
@@ -1986,6 +2004,12 @@ def _build_default_host_components(
         event_bus=event_bus,
         scene_preparation=scene_preparation,
         pending_turn_store=pending_turn_store,
+        cancellation_bridge_poll_interval_seconds=(
+            cancellation_bridge_poll_interval_seconds
+        ),
+        cancellation_bridge_failure_grace_period_seconds=(
+            cancellation_bridge_failure_grace_period_seconds
+        ),
     )
     return _DefaultHostComponents(
         executor=executor,

--- a/dayu/host/startup_preparation.py
+++ b/dayu/host/startup_preparation.py
@@ -20,6 +20,13 @@ DEFAULT_PENDING_TURN_RESUME_MAX_ATTEMPTS = 3
 # 未询问用户"是否重发"导致库无限累积。168 = 7 天，预留给 UI 的询问窗口，
 # 同时远大于正常 CLI / Web / WeChat 的实际询问周期（一般 <72 小时）。
 DEFAULT_PENDING_TURN_RETENTION_HOURS = 168
+# CancellationBridge 默认轮询间隔（秒）。覆盖 SQLite 单次 get_run 调用，
+# 与跨进程取消信号期望的探测时延同维度。
+DEFAULT_CANCELLATION_BRIDGE_POLL_INTERVAL_SECONDS = 0.5
+# CancellationBridge 默认连续失败容忍窗口（秒）。bridge 内部会按
+# `failure_grace_period_seconds / poll_interval_seconds` 推导连续失败次数阈值，
+# 5 秒窗口对应当前实现常量 10 次（与既有行为等价）。
+DEFAULT_CANCELLATION_BRIDGE_FAILURE_GRACE_PERIOD_SECONDS = 5.0
 
 
 @dataclass(frozen=True)
@@ -30,6 +37,8 @@ class ResolvedHostConfig:
     lane_config: dict[str, int]
     pending_turn_resume_max_attempts: int
     pending_turn_retention_hours: int
+    cancellation_bridge_poll_interval_seconds: float
+    cancellation_bridge_failure_grace_period_seconds: float
 
 
 def resolve_host_config(
@@ -71,6 +80,12 @@ def resolve_host_config(
         ),
         pending_turn_resume_max_attempts=_resolve_pending_turn_resume_max_attempts(raw_host_config),
         pending_turn_retention_hours=_resolve_pending_turn_retention_hours(raw_host_config),
+        cancellation_bridge_poll_interval_seconds=(
+            _resolve_cancellation_bridge_poll_interval_seconds(raw_host_config)
+        ),
+        cancellation_bridge_failure_grace_period_seconds=(
+            _resolve_cancellation_bridge_failure_grace_period_seconds(raw_host_config)
+        ),
     )
 
 
@@ -218,7 +233,81 @@ def _normalize_lane_config(raw_lane_config: Any, *, source_name: str) -> dict[st
     return normalized
 
 
+def _resolve_cancellation_bridge_poll_interval_seconds(
+    raw_host_config: dict[str, Any],
+) -> float:
+    """解析 CancellationBridge 轮询间隔（秒）。"""
+
+    raw_bridge_config = _read_cancellation_bridge_section(raw_host_config)
+    raw_value = raw_bridge_config.get(
+        "poll_interval_seconds",
+        DEFAULT_CANCELLATION_BRIDGE_POLL_INTERVAL_SECONDS,
+    )
+    return _coerce_positive_float(
+        raw_value,
+        field_name=(
+            "run.json.host_config.cancellation_bridge.poll_interval_seconds"
+        ),
+    )
+
+
+def _resolve_cancellation_bridge_failure_grace_period_seconds(
+    raw_host_config: dict[str, Any],
+) -> float:
+    """解析 CancellationBridge 失败容忍窗口（秒）。"""
+
+    raw_bridge_config = _read_cancellation_bridge_section(raw_host_config)
+    raw_value = raw_bridge_config.get(
+        "failure_grace_period_seconds",
+        DEFAULT_CANCELLATION_BRIDGE_FAILURE_GRACE_PERIOD_SECONDS,
+    )
+    return _coerce_positive_float(
+        raw_value,
+        field_name=(
+            "run.json.host_config.cancellation_bridge.failure_grace_period_seconds"
+        ),
+    )
+
+
+def _read_cancellation_bridge_section(
+    raw_host_config: dict[str, Any],
+) -> dict[str, Any]:
+    """读取并校验 ``cancellation_bridge`` 子配置块结构。
+
+    Returns:
+        若未配置则返回空字典；若结构非法抛 ``TypeError``。
+    """
+
+    raw_bridge_config = raw_host_config.get("cancellation_bridge")
+    if raw_bridge_config is None:
+        return {}
+    if not isinstance(raw_bridge_config, dict):
+        raise TypeError("run.json.host_config.cancellation_bridge 必须是对象")
+    return raw_bridge_config
+
+
+def _coerce_positive_float(raw_value: Any, *, field_name: str) -> float:
+    """把原始配置值转为正浮点数。
+
+    Args:
+        raw_value: 原始 JSON 值，允许 ``int`` 或 ``float``，禁止布尔。
+        field_name: 用于错误信息的字段全路径。
+
+    Raises:
+        ValueError: 类型非法或非正数。
+    """
+
+    if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+        raise ValueError(f"{field_name} 必须是正数")
+    coerced = float(raw_value)
+    if coerced <= 0.0:
+        raise ValueError(f"{field_name} 必须是正数")
+    return coerced
+
+
 __all__ = [
+    "DEFAULT_CANCELLATION_BRIDGE_FAILURE_GRACE_PERIOD_SECONDS",
+    "DEFAULT_CANCELLATION_BRIDGE_POLL_INTERVAL_SECONDS",
     "DEFAULT_PENDING_TURN_RESUME_MAX_ATTEMPTS",
     "DEFAULT_PENDING_TURN_RETENTION_HOURS",
     "ResolvedHostConfig",

--- a/dayu/services/startup_preparation.py
+++ b/dayu/services/startup_preparation.py
@@ -164,6 +164,12 @@ def prepare_host_runtime_dependencies(
         lane_config=host_config.lane_config,
         pending_turn_resume_max_attempts=host_config.pending_turn_resume_max_attempts,
         pending_turn_retention_hours=host_config.pending_turn_retention_hours,
+        cancellation_bridge_poll_interval_seconds=(
+            host_config.cancellation_bridge_poll_interval_seconds
+        ),
+        cancellation_bridge_failure_grace_period_seconds=(
+            host_config.cancellation_bridge_failure_grace_period_seconds
+        ),
         event_bus=None,
     )
     recover_host_startup_state(
@@ -220,6 +226,12 @@ def prepare_host_admin_dependencies(
         lane_config=host_config.lane_config,
         pending_turn_resume_max_attempts=host_config.pending_turn_resume_max_attempts,
         pending_turn_retention_hours=host_config.pending_turn_retention_hours,
+        cancellation_bridge_poll_interval_seconds=(
+            host_config.cancellation_bridge_poll_interval_seconds
+        ),
+        cancellation_bridge_failure_grace_period_seconds=(
+            host_config.cancellation_bridge_failure_grace_period_seconds
+        ),
         event_bus=None,
     )
     return PreparedHostAdminDependencies(

--- a/tests/application/test_cancellation_bridge.py
+++ b/tests/application/test_cancellation_bridge.py
@@ -10,10 +10,7 @@ from typing import cast
 
 import pytest
 
-from dayu.host.cancellation_bridge import (
-    CancellationBridge,
-    _MAX_CONSECUTIVE_POLL_FAILURES,
-)
+from dayu.host.cancellation_bridge import CancellationBridge
 from dayu.host.protocols import RunRegistryProtocol
 from dayu.contracts.run import RunRecord, RunState
 from dayu.contracts.cancellation import CancellationToken
@@ -44,6 +41,15 @@ class _MockRunRegistry:
             cancel_requested_at=self._cancel_requested_at,
             owner_pid=1,
         )
+
+
+class _NoopRegistry:
+    """始终返回 ``None`` 的 registry 桩，用于不依赖运行记录内容的构造期测试。"""
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        """返回 ``None`` 表示 run 已被删除。"""
+        _ = run_id
+        return None
 
 
 def _wait_until(predicate: Callable[[], bool], timeout_seconds: float, interval_seconds: float = 0.01) -> bool:
@@ -224,11 +230,16 @@ class TestCancellationBridgePolling:
 
         registry = _AlwaysFailingRegistry()
         token = CancellationToken()
+        # grace=0.1s, poll=0.01s -> 阈值 10 次
+        poll_interval = 0.01
+        grace = 0.1
+        expected_threshold = 10
         bridge = CancellationBridge(
             run_registry=cast(RunRegistryProtocol, registry),
             run_id="run_test",
             token=token,
-            poll_interval=0.01,
+            poll_interval=poll_interval,
+            failure_grace_period_seconds=grace,
         )
         bridge.start()
         # 等待轮询线程退出
@@ -239,8 +250,8 @@ class TestCancellationBridgePolling:
         # token 不应被取消（无法判定取消请求时不应误判取消）
         assert not token.is_cancelled()
         # 调用次数应在阈值附近（允许少量偏差，但远小于无限循环）
-        assert registry.call_count >= _MAX_CONSECUTIVE_POLL_FAILURES
-        assert registry.call_count <= _MAX_CONSECUTIVE_POLL_FAILURES + 2
+        assert registry.call_count >= expected_threshold
+        assert registry.call_count <= expected_threshold + 2
         bridge.stop()
 
     @pytest.mark.unit
@@ -270,14 +281,18 @@ class TestCancellationBridgePolling:
                 )
 
         # 失败次数小于阈值，且后续始终成功；轮询线程应保持运行。
-        fail_times = max(1, _MAX_CONSECUTIVE_POLL_FAILURES - 2)
+        # grace=0.1s, poll=0.01s -> 阈值 10 次，故意让失败次数 = 8 次。
+        poll_interval = 0.01
+        grace = 0.1
+        fail_times = 8
         registry = _IntermittentRegistry(fail_times=fail_times)
         token = CancellationToken()
         bridge = CancellationBridge(
             run_registry=cast(RunRegistryProtocol, registry),
             run_id="run_test",
             token=token,
-            poll_interval=0.01,
+            poll_interval=poll_interval,
+            failure_grace_period_seconds=grace,
         )
         bridge.start()
         # 给足时间让失败次数累计后再清零，并继续多轮成功轮询。
@@ -287,3 +302,61 @@ class TestCancellationBridgePolling:
         assert thread.is_alive(), "失败计数清零后轮询线程应继续运行"
         assert not token.is_cancelled()
         bridge.stop()
+
+    @pytest.mark.unit
+    def test_failure_threshold_derived_from_grace_period(self) -> None:
+        """失败阈值由 grace_period / poll_interval 推导，且至少为 1。"""
+
+        token = CancellationToken()
+
+        # grace=5s, poll=0.5s -> 10
+        bridge = CancellationBridge(
+            run_registry=cast(RunRegistryProtocol, _NoopRegistry()),
+            run_id="r",
+            token=token,
+            poll_interval=0.5,
+            failure_grace_period_seconds=5.0,
+        )
+        assert bridge._max_consecutive_failures == 10
+
+        # grace=0.3s, poll=0.5s -> ceil(0.6)=1，仍至少为 1
+        bridge_small = CancellationBridge(
+            run_registry=cast(RunRegistryProtocol, _NoopRegistry()),
+            run_id="r",
+            token=token,
+            poll_interval=0.5,
+            failure_grace_period_seconds=0.3,
+        )
+        assert bridge_small._max_consecutive_failures == 1
+
+        # grace=2.5s, poll=0.5s -> 5
+        bridge_mid = CancellationBridge(
+            run_registry=cast(RunRegistryProtocol, _NoopRegistry()),
+            run_id="r",
+            token=token,
+            poll_interval=0.5,
+            failure_grace_period_seconds=2.5,
+        )
+        assert bridge_mid._max_consecutive_failures == 5
+
+    @pytest.mark.unit
+    def test_invalid_constructor_arguments_raise(self) -> None:
+        """非法构造参数应直接抛 ValueError。"""
+
+        token = CancellationToken()
+
+        with pytest.raises(ValueError):
+            CancellationBridge(
+                run_registry=cast(RunRegistryProtocol, _NoopRegistry()),
+                run_id="r",
+                token=token,
+                poll_interval=0.0,
+            )
+        with pytest.raises(ValueError):
+            CancellationBridge(
+                run_registry=cast(RunRegistryProtocol, _NoopRegistry()),
+                run_id="r",
+                token=token,
+                poll_interval=0.5,
+                failure_grace_period_seconds=0.0,
+            )

--- a/tests/application/test_host_executor.py
+++ b/tests/application/test_host_executor.py
@@ -327,8 +327,9 @@ def test_start_run_marks_failed_when_deadline_watcher_start_raises(
             run_id: str,
             token: executor_module.CancellationToken,
             poll_interval: float = 0.5,
+            failure_grace_period_seconds: float = 5.0,
         ) -> None:
-            del run_registry, run_id, token, poll_interval
+            del run_registry, run_id, token, poll_interval, failure_grace_period_seconds
             self.started = False
             self.stopped = False
             _TrackingBridge.instances.append(self)

--- a/tests/application/test_host_public_helpers.py
+++ b/tests/application/test_host_public_helpers.py
@@ -182,6 +182,10 @@ def test_resolve_host_config_supports_defaults_and_nested_overrides() -> None:
                     "lane": {"default": 2, "writer": 3},
                     "pending_turn_resume": {"max_attempts": 5},
                     "pending_turn_retention": {"retention_hours": 72},
+                    "cancellation_bridge": {
+                        "poll_interval_seconds": 1.0,
+                        "failure_grace_period_seconds": 12.0,
+                    },
                 }
             },
             explicit_lane_config={"writer": 7},
@@ -190,11 +194,15 @@ def test_resolve_host_config_supports_defaults_and_nested_overrides() -> None:
         assert default_config.store_path == (workspace_root / ".dayu/host/dayu_host.db").resolve()
         assert default_config.pending_turn_resume_max_attempts == 3
         assert default_config.pending_turn_retention_hours == 168
+        assert default_config.cancellation_bridge_poll_interval_seconds == 0.5
+        assert default_config.cancellation_bridge_failure_grace_period_seconds == 5.0
         assert resolved.store_path == (workspace_root / "runtime/host.sqlite").resolve()
         assert resolved.lane_config["default"] == 2
         assert resolved.lane_config["writer"] == 7
         assert resolved.pending_turn_resume_max_attempts == 5
         assert resolved.pending_turn_retention_hours == 72
+        assert resolved.cancellation_bridge_poll_interval_seconds == 1.0
+        assert resolved.cancellation_bridge_failure_grace_period_seconds == 12.0
 
 
 @pytest.mark.unit
@@ -248,6 +256,47 @@ def test_resolve_host_config_rejects_legacy_and_invalid_shapes() -> None:
                 workspace_root=workspace_root,
                 run_config={
                     "host_config": {"pending_turn_retention": {"retention_hours": True}}
+                },
+            )
+        with pytest.raises(TypeError, match="cancellation_bridge 必须是对象"):
+            resolve_host_config(
+                workspace_root=workspace_root,
+                run_config={"host_config": {"cancellation_bridge": []}},
+            )
+        with pytest.raises(ValueError, match="poll_interval_seconds 必须是正数"):
+            resolve_host_config(
+                workspace_root=workspace_root,
+                run_config={
+                    "host_config": {
+                        "cancellation_bridge": {"poll_interval_seconds": 0}
+                    }
+                },
+            )
+        with pytest.raises(ValueError, match="failure_grace_period_seconds 必须是正数"):
+            resolve_host_config(
+                workspace_root=workspace_root,
+                run_config={
+                    "host_config": {
+                        "cancellation_bridge": {"failure_grace_period_seconds": -1}
+                    }
+                },
+            )
+        with pytest.raises(ValueError, match="poll_interval_seconds 必须是正数"):
+            resolve_host_config(
+                workspace_root=workspace_root,
+                run_config={
+                    "host_config": {
+                        "cancellation_bridge": {"poll_interval_seconds": True}
+                    }
+                },
+            )
+        with pytest.raises(ValueError, match="failure_grace_period_seconds 必须是正数"):
+            resolve_host_config(
+                workspace_root=workspace_root,
+                run_config={
+                    "host_config": {
+                        "cancellation_bridge": {"failure_grace_period_seconds": True}
+                    }
                 },
             )
 

--- a/tests/application/test_service_startup_preparation.py
+++ b/tests/application/test_service_startup_preparation.py
@@ -83,6 +83,8 @@ def test_prepare_host_runtime_dependencies_runs_unified_startup_recovery(
             lane_config={"llm_api": 1},
             pending_turn_resume_max_attempts=3,
             pending_turn_retention_hours=168,
+            cancellation_bridge_poll_interval_seconds=0.5,
+            cancellation_bridge_failure_grace_period_seconds=5.0,
         ),
     )
     monkeypatch.setattr("dayu.services.startup_preparation.Host", lambda **_kwargs: fake_host)
@@ -189,6 +191,8 @@ def test_prepare_host_runtime_dependencies_loads_run_config_once(
             lane_config={"llm_api": 1},
             pending_turn_resume_max_attempts=3,
             pending_turn_retention_hours=168,
+            cancellation_bridge_poll_interval_seconds=0.5,
+            cancellation_bridge_failure_grace_period_seconds=5.0,
         ),
     )
     monkeypatch.setattr("dayu.services.startup_preparation.Host", lambda **_kwargs: fake_host)


### PR DESCRIPTION
## Summary
- bridge 构造参数改用 `failure_grace_period_seconds`，内部按 `ceil(grace / poll_interval)` 推导阈值（最少 1），替换硬编码常量 `_MAX_CONSECUTIVE_POLL_FAILURES = 10`
- `host_config.cancellation_bridge.{poll_interval_seconds, failure_grace_period_seconds}` 接入 `run.json`，默认 0.5s / 5.0s，与原行为等价；配置链路 run.json → resolve_host_config → Host → DefaultHostExecutor → CancellationBridge 整链穿透
- 日志补 `poll_interval_seconds` / `failure_grace_period_seconds` 字段，便于线上识别 bridge 因持续失败退出
- 同步 `dayu/host/README.md`、`dayu/config/README.md`

Closes #96.

## Test plan
- [x] `pytest tests/application/test_cancellation_bridge.py tests/application/test_host_public_helpers.py tests/application/test_host_executor.py tests/application/test_service_startup_preparation.py` (66 passed)
- [x] `pytest tests/application/` (883 passed)
- [x] `pyright dayu/host dayu/services/startup_preparation.py` (0 errors)
- [x] 阈值推导（含 grace<poll 边界）、连续失败退出、失败计数清零、非法构造参数、布尔/非正数配置拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)