### PR TITLE
feat: pending turn resume_lease_id fence token 强一致 (#107)

### DIFF
--- a/dayu/host/README.md
+++ b/dayu/host/README.md
@@ -196,15 +196,30 @@ ACCEPTED_BY_HOST ─► PREPARED_BY_HOST ─► SENT_TO_LLM
 `PreparedAgentTurnSnapshot` 都必须携带完整的 `concurrency_acquire_policy`。
 缺字段的旧快照会被判为损坏记录，而不是再猜测默认等待语义。
 
-三种失败分别以 `PendingTurnResumeConflictError` 的不同 reason 抛出（冲突 vs 超限 vs 记录缺失 vs 不可恢复），上层据此决定"重试 / 跳过 / 转告用户"。
+acquire 失败按语义分流：
+- **`PendingTurnResumeConflictError`**：当前 state 不在可 acquire 集合内（已被其它 resumer 持有 RESUMING）。该异常**仅覆盖 acquire 阶段的并发互斥**，与持有 lease 后的 release / rebind / failure 路径无关——后者一律抛 `LeaseExpiredError`（见 §6.3.1）。
+- **`ValueError`**：`max_attempts` 非正、达上限（同事务原子删除记录）、或恢复目标快照解析失败 / 不可恢复。
+- **`KeyError`**：pending turn 记录不存在。
+
+上层据此决定"重试 / 跳过 / 转告用户"。
 
 **超限即删除**（稳定契约）：在同一事务内发现 `attempt_count >= max_attempts`，直接删除该 pending turn，避免进入半永久残留。
+
+### 6.3.1 Resume lease fence token（`resume_lease_id`）
+
+`resume_lease_id` 是 pending turn 上的 record 级 fence token，用于把"谁当前持有 RESUMING lease"刻成强一致条件，**根治"旧 resumer 迟到写入误覆盖新 holder"**。
+
+- **分配**：`record_resume_attempt` acquire 成功时由 store 通过 `dayu.host.lease.generate_lease_id()` 当场生成，写入记录的 `resume_lease_id` 字段并随返回的 `PendingConversationTurn` 一并交给 executor 持有。
+- **CAS 谓词**：`release_resume_lease` / `rebind_source_run_id_for_resume` / `record_resume_failure` 全部使用双条件 CAS `WHERE state = 'resuming' AND resume_lease_id = ?`；mismatch 时抛 `LeaseExpiredError`，旧 resumer 的迟到写入被 fail-closed 拦下。**state 非 RESUMING 也一律视为 lease 已过期**——cleanup 兜底已把记录回退到 `pre_resume_state`，旧 holder 持有的 lease 在物理上已不存在，对这三个写入路径必须统一抛 `LeaseExpiredError`，不允许沉默 no-op，也不允许仅写 `last_resume_error_message`（否则会把"已重新开放给后续恢复"的 pending turn 打上陈旧失败原因）。
+- **接管路径（Host 兜底专用）**：`cleanup_stale_resuming(pending_turn_id, *, expected_updated_at)` 在同一事务内把 stale RESUMING 强制回退到 `pre_resume_state`，并把 `resume_lease_id` 显式置 NULL。后续旧 resumer 用旧 lease 撞双条件 CAS 必然 mismatch（state 不再是 RESUMING），抛 `LeaseExpiredError`。该入口**不持 lease 也不允许带 lease**——它存在的语义就是"上层 lease 已无效，由 Host 兜底接管"。`expected_updated_at` 是必填的 TOCTOU 防御：Host 端"snapshot 判 stale → 调用 cleanup"之间记录可能已被合法新 holder 重新 acquire，store 在事务内重新校验 `updated_at` 与传入快照值一致才执行回退；否则视为 no-op，绝不抢占 fresh lease。
+- **lease 边界（不上翻 Service / UI）**：`resume_lease_id` 只在 Host 内部 round-trip。`PendingTurnSummary`、`PendingConversationTurnStoreProtocol` 的 view 层入口（`get_pending_turn` / `list_pending_turns`）一律**不**暴露 lease。executor 在 acquire 后内部持有，rebind/release/failure 在同一调用链内透传；Service 入口只交 `pending_turn_id` 触发 resume，全程不参与 lease round-trip。这与 `reply_outbox.lease_id`（需要由渠道侧 round-trip）不同，**因为 pending turn resume 的全链路都发生在 Host 内部，没有跨进程异步回调阶段**。
+- **`Host.resume_pending_turn_stream` 的 lease 异常自吸收契约**：`cleanup_stale_pending_turns` 在 Host 启动期与运行时（`host_admin_service` / `interactive_ui` 主动触发）都可能并发抢占当前 RESUMING lease。executor 抛业务异常后 Host 试图调用 `record_resume_failure` 写入失败原因时，若 cleanup 已并发抢占，store 会按 §6.3.1 的双条件 CAS 抛 `LeaseExpiredError`。Host 必须在外层 try/except 中捕获该异常并降级为 warning 日志，**让 executor 抛出的原始异常继续向上抛**——`LeaseExpiredError` 是内部 fence token 语义，对 Service / UI 没有诊断价值；让它覆盖原始执行失败原因会污染上层错误观测。同样，`SessionWriteBlockedError` 也按"自吸收 + 不覆盖原始异常"处理，由 cleanup 兜底完成 lease 回退。
 
 ### 6.4 Pending turn cleanup 三分支（启动恢复 + 周期性兜底）
 
 `cleanup_stale_pending_turns` 严格按以下分支顺序：
 
-- **分支 A — RESUMING 过期 lease 回退**：`state == RESUMING` 且 `updated_at` 超过 10 分钟 → 释放 lease，按 `pre_resume_state` 回写。保护"resumer 进程中断但 lease 未释放"场景。
+- **分支 A — RESUMING 过期 lease 回退**：`state == RESUMING` 且 `updated_at` 超过 10 分钟 → 通过 `cleanup_stale_resuming(pending_turn_id, expected_updated_at=record.updated_at)` 强制按 `pre_resume_state` 回写并把 `resume_lease_id` 置 NULL。`expected_updated_at` 是 TOCTOU 关键字段：若 snapshot 判 stale 之后该记录已被新 holder 合法重新 acquire，store 内层 CAS 失配视为 no-op，绝不抢占 fresh lease。该路径**不需要持 lease**，是 Host 兜底接管入口；旧 holder 用旧 lease 的迟到写入会因双条件 CAS 失配抛 `LeaseExpiredError`（见 §6.3.1）。
 - **分支 B — source_run 终态联动**：`source_run` 已是终态时，按 `should_delete_pending_turn_after_terminal_run` 真值表判定：
   - `run is None` → 删除；
   - `state ∈ {FAILED, UNSETTLED}` 且 `resumable=True` → **保留**（等 resume）；
@@ -705,10 +720,9 @@ Host 抛出的错误分两类：**业务可恢复** vs **上游编程错**。前
 **业务可恢复（必须 catch）**：
 
 - `SessionClosedError` — 目标 session 已 CLOSED；UI 应提示用户"会话已结束"。
-- `PendingTurnResumeConflictError` — 按 reason 分流：
-  - `attempt_exhausted` → 告知用户"已超最大重试"，不再 resume；
-  - `lease_conflict` → 有其它 resumer 在跑，通常等一下或跳过；
-  - `not_resumable` / `record_missing` → 对应"状态不合法"与"记录已不存在"，UI 按"静默丢弃 / 提示"处理。
+- `PendingTurnResumeConflictError` — **acquire 阶段并发互斥**：另有 resumer 已持有该 pending turn 的 RESUMING lease。Host 默认转译为 `ValueError("...正被其他 resumer 持有...")`，UI 通常按"等一下重试或跳过"处理。
+- `LeaseExpiredError` — Host **内部** fence token 异常：持有的 `resume_lease_id` 已被 cleanup 抢占改写。Host 在 `resume_pending_turn_stream` 里会自吸收为 warning 日志，**不向 Service / UI 暴露**；上层只会看到 executor 的原始执行异常或 Host 转译后的 `ValueError`，不需要直接 catch（见 §6.3.1）。
+- 其它 acquire 失败语义（达上限、记录缺失、不可恢复 / 快照损坏）由 Host 统一转成 `KeyError` / `ValueError`，按错误文本分流。
 - Run 超时 / 取消抛出的事件在事件流里以 `ERROR` / `CANCELLED` 呈现；UI 按事件处理，**不要**等异常。
 
 **上游编程错（不该 catch）**：

--- a/dayu/host/executor.py
+++ b/dayu/host/executor.py
@@ -205,6 +205,31 @@ def _resolve_concurrency_acquire_timeout_seconds(spec: HostedRunSpec) -> float |
     return max(0.001, spec.timeout_ms / 1000.0)
 
 
+def _ensure_resume_lease_pair_consistent(
+    *,
+    resumed_pending_turn_id: str | None,
+    resumed_pending_turn_lease_id: str | None,
+) -> None:
+    """校验 resume 路径下 ``pending_turn_id`` 与 ``lease_id`` 必须同时存在或同时为空。
+
+    Args:
+        resumed_pending_turn_id: 调用方传入的 pending turn ID。
+        resumed_pending_turn_lease_id: 调用方传入的 resume_lease_id。
+
+    Returns:
+        无。
+
+    Raises:
+        ValueError: 两者一者非空、另一者为空时抛出，避免 executor 走入"想用 lease
+            但没拿到 / 拿到了 lease 但没指定 turn"的歧义路径。
+    """
+
+    if (resumed_pending_turn_id is None) != (resumed_pending_turn_lease_id is None):
+        raise ValueError(
+            "resumed_pending_turn_id 与 resumed_pending_turn_lease_id 必须同时提供或同时缺省"
+        )
+
+
 def _required_lanes_for_spec(spec: HostedRunSpec, *, include_agent_lane: bool) -> list[str]:
     """计算一次 run 需要叠加持有的 lane 名，按字母序返回以防死锁。
 
@@ -489,6 +514,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
         execution_contract: ExecutionContract,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[Any]:
         """托管一次 Agent 子执行并返回应用层事件流。
 
@@ -498,17 +524,27 @@ class DefaultHostExecutor(HostExecutorProtocol):
                 表示本次执行已由 Host 端持有 RESUMING lease；executor 必须跳过
                 ``_register_accepted_pending_turn`` 的 upsert，以免覆盖调用方持有的
                 lease。非 resume 路径保持 ``None``。
+            resumed_pending_turn_lease_id: resume 路径下 Host 端持有的
+                ``resume_lease_id``；executor 在 rebind / release 时必须原样回传，
+                双条件 CAS 失配会被识别为"已被接管"。``resumed_pending_turn_id``
+                非 ``None`` 时本字段必填。
 
         Returns:
             应用层事件流。
 
         Raises:
             RuntimeError: 未配置 scene preparation 时抛出。
+            ValueError: ``resumed_pending_turn_id`` 与 lease 字段一者非空、另一者为空时抛出。
         """
 
+        _ensure_resume_lease_pair_consistent(
+            resumed_pending_turn_id=resumed_pending_turn_id,
+            resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
+        )
         async for event in self._run_agent_stream_internal(
             execution_contract,
             resumed_pending_turn_id=resumed_pending_turn_id,
+            resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
             replay_capture=None,
         ):
             yield event
@@ -518,6 +554,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
         execution_contract: ExecutionContract,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
         replay_capture: _ReplayCapture | None = None,
     ) -> AsyncIterator[Any]:
         """``run_agent_stream`` 的内部实现，附带 replay 捕获能力。
@@ -564,6 +601,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
             yield self._settle_agent_cancelled_before_pending_turn_binding(
                 run_id=run.run_id,
                 resumed_pending_turn_id=resumed_pending_turn_id,
+                resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
                 resumable=resumable,
             )
             return
@@ -597,9 +635,11 @@ class DefaultHostExecutor(HostExecutorProtocol):
                 # pending turn 的 source_run_id 重绑到当前 resumed run；否则 "成功执行
                 # 后 delete 瞬时失败" 会留下 source_run_id 指向旧 timeout-cancelled run
                 # 的残留，后续 resume gate 仍会放行，触发重复恢复。
+                assert resumed_pending_turn_lease_id is not None  # 由入口 _ensure_resume_lease_pair_consistent 保证
                 self.pending_turn_store.rebind_source_run_id_for_resume(
                     resumed_pending_turn_id,
                     new_source_run_id=run.run_id,
+                    lease_id=resumed_pending_turn_lease_id,
                 )
             prepared_execution = await self.scene_preparation.prepare(execution_contract, context)
             if resumable and prepared_execution.resume_snapshot is None:
@@ -647,6 +687,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
         prepared_turn: PreparedAgentTurnSnapshot,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[Any]:
         """基于 prepared turn 快照恢复一次 Agent 子执行。
 
@@ -656,7 +697,18 @@ class DefaultHostExecutor(HostExecutorProtocol):
                 表示本次执行已由 Host 端持有 RESUMING lease；executor 必须跳过
                 ``_register_prepared_pending_turn`` 的 upsert，以免覆盖调用方持有
                 的 lease。非 resume 路径保持 ``None``。
+            resumed_pending_turn_lease_id: resume 路径下 Host 端持有的
+                ``resume_lease_id``；executor 在 rebind / release 时必须原样回传。
+                ``resumed_pending_turn_id`` 非 ``None`` 时本字段必填。
+
+        Raises:
+            ValueError: ``resumed_pending_turn_id`` 与 lease 字段一者非空、另一者为空时抛出。
         """
+
+        _ensure_resume_lease_pair_consistent(
+            resumed_pending_turn_id=resumed_pending_turn_id,
+            resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
+        )
 
         if self.scene_preparation is None:
             raise RuntimeError("当前 HostExecutor 未配置 scene preparation")
@@ -677,6 +729,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
             yield self._settle_agent_cancelled_before_pending_turn_binding(
                 run_id=run.run_id,
                 resumed_pending_turn_id=resumed_pending_turn_id,
+                resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
                 resumable=resumable,
             )
             return
@@ -707,9 +760,11 @@ class DefaultHostExecutor(HostExecutorProtocol):
             if resumed_pending_turn_id is not None and self.pending_turn_store is not None:
                 # 同 run_agent_stream 的 resume 分支：显式把 source_run_id 切到当前
                 # resumed run，避免 delete 失败后旧 source_run 被再次放行恢复。
+                assert resumed_pending_turn_lease_id is not None  # 由入口 _ensure_resume_lease_pair_consistent 保证
                 self.pending_turn_store.rebind_source_run_id_for_resume(
                     resumed_pending_turn_id,
                     new_source_run_id=run.run_id,
+                    lease_id=resumed_pending_turn_lease_id,
                 )
             agent_input = await self.scene_preparation.restore_prepared_execution(prepared_turn, context)
             async for event in self._run_prepared_agent_stream(
@@ -1825,6 +1880,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
         *,
         run_id: str,
         resumed_pending_turn_id: str | None,
+        resumed_pending_turn_lease_id: str | None,
         resumable: bool,
     ) -> AppEvent:
         """收敛发生在 pending turn 绑定前的 Agent 取消。
@@ -1839,6 +1895,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
             run_id: 当前 Host run ID。
             resumed_pending_turn_id: Host 外层已持有的 resume lease 对应 pending turn ID；
                 非 resume 路径为 `None`。
+            resumed_pending_turn_lease_id: 配套 lease；resume 路径必传。
             resumable: 当前 scene 是否允许恢复。
 
         Returns:
@@ -1861,6 +1918,7 @@ class DefaultHostExecutor(HostExecutorProtocol):
         self._release_resumed_pending_turn_lease_best_effort(
             run_id=run_id,
             pending_turn_id=resumed_pending_turn_id,
+            lease_id=resumed_pending_turn_lease_id,
         )
         return self._publish_cancelled_app_event(run_id=run_id, run=cancelled_run)
 
@@ -1869,24 +1927,33 @@ class DefaultHostExecutor(HostExecutorProtocol):
         *,
         run_id: str,
         pending_turn_id: str | None,
+        lease_id: str | None,
     ) -> None:
         """best-effort 释放 resume 路径已持有的 RESUMING lease。
 
         Args:
             run_id: 当前 Host run ID，仅用于日志。
             pending_turn_id: 待释放 lease 的 pending turn ID；为 `None` 时直接返回。
+            lease_id: 调用方持有的 ``resume_lease_id``；``pending_turn_id`` 非空时必填。
 
         Returns:
             无。
 
         Raises:
-            无。释放失败只记录告警，最终由 stale-RESUMING cleanup 兜底。
+            无。释放失败（含 lease 已被接管）只记录告警，最终由 stale-RESUMING cleanup 兜底。
         """
 
         if pending_turn_id is None or self.pending_turn_store is None:
             return
+        if lease_id is None:
+            Log.warn(
+                "resume 取消前释放 RESUMING lease 缺少 lease_id，跳过释放，依赖 cleanup 兜底: "
+                f"run_id={run_id}, pending_turn_id={pending_turn_id}",
+                module=MODULE,
+            )
+            return
         try:
-            self.pending_turn_store.release_resume_lease(pending_turn_id)
+            self.pending_turn_store.release_resume_lease(pending_turn_id, lease_id=lease_id)
         except Exception as exc:  # noqa: BLE001
             Log.warn(
                 "resume 取消前释放 RESUMING lease 失败，依赖 cleanup 兜底: "

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -29,6 +29,7 @@ from dayu.host.executor import DefaultHostExecutor, should_delete_pending_turn_a
 from dayu.host.host_execution import HostExecutorProtocol, HostedRunContext, HostedRunSpec
 from dayu.host._datetime_utils import now_utc as _now_utc
 from dayu.host.host_store import HostStore
+from dayu.host.lease import LeaseExpiredError
 from dayu.host.pending_turn_store import (
     InMemoryPendingConversationTurnStore,
     PendingConversationTurn,
@@ -610,6 +611,7 @@ class Host:
         execution_contract: ExecutionContract,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[AppEvent]:
         """托管一次 Agent 子执行并返回应用层事件流。
 
@@ -618,6 +620,9 @@ class Host:
             resumed_pending_turn_id: resume 路径下由 Host 端传入的 pending turn
                 ID；executor 以此识别"不要再 upsert pending turn"。非 resume 路径
                 保持 ``None``。
+            resumed_pending_turn_lease_id: resume 路径下 Host 端持有的
+                ``resume_lease_id``；executor 在 rebind / release 时必须原样回传，
+                双条件 CAS 失配会被识别为"已被接管"。非 resume 路径保持 ``None``。
 
         Yields:
             应用层事件。
@@ -633,6 +638,7 @@ class Host:
         async for event in self._executor.run_agent_stream(
             execution_contract,
             resumed_pending_turn_id=resumed_pending_turn_id,
+            resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
         ):
             yield event
 
@@ -641,6 +647,7 @@ class Host:
         prepared_turn: PreparedAgentTurnSnapshot,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[AppEvent]:
         """托管一次已完成 scene preparation 的 Agent 子执行。
 
@@ -649,6 +656,9 @@ class Host:
             resumed_pending_turn_id: resume 路径下由 Host 端传入的 pending turn
                 ID；executor 以此识别"不要再 upsert pending turn"。非 resume 路径
                 保持 ``None``。
+            resumed_pending_turn_lease_id: resume 路径下 Host 端持有的
+                ``resume_lease_id``；executor 在 rebind / release 时必须原样回传。
+                非 resume 路径保持 ``None``。
 
         Yields:
             应用层事件。
@@ -664,6 +674,7 @@ class Host:
         async for event in self._executor.run_prepared_turn_stream(
             prepared_turn,
             resumed_pending_turn_id=resumed_pending_turn_id,
+            resumed_pending_turn_lease_id=resumed_pending_turn_lease_id,
         ):
             yield event
 
@@ -1271,7 +1282,10 @@ class Host:
                 if now - record.updated_at < _STALE_RESUMING_PENDING_TURN_MAX_AGE:
                     continue
                 try:
-                    released = self._pending_turn_store.release_resume_lease(record.pending_turn_id)
+                    released = self._pending_turn_store.cleanup_stale_resuming(
+                        record.pending_turn_id,
+                        expected_updated_at=record.updated_at,
+                    )
                 except Exception as exc:
                     Log.warn(
                         "Host 释放 stale RESUMING pending turn lease 失败: "
@@ -1596,6 +1610,7 @@ class Host:
                 async for event in self._executor.run_agent_stream(
                     execution_contract,
                     resumed_pending_turn_id=pending_turn_id,
+                    resumed_pending_turn_lease_id=pending_turn_record.resume_lease_id,
                 ):
                     yield event
                 return
@@ -1608,6 +1623,7 @@ class Host:
             async for event in self._executor.run_prepared_turn_stream(
                 prepared_turn,
                 resumed_pending_turn_id=pending_turn_id,
+                resumed_pending_turn_lease_id=pending_turn_record.resume_lease_id,
             ):
                 yield event
         except Exception as exc:
@@ -1631,6 +1647,7 @@ class Host:
                     self._pending_turn_store.record_resume_failure(
                         pending_turn_id,
                         error_message=str(exc),
+                        lease_id=pending_turn_record.resume_lease_id or "",
                     )
                 except SessionWriteBlockedError as failure_exc:
                     # session 已不再接受写入（CLOSED / CLEARING / CLEARING_FAILED），
@@ -1641,6 +1658,19 @@ class Host:
                         f"依赖 cleanup 兜底: pending_turn_id={pending_turn_id}, "
                         f"session_id={session_id}, barrier={type(failure_exc).__name__}, "
                         f"error={failure_exc}",
+                        module=MODULE,
+                    )
+                except LeaseExpiredError as lease_exc:
+                    # 在执行期间被 cleanup_stale_pending_turns 抢占：记录已被回退到非
+                    # RESUMING 或 lease_id 已被换发，store 双条件 CAS 拒绝当前补写。
+                    # 此时不得让 lease 异常覆盖真正的执行失败原因 exc，由 cleanup 兜底
+                    # 即可。注意：cleanup_stale_pending_turns 可在运行时由
+                    # host_admin_service / interactive_ui 主动触发，不仅启动期生效。
+                    Log.warning(
+                        "pending conversation turn lease 回退被 cleanup 抢占，"
+                        f"跳过补写并保留原始执行异常: pending_turn_id={pending_turn_id}, "
+                        f"session_id={session_id}, lease_id={lease_exc.lease_id}, "
+                        f"error={lease_exc}",
                         module=MODULE,
                     )
             # Host 对外只暴露业务语义异常：把仓储写入屏障抛出的

--- a/dayu/host/host.py
+++ b/dayu/host/host.py
@@ -1644,10 +1644,16 @@ class Host:
                         f"pending_turn_id={pending_turn_id}, session_id={session_id}"
                     ) from exc
                 try:
+                    # acquire 阶段（record_resume_attempt 成功）后 store 已写入
+                    # uuid4 hex lease_id；此处必为非空，否则属于 store 实现 bug，
+                    # 让 AssertionError 直接冒泡而不是用 ``or ""`` 静默送一个永远
+                    # 失配的空 lease 进 CAS（与 executor 中 _ensure_resume_lease_pair_consistent
+                    # 保证后的 assert 同构）。
+                    assert pending_turn_record.resume_lease_id is not None
                     self._pending_turn_store.record_resume_failure(
                         pending_turn_id,
                         error_message=str(exc),
-                        lease_id=pending_turn_record.resume_lease_id or "",
+                        lease_id=pending_turn_record.resume_lease_id,
                     )
                 except SessionWriteBlockedError as failure_exc:
                     # session 已不再接受写入（CLOSED / CLEARING / CLEARING_FAILED），

--- a/dayu/host/host_execution.py
+++ b/dayu/host/host_execution.py
@@ -49,6 +49,7 @@ class HostExecutorProtocol(Protocol):
         execution_contract: ExecutionContract,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[AppEvent]:
         """托管一次 Agent 子执行并返回应用层事件流。"""
         ...
@@ -58,6 +59,7 @@ class HostExecutorProtocol(Protocol):
         prepared_turn: PreparedAgentTurnSnapshot,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[AppEvent]:
         """基于 Host prepared turn 快照恢复一次 Agent 子执行。"""
         ...

--- a/dayu/host/host_store.py
+++ b/dayu/host/host_store.py
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS pending_conversation_turns (
     resume_attempt_count INTEGER NOT NULL DEFAULT 0,
     last_resume_error_message TEXT,
     pre_resume_state TEXT,
+    resume_lease_id TEXT,
     metadata_json   TEXT NOT NULL DEFAULT '{}'
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_turns_session_scene
@@ -223,6 +224,8 @@ class HostStore:
                 "resume_source_json",
                 "resume_attempt_count",
                 "last_resume_error_message",
+                "pre_resume_state",
+                "resume_lease_id",
                 "metadata_json",
             ),
             db_path=self._db_path,

--- a/dayu/host/pending_turn_store.py
+++ b/dayu/host/pending_turn_store.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 
 from dayu.host._datetime_utils import now_utc as _now_utc, parse_dt as _parse_dt, serialize_dt as _serialize_dt
+from dayu.host.lease import LeaseExpiredError, generate_lease_id
 from dayu.log import Log
 
 
@@ -152,6 +153,7 @@ class PendingConversationTurn:
     resume_attempt_count: int = 0
     last_resume_error_message: str | None = None
     pre_resume_state: PendingConversationTurnState | None = None
+    resume_lease_id: str | None = None
     metadata: ExecutionDeliveryContext = field(default_factory=empty_execution_delivery_context)
 
 
@@ -235,6 +237,7 @@ class InMemoryPendingConversationTurnStore:
                 resumable=bool(resumable),
                 state=state,
                 resume_source_json=normalized_resume_source_json,
+                resume_lease_id=None,
                 metadata=normalized_metadata,
             )
             self._records[record.pending_turn_id] = record
@@ -258,6 +261,7 @@ class InMemoryPendingConversationTurnStore:
             resume_attempt_count=existing.resume_attempt_count,
             last_resume_error_message=existing.last_resume_error_message,
             pre_resume_state=existing.pre_resume_state,
+            resume_lease_id=existing.resume_lease_id,
             metadata=normalized_metadata,
         )
         self._records[updated.pending_turn_id] = updated
@@ -342,6 +346,7 @@ class InMemoryPendingConversationTurnStore:
             resume_attempt_count=existing.resume_attempt_count,
             last_resume_error_message=existing.last_resume_error_message,
             pre_resume_state=existing.pre_resume_state,
+            resume_lease_id=existing.resume_lease_id,
             metadata=_normalize_metadata(existing.metadata),
         )
         self._records[updated.pending_turn_id] = updated
@@ -397,29 +402,117 @@ class InMemoryPendingConversationTurnStore:
             resume_attempt_count=existing.resume_attempt_count + 1,
             last_resume_error_message=None,
             pre_resume_state=existing.state,
+            resume_lease_id=generate_lease_id(),
             metadata=_normalize_metadata(existing.metadata),
         )
         self._records[updated.pending_turn_id] = updated
         return updated
 
-    def release_resume_lease(self, pending_turn_id: str) -> PendingConversationTurn | None:
+    def release_resume_lease(
+        self,
+        pending_turn_id: str,
+        *,
+        lease_id: str,
+    ) -> PendingConversationTurn | None:
         """把 RESUMING 的 pending turn 回退到 ``pre_resume_state``。
 
         Args:
             pending_turn_id: 目标 pending turn ID。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease
+                等值；mismatch 抛 ``LeaseExpiredError``，杜绝旧 resumer 误覆盖
+                被新 holder 接管的记录。
 
         Returns:
-            回退后的 pending turn；若记录不存在或当前 state 非 RESUMING 则返回
-            ``None``（幂等 no-op）。
+            回退后的 pending turn；若记录不存在则返回 ``None``。
 
         Raises:
-            无：记录缺失、状态不符合回退条件时视为 no-op。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 ``lease_id`` 与
+                当前 lease 不匹配时抛出（统一从 fence token 视角看作"lease 已过期"）。
         """
 
         existing = self.get_pending_turn(pending_turn_id)
         if existing is None:
             return None
         if existing.state is not PendingConversationTurnState.RESUMING:
+            # state 已被 cleanup 兜底回退，旧 holder 持有的 lease 一律视为过期。
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=existing.pending_turn_id,
+                lease_id=lease_id,
+            )
+        if existing.resume_lease_id != lease_id:
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=existing.pending_turn_id,
+                lease_id=lease_id,
+            )
+        if existing.pre_resume_state is None:
+            Log.warn(
+                "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                f"pending_turn_id={existing.pending_turn_id}, "
+                f"session_id={existing.session_id}",
+                module=MODULE,
+            )
+        restored_state = existing.pre_resume_state or PendingConversationTurnState.ACCEPTED_BY_HOST
+        updated = PendingConversationTurn(
+            pending_turn_id=existing.pending_turn_id,
+            session_id=existing.session_id,
+            scene_name=existing.scene_name,
+            user_text=existing.user_text,
+            source_run_id=existing.source_run_id,
+            created_at=existing.created_at,
+            updated_at=_now_utc(),
+            resumable=existing.resumable,
+            state=restored_state,
+            resume_source_json=existing.resume_source_json,
+            resume_attempt_count=existing.resume_attempt_count,
+            last_resume_error_message=existing.last_resume_error_message,
+            pre_resume_state=None,
+            resume_lease_id=None,
+            metadata=_normalize_metadata(existing.metadata),
+        )
+        self._records[updated.pending_turn_id] = updated
+        return updated
+
+    def cleanup_stale_resuming(
+        self,
+        pending_turn_id: str,
+        *,
+        expected_updated_at: datetime,
+    ) -> PendingConversationTurn | None:
+        """Host 兜底专用：把 stale RESUMING 的 pending turn 强制回退到 ``pre_resume_state``。
+
+        与 ``release_resume_lease`` 不同，本方法**不要求 lease_id 匹配**——它
+        是 Host stale cleanup 的兜底路径，不持有任何活 lease。回退时把 lease
+        置 NULL，旧 resumer 后续的 release/rebind/failure 双条件 CAS 必失败，
+        统一从 fence token 视角看作"lease 已过期"。
+
+        为消除 Host 端"snapshot 判 stale → 调用 cleanup"之间的 TOCTOU 窗口，
+        本方法以 ``updated_at == expected_updated_at`` 作为附加 CAS 条件：若
+        快照之间记录已被合法新 holder 重新 acquire / 重新 touch（``updated_at``
+        被刷新），cleanup 视为 no-op，绝不接管 fresh lease。
+
+        Args:
+            pending_turn_id: 目标 pending turn ID。
+            expected_updated_at: Host 在判定 stale 时持有的 ``updated_at``
+                快照值；只有在记录当前 ``updated_at`` 与该快照仍然一致时才
+                执行回退，避免误杀新 holder。
+
+        Returns:
+            回退后的 pending turn；若记录缺失、当前 state 非 RESUMING 或
+            ``updated_at`` 已被刷新，返回 ``None`` / 原记录（幂等 no-op）。
+
+        Raises:
+            无：状态不符合回退条件时视为 no-op。
+        """
+
+        existing = self.get_pending_turn(pending_turn_id)
+        if existing is None:
+            return None
+        if existing.state is not PendingConversationTurnState.RESUMING:
+            return existing
+        if existing.updated_at != expected_updated_at:
+            # 记录已被新 holder 重新 acquire / 重新 touch，放弃接管。
             return existing
         if existing.pre_resume_state is None:
             Log.warn(
@@ -443,6 +536,7 @@ class InMemoryPendingConversationTurnStore:
             resume_attempt_count=existing.resume_attempt_count,
             last_resume_error_message=existing.last_resume_error_message,
             pre_resume_state=None,
+            resume_lease_id=None,
             metadata=_normalize_metadata(existing.metadata),
         )
         self._records[updated.pending_turn_id] = updated
@@ -453,6 +547,7 @@ class InMemoryPendingConversationTurnStore:
         pending_turn_id: str,
         *,
         new_source_run_id: str,
+        lease_id: str,
     ) -> PendingConversationTurn:
         """把持有 RESUMING lease 的 pending turn 的 ``source_run_id`` 重绑到当前 resumed run。
 
@@ -465,6 +560,8 @@ class InMemoryPendingConversationTurnStore:
         Args:
             pending_turn_id: 目标 pending turn ID。
             new_source_run_id: 当前 resumed run 的 run_id。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease
+                等值。mismatch 抛 ``LeaseExpiredError``。
 
         Returns:
             重绑后的 pending turn 记录。
@@ -472,8 +569,8 @@ class InMemoryPendingConversationTurnStore:
         Raises:
             KeyError: 记录不存在时抛出。
             ValueError: ``new_source_run_id`` 为空字符串时抛出。
-            PendingTurnResumeConflictError: 当前 state 非 ``RESUMING``（本方法仅
-                允许 lease 在手的 resumer 调用）时抛出。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 ``lease_id`` 与
+                当前 lease 不匹配时抛出（统一从 fence token 视角看作"lease 已过期"）。
         """
 
         normalized_new_source_run_id = _normalize_text(new_source_run_id, field_name="new_source_run_id")
@@ -488,7 +585,18 @@ class InMemoryPendingConversationTurnStore:
             target_name="pending turn",
         )
         if existing.state is not PendingConversationTurnState.RESUMING:
-            raise PendingTurnResumeConflictError(existing.pending_turn_id)
+            # state 已被 cleanup 兜底回退，旧 holder 持有的 lease 一律视为过期。
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=existing.pending_turn_id,
+                lease_id=lease_id,
+            )
+        if existing.resume_lease_id != lease_id:
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=existing.pending_turn_id,
+                lease_id=lease_id,
+            )
         updated = PendingConversationTurn(
             pending_turn_id=existing.pending_turn_id,
             session_id=existing.session_id,
@@ -503,6 +611,7 @@ class InMemoryPendingConversationTurnStore:
             resume_attempt_count=existing.resume_attempt_count,
             last_resume_error_message=existing.last_resume_error_message,
             pre_resume_state=existing.pre_resume_state,
+            resume_lease_id=existing.resume_lease_id,
             metadata=_normalize_metadata(existing.metadata),
         )
         self._records[updated.pending_turn_id] = updated
@@ -513,8 +622,24 @@ class InMemoryPendingConversationTurnStore:
         pending_turn_id: str,
         *,
         error_message: str,
+        lease_id: str,
     ) -> PendingConversationTurn:
-        """记录一次 pending turn 恢复失败，并把 RESUMING 状态回退到来源态。"""
+        """记录一次 pending turn 恢复失败，并把 RESUMING 状态回退到来源态。
+
+        Args:
+            pending_turn_id: 目标 pending turn ID。
+            error_message: 失败说明。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease
+                等值；mismatch 抛 ``LeaseExpiredError``。
+
+        Returns:
+            写入失败信息后的 pending turn 记录。
+
+        Raises:
+            KeyError: 记录不存在时抛出。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 ``lease_id``
+                与当前 lease 不匹配时抛出（统一从 fence token 视角看作"lease 已过期"）。
+        """
 
         existing = self.get_pending_turn(pending_turn_id)
         if existing is None:
@@ -526,8 +651,13 @@ class InMemoryPendingConversationTurnStore:
             module=MODULE,
             target_name="pending turn",
         )
-        # 失败路径一并回退 RESUMING lease；非 RESUMING 则仅写错误消息。
         if existing.state is PendingConversationTurnState.RESUMING:
+            if existing.resume_lease_id != lease_id:
+                raise LeaseExpiredError(
+                    "pending turn resume lease 已过期或不匹配",
+                    record_id=existing.pending_turn_id,
+                    lease_id=lease_id,
+                )
             if existing.pre_resume_state is None:
                 Log.warn(
                     "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
@@ -537,9 +667,14 @@ class InMemoryPendingConversationTurnStore:
                 )
             restored_state = existing.pre_resume_state or PendingConversationTurnState.ACCEPTED_BY_HOST
             new_pre_resume_state: PendingConversationTurnState | None = None
+            new_lease_id: str | None = None
         else:
-            restored_state = existing.state
-            new_pre_resume_state = existing.pre_resume_state
+            # state 已被 cleanup 兜底回退，旧 holder 持有的 lease 一律视为过期。
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=existing.pending_turn_id,
+                lease_id=lease_id,
+            )
         updated = PendingConversationTurn(
             pending_turn_id=existing.pending_turn_id,
             session_id=existing.session_id,
@@ -554,6 +689,7 @@ class InMemoryPendingConversationTurnStore:
             resume_attempt_count=existing.resume_attempt_count,
             last_resume_error_message=str(error_message).strip() or None,
             pre_resume_state=new_pre_resume_state,
+            resume_lease_id=new_lease_id,
             metadata=_normalize_metadata(existing.metadata),
         )
         self._records[updated.pending_turn_id] = updated
@@ -884,6 +1020,7 @@ class SQLitePendingConversationTurnStore:
         over_limit_deleted = False
         over_limit_session_id = ""
         with write_transaction(conn):
+            new_lease_id = generate_lease_id()
             cursor = conn.execute(
                 f"""
                 UPDATE pending_conversation_turns
@@ -891,6 +1028,7 @@ class SQLitePendingConversationTurnStore:
                     pre_resume_state = state,
                     resume_attempt_count = resume_attempt_count + 1,
                     last_resume_error_message = NULL,
+                    resume_lease_id = ?,
                     updated_at = ?
                 WHERE pending_turn_id = ?
                   AND state IN ({acquirable_placeholders})
@@ -898,6 +1036,7 @@ class SQLitePendingConversationTurnStore:
                 """,
                 (
                     PendingConversationTurnState.RESUMING.value,
+                    new_lease_id,
                     _serialize_dt(_now_utc()),
                     normalized_pending_turn_id,
                     *acquirable_state_values,
@@ -961,17 +1100,25 @@ class SQLitePendingConversationTurnStore:
         )
         raise PendingTurnResumeConflictError(normalized_pending_turn_id)
 
-    def release_resume_lease(self, pending_turn_id: str) -> PendingConversationTurn | None:
+    def release_resume_lease(
+        self,
+        pending_turn_id: str,
+        *,
+        lease_id: str,
+    ) -> PendingConversationTurn | None:
         """把 RESUMING 的 pending turn 原子回退到 ``pre_resume_state``。
 
         Args:
             pending_turn_id: 目标 pending turn ID。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease
+                等值；mismatch 抛 ``LeaseExpiredError``。
 
         Returns:
-            回退后的 pending turn；若记录缺失或当前 state 非 RESUMING
-            则返回 ``None`` / 原记录（幂等 no-op）。
+            回退后的 pending turn；若记录缺失则返回 ``None``。
 
         Raises:
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 ``lease_id`` 与
+                当前 lease 不匹配时抛出（统一从 fence token 视角看作"lease 已过期"）。
             RuntimeError: 回退成功后重新读取失败时抛出。
         """
 
@@ -979,6 +1126,101 @@ class SQLitePendingConversationTurnStore:
         conn = self._host_store.get_connection()
         # write_transaction(BEGIN IMMEDIATE) 序列化 SELECT + UPDATE，避免并发下
         # "释放胜出方读到 state 已被再次 acquire" 的竞态。
+        refreshed: sqlite3.Row | None = None
+        missing = False
+        lease_mismatch = False
+        with write_transaction(conn):
+            row = conn.execute(
+                "SELECT * FROM pending_conversation_turns WHERE pending_turn_id = ?",
+                (normalized_pending_turn_id,),
+            ).fetchone()
+            if row is None:
+                missing = True
+            elif str(row["state"]) != PendingConversationTurnState.RESUMING.value:
+                # state 已被 cleanup 兜底回退，旧 holder 持有的 lease 一律视为过期。
+                lease_mismatch = True
+            else:
+                current_lease = row["resume_lease_id"] if "resume_lease_id" in row.keys() else None
+                if current_lease != lease_id:
+                    lease_mismatch = True
+                else:
+                    pre_resume_state_raw = row["pre_resume_state"] if "pre_resume_state" in row.keys() else None
+                    if not pre_resume_state_raw:
+                        Log.warn(
+                            "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                            f"pending_turn_id={normalized_pending_turn_id}, "
+                            f"session_id={str(row['session_id'])}",
+                            module=MODULE,
+                        )
+                    restored_state_value = (
+                        str(pre_resume_state_raw)
+                        if pre_resume_state_raw
+                        else PendingConversationTurnState.ACCEPTED_BY_HOST.value
+                    )
+                    conn.execute(
+                        """
+                        UPDATE pending_conversation_turns
+                        SET state = ?,
+                            pre_resume_state = NULL,
+                            resume_lease_id = NULL,
+                            updated_at = ?
+                        WHERE pending_turn_id = ?
+                        """,
+                        (
+                            restored_state_value,
+                            _serialize_dt(_now_utc()),
+                            normalized_pending_turn_id,
+                        ),
+                    )
+                    refreshed = conn.execute(
+                        "SELECT * FROM pending_conversation_turns WHERE pending_turn_id = ?",
+                        (normalized_pending_turn_id,),
+                    ).fetchone()
+        if lease_mismatch:
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=normalized_pending_turn_id,
+                lease_id=lease_id,
+            )
+        if refreshed is not None:
+            return _row_to_pending_turn(dict(refreshed))
+        if missing:
+            return None
+        return None
+
+    def cleanup_stale_resuming(
+        self,
+        pending_turn_id: str,
+        *,
+        expected_updated_at: datetime,
+    ) -> PendingConversationTurn | None:
+        """Host 兜底专用：把 stale RESUMING 强制回退到 ``pre_resume_state``。
+
+        与 ``release_resume_lease`` 不同，本方法不要求 lease_id 匹配——
+        ``cleanup_stale_pending_turns`` 是 Host 端的接管路径，没有持有任何活
+        lease。回退时把 ``resume_lease_id`` 置 NULL：旧 resumer 后续走双条件
+        CAS 写入必然 no-op（state/lease 都已不再匹配），统一被 fence token
+        语义识别为"lease 已过期"。
+
+        为消除 Host 端"snapshot 判 stale → cleanup"之间的 TOCTOU 窗口，
+        本方法以 ``updated_at == expected_updated_at`` 作为附加 CAS 条件：
+        若快照间记录已被新 holder 合法重新 acquire / 重新 touch，cleanup
+        视为 no-op，绝不接管 fresh lease。
+
+        Args:
+            pending_turn_id: 目标 pending turn ID。
+            expected_updated_at: Host 判 stale 时持有的 ``updated_at`` 快照值。
+
+        Returns:
+            回退后的 pending turn；记录缺失、当前 state 非 RESUMING、或
+            ``updated_at`` 已被刷新时返回 ``None`` / 原记录（幂等 no-op）。
+
+        Raises:
+            RuntimeError: 回退成功后重新读取失败时抛出。
+        """
+
+        normalized_pending_turn_id = _normalize_text(pending_turn_id, field_name="pending_turn_id")
+        conn = self._host_store.get_connection()
         early_row: sqlite3.Row | None = None
         refreshed: sqlite3.Row | None = None
         with write_transaction(conn):
@@ -989,6 +1231,9 @@ class SQLitePendingConversationTurnStore:
             if row is None:
                 early_row = None
             elif str(row["state"]) != PendingConversationTurnState.RESUMING.value:
+                early_row = row
+            elif _parse_dt(row["updated_at"]) != expected_updated_at:
+                # 记录已被新 holder 重新 acquire / 重新 touch，放弃接管。
                 early_row = row
             else:
                 pre_resume_state_raw = row["pre_resume_state"] if "pre_resume_state" in row.keys() else None
@@ -1009,6 +1254,7 @@ class SQLitePendingConversationTurnStore:
                     UPDATE pending_conversation_turns
                     SET state = ?,
                         pre_resume_state = NULL,
+                        resume_lease_id = NULL,
                         updated_at = ?
                     WHERE pending_turn_id = ?
                     """,
@@ -1025,8 +1271,6 @@ class SQLitePendingConversationTurnStore:
         if refreshed is not None:
             return _row_to_pending_turn(dict(refreshed))
         if early_row is None:
-            # 既未读取到记录（缺失），也未进入 UPDATE 分支。
-            # 事务内 row is None 时 early_row 保持 None，此处直接返回 None。
             return None
         return _row_to_pending_turn(dict(early_row))
 
@@ -1035,16 +1279,17 @@ class SQLitePendingConversationTurnStore:
         pending_turn_id: str,
         *,
         new_source_run_id: str,
+        lease_id: str,
     ) -> PendingConversationTurn:
         """在持有 RESUMING lease 的前提下，把 ``source_run_id`` 原子重绑到当前 resumed run。
 
-        CAS 条件：``state = 'resuming'``。lease 不在手时直接返回
-        ``PendingTurnResumeConflictError``，杜绝"调用方误把别人的 pending turn
-        绑到自己 run"的错接风险。
+        CAS 条件：``state = 'resuming' AND resume_lease_id = ?``。lease 不在手或
+        已被接管时统一抛 ``LeaseExpiredError``。
 
         Args:
             pending_turn_id: 目标 pending turn ID。
             new_source_run_id: 当前 resumed run 的 run_id。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease 等值。
 
         Returns:
             重绑后的 pending turn 记录。
@@ -1052,7 +1297,8 @@ class SQLitePendingConversationTurnStore:
         Raises:
             KeyError: 记录不存在时抛出。
             ValueError: ``new_source_run_id`` 为空字符串时抛出。
-            PendingTurnResumeConflictError: 当前 state 非 ``RESUMING`` 时抛出。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 ``lease_id`` 与
+                当前 lease 不匹配时抛出（统一从 fence token 视角看作"lease 已过期"）。
             RuntimeError: 重绑成功后重新读取失败时抛出。
         """
 
@@ -1071,7 +1317,7 @@ class SQLitePendingConversationTurnStore:
         conn = self._host_store.get_connection()
         refreshed: sqlite3.Row | None = None
         cas_failed_row_missing = False
-        cas_failed_conflict = False
+        cas_failed_lease_mismatch = False
         with write_transaction(conn):
             cursor = conn.execute(
                 """
@@ -1080,12 +1326,14 @@ class SQLitePendingConversationTurnStore:
                     updated_at = ?
                 WHERE pending_turn_id = ?
                   AND state = ?
+                  AND resume_lease_id = ?
                 """,
                 (
                     normalized_new_source_run_id,
                     _serialize_dt(_now_utc()),
                     normalized_pending_turn_id,
                     PendingConversationTurnState.RESUMING.value,
+                    lease_id,
                 ),
             )
             if cursor.rowcount == 0:
@@ -1096,7 +1344,8 @@ class SQLitePendingConversationTurnStore:
                 if row is None:
                     cas_failed_row_missing = True
                 else:
-                    cas_failed_conflict = True
+                    # state 非 RESUMING 或 lease 不匹配，统一视为 lease 已过期。
+                    cas_failed_lease_mismatch = True
             else:
                 refreshed = conn.execute(
                     "SELECT * FROM pending_conversation_turns WHERE pending_turn_id = ?",
@@ -1104,8 +1353,12 @@ class SQLitePendingConversationTurnStore:
                 ).fetchone()
         if cas_failed_row_missing:
             raise KeyError(f"pending turn 不存在: {normalized_pending_turn_id}")
-        if cas_failed_conflict:
-            raise PendingTurnResumeConflictError(normalized_pending_turn_id)
+        if cas_failed_lease_mismatch:
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=normalized_pending_turn_id,
+                lease_id=lease_id,
+            )
         if refreshed is None:
             raise RuntimeError(f"pending turn 重绑 source_run_id 后读取失败: {normalized_pending_turn_id}")
         return _row_to_pending_turn(dict(refreshed))
@@ -1115,8 +1368,25 @@ class SQLitePendingConversationTurnStore:
         pending_turn_id: str,
         *,
         error_message: str,
+        lease_id: str,
     ) -> PendingConversationTurn:
-        """记录一次 pending turn 恢复失败，并在 RESUMING 时回退到来源态。"""
+        """记录一次 pending turn 恢复失败，并在 RESUMING 时回退到来源态。
+
+        Args:
+            pending_turn_id: 目标 pending turn ID。
+            error_message: 失败说明。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease
+                等值；mismatch 抛 ``LeaseExpiredError``。
+
+        Returns:
+            写入失败信息后的 pending turn 记录。
+
+        Raises:
+            KeyError: 记录不存在时抛出。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 ``lease_id``
+                与当前 lease 不匹配时抛出（统一从 fence token 视角看作"lease 已过期"）。
+            RuntimeError: 重新读取失败时抛出。
+        """
 
         normalized_pending_turn_id = _normalize_text(pending_turn_id, field_name="pending_turn_id")
         normalized_error_message = str(error_message).strip() or None
@@ -1133,6 +1403,7 @@ class SQLitePendingConversationTurnStore:
         conn = self._host_store.get_connection()
         refreshed: sqlite3.Row | None = None
         missing = False
+        lease_mismatch = False
         with write_transaction(conn):
             row = conn.execute(
                 "SELECT * FROM pending_conversation_turns WHERE pending_turn_id = ?",
@@ -1143,55 +1414,55 @@ class SQLitePendingConversationTurnStore:
             else:
                 current_state = str(row["state"])
                 if current_state == PendingConversationTurnState.RESUMING.value:
-                    pre_resume_state_raw = row["pre_resume_state"] if "pre_resume_state" in row.keys() else None
-                    if not pre_resume_state_raw:
-                        Log.warn(
-                            "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
-                            f"pending_turn_id={normalized_pending_turn_id}, "
-                            f"session_id={str(row['session_id'])}",
-                            module=MODULE,
+                    current_lease = row["resume_lease_id"] if "resume_lease_id" in row.keys() else None
+                    if current_lease != lease_id:
+                        lease_mismatch = True
+                    else:
+                        pre_resume_state_raw = row["pre_resume_state"] if "pre_resume_state" in row.keys() else None
+                        if not pre_resume_state_raw:
+                            Log.warn(
+                                "pending turn pre_resume_state 缺失，按 ACCEPTED_BY_HOST 降级回退: "
+                                f"pending_turn_id={normalized_pending_turn_id}, "
+                                f"session_id={str(row['session_id'])}",
+                                module=MODULE,
+                            )
+                        restored_state_value = (
+                            str(pre_resume_state_raw)
+                            if pre_resume_state_raw
+                            else PendingConversationTurnState.ACCEPTED_BY_HOST.value
                         )
-                    restored_state_value = (
-                        str(pre_resume_state_raw)
-                        if pre_resume_state_raw
-                        else PendingConversationTurnState.ACCEPTED_BY_HOST.value
-                    )
-                    conn.execute(
-                        """
-                        UPDATE pending_conversation_turns
-                        SET state = ?,
-                            pre_resume_state = NULL,
-                            last_resume_error_message = ?,
-                            updated_at = ?
-                        WHERE pending_turn_id = ?
-                        """,
-                        (
-                            restored_state_value,
-                            normalized_error_message,
-                            _serialize_dt(_now_utc()),
-                            normalized_pending_turn_id,
-                        ),
-                    )
+                        conn.execute(
+                            """
+                            UPDATE pending_conversation_turns
+                            SET state = ?,
+                                pre_resume_state = NULL,
+                                resume_lease_id = NULL,
+                                last_resume_error_message = ?,
+                                updated_at = ?
+                            WHERE pending_turn_id = ?
+                            """,
+                            (
+                                restored_state_value,
+                                normalized_error_message,
+                                _serialize_dt(_now_utc()),
+                                normalized_pending_turn_id,
+                            ),
+                        )
+                        refreshed = conn.execute(
+                            "SELECT * FROM pending_conversation_turns WHERE pending_turn_id = ?",
+                            (normalized_pending_turn_id,),
+                        ).fetchone()
                 else:
-                    conn.execute(
-                        """
-                        UPDATE pending_conversation_turns
-                        SET last_resume_error_message = ?,
-                            updated_at = ?
-                        WHERE pending_turn_id = ?
-                        """,
-                        (
-                            normalized_error_message,
-                            _serialize_dt(_now_utc()),
-                            normalized_pending_turn_id,
-                        ),
-                    )
-                refreshed = conn.execute(
-                    "SELECT * FROM pending_conversation_turns WHERE pending_turn_id = ?",
-                    (normalized_pending_turn_id,),
-                ).fetchone()
+                    # state 已被 cleanup 兜底回退，旧 holder 持有的 lease 一律视为过期。
+                    lease_mismatch = True
         if missing:
             raise KeyError(f"pending turn 不存在: {normalized_pending_turn_id}")
+        if lease_mismatch:
+            raise LeaseExpiredError(
+                "pending turn resume lease 已过期或不匹配",
+                record_id=normalized_pending_turn_id,
+                lease_id=lease_id,
+            )
         if refreshed is None:
             raise RuntimeError(f"pending turn 更新后读取失败: {normalized_pending_turn_id}")
         return _row_to_pending_turn(dict(refreshed))
@@ -1252,6 +1523,10 @@ def _row_to_pending_turn(row: dict[str, Any]) -> PendingConversationTurn:
     pre_resume_state = (
         PendingConversationTurnState(pre_resume_state_value) if pre_resume_state_value else None
     )
+    raw_resume_lease_id = row.get("resume_lease_id")
+    resume_lease_id = (
+        str(raw_resume_lease_id).strip() or None if raw_resume_lease_id else None
+    )
     return PendingConversationTurn(
         pending_turn_id=str(row["pending_turn_id"]),
         session_id=str(row["session_id"]),
@@ -1268,6 +1543,7 @@ def _row_to_pending_turn(row: dict[str, Any]) -> PendingConversationTurn:
         if row.get("last_resume_error_message") is not None
         else None,
         pre_resume_state=pre_resume_state,
+        resume_lease_id=resume_lease_id,
         metadata=metadata,
     )
 

--- a/dayu/host/protocols.py
+++ b/dayu/host/protocols.py
@@ -728,19 +728,70 @@ class PendingConversationTurnStoreProtocol(Protocol):
         pending_turn_id: str,
         *,
         error_message: str,
+        lease_id: str,
     ) -> PendingConversationTurn:
-        """记录一次 pending turn 恢复失败。"""
+        """记录一次 pending turn 恢复失败。
+
+        Args:
+            pending_turn_id: 目标 pending turn ID。
+            error_message: 失败原因文本。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease 等值。
+
+        Returns:
+            写入失败信息后的 pending turn 记录。
+
+        Raises:
+            KeyError: 记录不存在时抛出。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 lease_id 与记录
+                当前 lease 不匹配时抛出（含 cleanup 抢占改写 lease 的场景）。
+        """
         ...
 
-    def release_resume_lease(self, pending_turn_id: str) -> PendingConversationTurn | None:
+    def release_resume_lease(
+        self,
+        pending_turn_id: str,
+        *,
+        lease_id: str,
+    ) -> PendingConversationTurn | None:
         """把 RESUMING 的 pending turn 原子回退到 ``pre_resume_state``。
 
         Args:
             pending_turn_id: 目标 pending turn ID。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease
+                等值；mismatch 抛 ``LeaseExpiredError``。
 
         Returns:
-            回退后的 pending turn；若记录缺失或当前 state 非 RESUMING 则
-            返回 ``None`` 或原记录（幂等 no-op）。
+            回退后的 pending turn 记录；记录不存在时返回 ``None``。
+
+        Raises:
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 lease_id 与记录当前
+                lease 不匹配时抛出（含 cleanup 抢占改写 lease 的场景）。
+        """
+        ...
+
+    def cleanup_stale_resuming(
+        self,
+        pending_turn_id: str,
+        *,
+        expected_updated_at: datetime,
+    ) -> PendingConversationTurn | None:
+        """Host 兜底专用：把 stale RESUMING 强制回退到 ``pre_resume_state``。
+
+        与 ``release_resume_lease`` 不同，本方法不要求 lease_id 匹配；它是
+        ``cleanup_stale_pending_turns`` 兜底用的接管路径，会把 ``resume_lease_id``
+        置 NULL，让旧 resumer 后续 release/rebind/failure 双条件 CAS 必失败。
+
+        以 ``updated_at == expected_updated_at`` 作为附加 CAS 条件，关闭
+        Host 端"snapshot 判 stale → cleanup" 的 TOCTOU 窗口：若期间记录已被
+        合法 holder 重新 acquire / 重新 touch，cleanup 视为 no-op。
+
+        Args:
+            pending_turn_id: 目标 pending turn ID。
+            expected_updated_at: Host 判 stale 时持有的 ``updated_at`` 快照值。
+
+        Returns:
+            回退后的 pending turn；记录缺失、当前 state 非 RESUMING 或
+            ``updated_at`` 已被刷新时返回 ``None`` / 原记录（幂等 no-op）。
 
         Raises:
             无：状态不符合回退条件时视为 no-op。
@@ -752,12 +803,14 @@ class PendingConversationTurnStoreProtocol(Protocol):
         pending_turn_id: str,
         *,
         new_source_run_id: str,
+        lease_id: str,
     ) -> PendingConversationTurn:
         """在持有 RESUMING lease 的前提下把 ``source_run_id`` 原子重绑到当前 resumed run。
 
         Args:
             pending_turn_id: 目标 pending turn ID。
             new_source_run_id: 当前 resumed run 的 run_id。
+            lease_id: 调用方持有的 ``resume_lease_id``，必须与记录当前 lease 等值。
 
         Returns:
             重绑后的 pending turn 记录。
@@ -765,7 +818,8 @@ class PendingConversationTurnStoreProtocol(Protocol):
         Raises:
             KeyError: 记录不存在时抛出。
             ValueError: ``new_source_run_id`` 为空字符串时抛出。
-            PendingTurnResumeConflictError: 当前 state 非 ``RESUMING`` 时抛出。
+            LeaseExpiredError: 当前 state 非 ``RESUMING``，或 lease_id 与记录
+                当前 lease 不匹配时抛出（含 cleanup 抢占改写 lease 的场景）。
         """
         ...
 

--- a/tests/application/conftest.py
+++ b/tests/application/conftest.py
@@ -498,11 +498,13 @@ class StubHostExecutor:
         execution_contract: ExecutionContract,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[AppEvent]:
         """执行 Agent 路径 stub。"""
 
         self.last_execution_contract = execution_contract
         self.last_resumed_pending_turn_id = resumed_pending_turn_id
+        self.last_resumed_pending_turn_lease_id = resumed_pending_turn_lease_id
         yield AppEvent(type=AppEventType.CONTENT_DELTA, payload="hello", meta={})
         yield AppEvent(
             type=AppEventType.FINAL_ANSWER,
@@ -515,11 +517,13 @@ class StubHostExecutor:
         prepared_turn: PreparedAgentTurnSnapshot,
         *,
         resumed_pending_turn_id: str | None = None,
+        resumed_pending_turn_lease_id: str | None = None,
     ) -> AsyncIterator[AppEvent]:
         """执行 prepared turn 恢复路径 stub。"""
 
         self.last_prepared_turn = prepared_turn
         self.last_resumed_pending_turn_id = resumed_pending_turn_id
+        self.last_resumed_pending_turn_lease_id = resumed_pending_turn_lease_id
         yield AppEvent(type=AppEventType.CONTENT_DELTA, payload="hello", meta={})
         yield AppEvent(
             type=AppEventType.FINAL_ANSWER,

--- a/tests/application/test_chat_service.py
+++ b/tests/application/test_chat_service.py
@@ -860,7 +860,12 @@ def test_resume_pending_turn_deletes_record_after_max_attempts(monkeypatch: pyte
     )
     host_executor = _executor(service)
 
-    async def _failing_run_prepared_turn_stream(_prepared_turn, *, resumed_pending_turn_id=None):
+    async def _failing_run_prepared_turn_stream(
+        _prepared_turn,
+        *,
+        resumed_pending_turn_id=None,
+        resumed_pending_turn_lease_id=None,
+    ):
         raise RuntimeError("network boom")
         yield  # pragma: no cover
 

--- a/tests/application/test_host_executor.py
+++ b/tests/application/test_host_executor.py
@@ -2533,8 +2533,9 @@ def test_resume_pending_turn_stream_rebind_failure_finishes_run_without_leak(
             pending_turn_id: str,
             *,
             new_source_run_id: str,
+            lease_id: str,
         ) -> PendingConversationTurn:
-            del pending_turn_id, new_source_run_id
+            del pending_turn_id, new_source_run_id, lease_id
             raise SessionClosedError("session closed during rebind")
 
     class _StubScenePreparation:
@@ -3043,4 +3044,132 @@ def test_register_accepted_pending_turn_absorbs_clearing_failed_error() -> None:
         run_id="run_test",
     )
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# PR-2 review #4 回归：执行期间被 cleanup_stale_pending_turns 抢占时，
+# 失败补写抛出的 LeaseExpiredError 不得覆盖原始执行异常。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_pending_turn_stream_lease_expired_during_failure_record_does_not_mask_original_exc() -> None:
+    """executor 抛业务异常 + 并发 cleanup 抢占 lease 场景下原始异常必须穿透到上层。
+
+    场景：``Host.resume_pending_turn_stream`` 进入 try/except 后，executor 抛出
+    业务异常 ``RuntimeError("executor 内部失败")``；此时若 ``cleanup_stale_pending_turns``
+    在运行时（``host_admin_service`` / ``interactive_ui`` 都可主动触发）已把记录
+    回退至非 RESUMING，``record_resume_failure`` 会抛 ``LeaseExpiredError``。Host 必须
+    捕获并降级为告警日志，让原始 ``RuntimeError`` 继续向上抛，否则上层看到的会
+    是 ``LeaseExpiredError`` 这种内部 fence token 异常，原因诊断被掩盖。
+    """
+
+    from dayu.host.lease import LeaseExpiredError
+    from tests.application.conftest import (
+        StubPendingTurnStore,
+        StubRunRegistry,
+        StubSessionRegistry,
+    )
+
+    class _LeaseExpiredOnFailurePendingTurnStore(StubPendingTurnStore):
+        """``record_resume_failure`` 强制抛 ``LeaseExpiredError``，模拟并发 cleanup。"""
+
+        def record_resume_failure(
+            self,
+            pending_turn_id: str,
+            *,
+            error_message: str,
+            lease_id: str,
+        ) -> PendingConversationTurn:
+            del pending_turn_id, error_message
+            raise LeaseExpiredError(
+                "lease 已被 cleanup 抢占",
+                record_id="pt-mocked",
+                lease_id=lease_id,
+            )
+
+    class _StubScenePreparation:
+        async def prepare(
+            self,
+            execution_contract: ExecutionContract,
+            run_context: HostedRunContext,
+        ) -> PreparedAgentExecution:
+            del execution_contract, run_context
+            raise AssertionError("prepared snapshot 路径不应走 prepare")
+
+        async def restore_prepared_execution(
+            self,
+            prepared_turn: PreparedAgentTurnSnapshot,
+            run_context: HostedRunContext,
+        ) -> AgentInput:
+            del prepared_turn, run_context
+            # executor 在 restore 阶段抛业务异常，模拟"恢复执行失败"。
+            raise RuntimeError("executor 内部失败")
+
+    session_registry = StubSessionRegistry()
+    session_registry.create_session(source=cast("object", "interactive"), session_id="s-lease-overrides")  # type: ignore[arg-type]
+    run_registry = StubRunRegistry()
+    pending_turn_store = _LeaseExpiredOnFailurePendingTurnStore()
+
+    execution_contract = ExecutionContract(
+        service_name="chat_turn",
+        scene_name="interactive",
+        host_policy=ExecutionHostPolicy(session_key="s-lease-overrides", resumable=True),
+        preparation_spec=ScenePreparationSpec(),
+        message_inputs=ExecutionMessageInputs(user_message="问题-lease-overrides"),
+        accepted_execution_spec=_minimal_accepted_execution_spec(),
+        execution_options=ExecutionOptions(model_name="resume-model", max_iterations=6),
+        metadata={"delivery_channel": "interactive"},
+    )
+    prepared_execution = _build_prepared_execution(execution_contract=execution_contract)
+    prepared_turn = prepared_execution.resume_snapshot
+    assert prepared_turn is not None
+    prepared_turn_json = json.dumps(
+        serialize_prepared_agent_turn_snapshot(prepared_turn),
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+    source_run = run_registry.register_run(
+        session_id="s-lease-overrides",
+        service_type="chat_turn",
+        scene_name="interactive",
+    )
+    run_registry.start_run(source_run.run_id)
+    run_registry.mark_cancelled(source_run.run_id, cancel_reason=RunCancelReason.TIMEOUT)
+
+    seeded = pending_turn_store.seed_pending_turn(
+        session_id="s-lease-overrides",
+        scene_name="interactive",
+        user_text="问题-lease-overrides",
+        source_run_id=source_run.run_id,
+        resumable=True,
+        resume_source_json=prepared_turn_json,
+        state=PendingConversationTurnState.PREPARED_BY_HOST,
+    )
+
+    executor = DefaultHostExecutor(
+        run_registry=run_registry,  # type: ignore[arg-type]
+        pending_turn_store=pending_turn_store,  # type: ignore[arg-type]
+        scene_preparation=_StubScenePreparation(),  # type: ignore[arg-type]
+    )
+    host = Host(
+        executor=executor,
+        session_registry=session_registry,  # type: ignore[arg-type]
+        run_registry=run_registry,  # type: ignore[arg-type]
+        pending_turn_store=pending_turn_store,  # type: ignore[arg-type]
+    )
+
+    async def _resume() -> None:
+        async for _event in host.resume_pending_turn_stream(
+            pending_turn_id=seeded.pending_turn_id,
+            session_id="s-lease-overrides",
+        ):
+            pass
+
+    # 关键断言：上抛的必须是 executor 抛出的原始 RuntimeError，
+    # 而不是 record_resume_failure 抛出的 LeaseExpiredError。
+    with pytest.raises(RuntimeError, match="executor 内部失败") as exc_info:
+        asyncio.run(_resume())
+    assert not isinstance(exc_info.value, LeaseExpiredError)
 

--- a/tests/application/test_pending_turn_store.py
+++ b/tests/application/test_pending_turn_store.py
@@ -17,6 +17,7 @@ from dayu.contracts.execution_metadata import ExecutionDeliveryContext
 from dayu.contracts.model_config import OpenAICompatibleRunnerParams
 from dayu.contracts.toolset_config import ToolsetConfigSnapshot
 from dayu.host.host_store import HostStore
+from dayu.host.lease import LeaseExpiredError
 from dayu.host.conversation_store import ConversationTranscript
 from dayu.host.pending_turn_store import (
     InMemoryPendingConversationTurnStore,
@@ -484,7 +485,11 @@ def test_sqlite_pending_turn_store_records_resume_attempts_and_failure_message(t
     )
 
     attempted = store.record_resume_attempt(created.pending_turn_id, max_attempts=3)
-    failed = store.record_resume_failure(created.pending_turn_id, error_message="source run still active")
+    failed = store.record_resume_failure(
+        created.pending_turn_id,
+        error_message="source run still active",
+        lease_id=attempted.resume_lease_id or "",
+    )
 
     assert attempted.resume_attempt_count == 1
     assert attempted.last_resume_error_message is None
@@ -672,18 +677,21 @@ def test_sqlite_pending_turn_store_release_resume_lease_restores_state(tmp_path:
         state=PendingConversationTurnState.PREPARED_BY_HOST,
         resume_source_json='{"scene_name": "wechat"}',
     )
-    store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    attempted = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
 
-    released = store.release_resume_lease(created.pending_turn_id)
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=attempted.resume_lease_id or ""
+    )
     assert released is not None
     assert released.state is PendingConversationTurnState.PREPARED_BY_HOST
     assert released.pre_resume_state is None
 
-    # 幂等：非 RESUMING 再调用返回当前记录（no-op），不再变更 state。
-    again = store.release_resume_lease(created.pending_turn_id)
-    assert again is not None
-    assert again.state is PendingConversationTurnState.PREPARED_BY_HOST
-    assert again.pre_resume_state is None
+    # 同一持有者的 lease 在 release 后已被清空，再调用应抛 LeaseExpiredError
+    # （fence token 语义：state 非 RESUMING 时旧 lease 一律视为过期）。
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(
+            created.pending_turn_id, lease_id=attempted.resume_lease_id or ""
+        )
 
 
 @pytest.mark.unit
@@ -702,9 +710,13 @@ def test_sqlite_pending_turn_store_record_resume_failure_releases_lease(tmp_path
         state=PendingConversationTurnState.PREPARED_BY_HOST,
         resume_source_json='{"scene_name": "wechat"}',
     )
-    store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    attempted = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
 
-    failed = store.record_resume_failure(created.pending_turn_id, error_message="boom")
+    failed = store.record_resume_failure(
+        created.pending_turn_id,
+        error_message="boom",
+        lease_id=attempted.resume_lease_id or "",
+    )
     assert failed.state is PendingConversationTurnState.PREPARED_BY_HOST
     assert failed.pre_resume_state is None
     assert failed.last_resume_error_message == "boom"
@@ -723,14 +735,20 @@ def test_inmemory_pending_turn_store_release_resume_lease_restores_state() -> No
         resumable=True,
         state=PendingConversationTurnState.ACCEPTED_BY_HOST,
     )
-    store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    attempted = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
 
-    released = store.release_resume_lease(created.pending_turn_id)
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=attempted.resume_lease_id or ""
+    )
     assert released is not None
     assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
     assert released.pre_resume_state is None
 
-    assert store.release_resume_lease(created.pending_turn_id) is not None
+    # 第二次回退：state 已不在 RESUMING，旧 lease 视为过期，必抛 LeaseExpiredError。
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(
+            created.pending_turn_id, lease_id=attempted.resume_lease_id or ""
+        )
 
 
 @pytest.mark.unit
@@ -774,7 +792,7 @@ def test_inmemory_release_resume_lease_warns_on_missing_pre_resume_state(
     )
     # 模拟 pre_resume_state 字段损坏：手动写入 RESUMING 但不附带 pre_resume_state。
     record = store._records[created.pending_turn_id]
-    store._records[created.pending_turn_id] = type(record)(
+    forced_record = type(record)(
         pending_turn_id=record.pending_turn_id,
         session_id=record.session_id,
         scene_name=record.scene_name,
@@ -790,9 +808,13 @@ def test_inmemory_release_resume_lease_warns_on_missing_pre_resume_state(
         pre_resume_state=None,
         metadata=record.metadata,
     )
+    store._records[created.pending_turn_id] = forced_record
 
     with caplog.at_level("WARNING"):
-        released = store.release_resume_lease(created.pending_turn_id)
+        released = store.cleanup_stale_resuming(
+            created.pending_turn_id,
+            expected_updated_at=forced_record.updated_at,
+        )
     assert released is not None
     assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
     assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
@@ -815,6 +837,7 @@ def test_inmemory_record_resume_failure_warns_on_missing_pre_resume_state(
         resumable=True,
         state=PendingConversationTurnState.ACCEPTED_BY_HOST,
     )
+    forced_lease = "lease_force_inmemory"
     record = store._records[created.pending_turn_id]
     store._records[created.pending_turn_id] = type(record)(
         pending_turn_id=record.pending_turn_id,
@@ -830,11 +853,14 @@ def test_inmemory_record_resume_failure_warns_on_missing_pre_resume_state(
         resume_attempt_count=record.resume_attempt_count,
         last_resume_error_message=record.last_resume_error_message,
         pre_resume_state=None,
+        resume_lease_id=forced_lease,
         metadata=record.metadata,
     )
 
     with caplog.at_level("WARNING"):
-        failed = store.record_resume_failure(created.pending_turn_id, error_message="boom")
+        failed = store.record_resume_failure(
+            created.pending_turn_id, error_message="boom", lease_id=forced_lease,
+        )
     assert failed.state is PendingConversationTurnState.ACCEPTED_BY_HOST
     assert failed.last_resume_error_message == "boom"
     assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
@@ -847,7 +873,7 @@ def test_sqlite_release_resume_lease_warns_on_missing_pre_resume_state(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """SQLite 版 release_resume_lease 在 pre_resume_state 为 NULL 时应告警并降级回退。"""
+    """SQLite 版 cleanup_stale_resuming 在 pre_resume_state 为 NULL 时应告警并降级回退。"""
 
     host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
     host_store.initialize_schema()
@@ -870,8 +896,13 @@ def test_sqlite_release_resume_lease_warns_on_missing_pre_resume_state(
     )
     conn.commit()
 
+    refreshed = store.get_pending_turn(created.pending_turn_id)
+    assert refreshed is not None
     with caplog.at_level("WARNING"):
-        released = store.release_resume_lease(created.pending_turn_id)
+        released = store.cleanup_stale_resuming(
+            created.pending_turn_id,
+            expected_updated_at=refreshed.updated_at,
+        )
     assert released is not None
     assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
     assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
@@ -898,17 +929,365 @@ def test_sqlite_record_resume_failure_warns_on_missing_pre_resume_state(
         resumable=True,
         state=PendingConversationTurnState.ACCEPTED_BY_HOST,
     )
+    forced_lease = "lease_force_sqlite"
     conn = host_store.get_connection()
     conn.execute(
-        "UPDATE pending_conversation_turns SET state = ?, pre_resume_state = NULL WHERE pending_turn_id = ?",
-        (PendingConversationTurnState.RESUMING.value, created.pending_turn_id),
+        "UPDATE pending_conversation_turns SET state = ?, pre_resume_state = NULL, resume_lease_id = ? WHERE pending_turn_id = ?",
+        (PendingConversationTurnState.RESUMING.value, forced_lease, created.pending_turn_id),
     )
     conn.commit()
 
     with caplog.at_level("WARNING"):
-        failed = store.record_resume_failure(created.pending_turn_id, error_message="boom")
+        failed = store.record_resume_failure(
+            created.pending_turn_id, error_message="boom", lease_id=forced_lease,
+        )
     assert failed.state is PendingConversationTurnState.ACCEPTED_BY_HOST
     assert failed.last_resume_error_message == "boom"
     assert any("pre_resume_state 缺失" in r.message for r in caplog.records), (
         "pre_resume_state 缺失时应输出告警"
     )
+
+
+@pytest.mark.unit
+def test_inmemory_lease_mismatch_release_raises_lease_expired() -> None:
+    """In-Memory 实现：A 持有 lease → cleanup_stale_resuming 抢占 → A 迟到 release 必抛 LeaseExpiredError。"""
+
+    store = InMemoryPendingConversationTurnStore()
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert a_record.resume_lease_id
+
+    # cleanup 兜底：把 lease 抢占清空，state 回退到 ACCEPTED_BY_HOST。
+    cleaned = store.cleanup_stale_resuming(
+        created.pending_turn_id,
+        expected_updated_at=a_record.updated_at,
+    )
+    assert cleaned is not None
+    assert cleaned.resume_lease_id is None
+
+    # B 重新 acquire，分配新 lease。
+    b_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert b_record.resume_lease_id
+    assert b_record.resume_lease_id != a_record.resume_lease_id
+
+    # A 迟到的 release / rebind / failure 全部应抛 LeaseExpiredError。
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(created.pending_turn_id, lease_id=a_record.resume_lease_id or "")
+    with pytest.raises(LeaseExpiredError):
+        store.rebind_source_run_id_for_resume(
+            created.pending_turn_id,
+            new_source_run_id="run_a_late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.record_resume_failure(
+            created.pending_turn_id,
+            error_message="late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+
+    # B 持有的新 lease 仍能正常 release。
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=b_record.resume_lease_id or ""
+    )
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+
+
+@pytest.mark.unit
+def test_sqlite_lease_mismatch_release_raises_lease_expired(tmp_path: Path) -> None:
+    """SQLite 实现：A → cleanup → B → A 迟到写入路径全部 LeaseExpiredError。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLitePendingConversationTurnStore(host_store)
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert a_record.resume_lease_id
+    assert a_record.state is PendingConversationTurnState.RESUMING
+
+    cleaned = store.cleanup_stale_resuming(
+        created.pending_turn_id,
+        expected_updated_at=a_record.updated_at,
+    )
+    assert cleaned is not None
+    assert cleaned.resume_lease_id is None
+    assert cleaned.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+
+    b_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert b_record.resume_lease_id
+    assert b_record.resume_lease_id != a_record.resume_lease_id
+
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(created.pending_turn_id, lease_id=a_record.resume_lease_id or "")
+    with pytest.raises(LeaseExpiredError):
+        store.rebind_source_run_id_for_resume(
+            created.pending_turn_id,
+            new_source_run_id="run_a_late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.record_resume_failure(
+            created.pending_turn_id,
+            error_message="late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+
+    # B 仍可正常 release。
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=b_record.resume_lease_id or ""
+    )
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+
+
+@pytest.mark.unit
+def test_sqlite_lease_threading_double_connection(tmp_path: Path) -> None:
+    """跨线程双连接：A acquire → cleanup（另一线程）→ A 迟到 rebind 必抛 LeaseExpiredError。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLitePendingConversationTurnStore(host_store)
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+
+    cleanup_done = threading.Event()
+    cleanup_error: list[BaseException] = []
+
+    def _cleanup_in_other_thread() -> None:
+        try:
+            store.cleanup_stale_resuming(
+                created.pending_turn_id,
+                expected_updated_at=a_record.updated_at,
+            )
+        except BaseException as exc:  # pragma: no cover - 被主线程抓取
+            cleanup_error.append(exc)
+        finally:
+            cleanup_done.set()
+
+    thread = threading.Thread(target=_cleanup_in_other_thread, name="lease-cleanup")
+    thread.start()
+    thread.join(timeout=5.0)
+    assert cleanup_done.is_set()
+    assert not cleanup_error
+
+    # B 在主线程重新 acquire，使状态再次进入 RESUMING（持新 lease）。
+    b_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert b_record.resume_lease_id
+    assert b_record.resume_lease_id != a_record.resume_lease_id
+
+    # A 迟到 rebind 必失配。
+    with pytest.raises(LeaseExpiredError):
+        store.rebind_source_run_id_for_resume(
+            created.pending_turn_id,
+            new_source_run_id="run_a_late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+
+
+@pytest.mark.unit
+def test_inmemory_cleanup_stale_resuming_skips_when_updated_at_advanced() -> None:
+    """InMemory：cleanup 带 stale ``expected_updated_at`` 时不得抢占 fresh lease。
+
+    覆盖"Host snapshot 判 stale → 期间被合法新 holder 重新 acquire → cleanup 必须 no-op"
+    的 TOCTOU 窗口。
+    """
+
+    store = InMemoryPendingConversationTurnStore()
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    stale_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert stale_record.resume_lease_id
+
+    # 模拟 lease 自动过期被 cleanup 接管，B 立刻重新 acquire 拿到 fresh lease。
+    store.cleanup_stale_resuming(
+        created.pending_turn_id, expected_updated_at=stale_record.updated_at
+    )
+    fresh_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert fresh_record.resume_lease_id
+    assert fresh_record.resume_lease_id != stale_record.resume_lease_id
+
+    # Host 持有的 stale snapshot 触发 cleanup：必须 no-op，不能抹掉 B 的 fresh lease。
+    result = store.cleanup_stale_resuming(
+        created.pending_turn_id, expected_updated_at=stale_record.updated_at
+    )
+    assert result is not None
+    assert result.state is PendingConversationTurnState.RESUMING
+    assert result.resume_lease_id == fresh_record.resume_lease_id
+
+    # B 仍能正常 release。
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=fresh_record.resume_lease_id or ""
+    )
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+
+
+@pytest.mark.unit
+def test_sqlite_cleanup_stale_resuming_skips_when_updated_at_advanced(tmp_path: Path) -> None:
+    """SQLite：同结构 TOCTOU 防御：stale snapshot 不得抹掉 fresh lease。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLitePendingConversationTurnStore(host_store)
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    stale_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert stale_record.resume_lease_id
+
+    store.cleanup_stale_resuming(
+        created.pending_turn_id, expected_updated_at=stale_record.updated_at
+    )
+    fresh_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    assert fresh_record.resume_lease_id
+    assert fresh_record.resume_lease_id != stale_record.resume_lease_id
+
+    # Host stale snapshot 再触发 cleanup：必须 no-op。
+    result = store.cleanup_stale_resuming(
+        created.pending_turn_id, expected_updated_at=stale_record.updated_at
+    )
+    assert result is not None
+    assert result.state is PendingConversationTurnState.RESUMING
+    assert result.resume_lease_id == fresh_record.resume_lease_id
+
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=fresh_record.resume_lease_id or ""
+    )
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+
+
+@pytest.mark.unit
+def test_inmemory_writes_after_cleanup_before_reacquire_raise_lease_expired() -> None:
+    """InMemory：cleanup 后、B 还未 acquire 时，A 的所有迟到写入必抛 LeaseExpiredError。
+
+    覆盖三个缺口：``release_resume_lease`` / ``rebind_source_run_id_for_resume`` /
+    ``record_resume_failure`` 在 state 已被 cleanup 回退到非 RESUMING 时，必须统一
+    把旧 lease 识别为过期，**不允许**沉默 no-op、不允许误改 ``last_resume_error_message``。
+    """
+
+    store = InMemoryPendingConversationTurnStore()
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+
+    # cleanup 把 lease 抢占清空，state 回退；B 尚未 acquire。
+    store.cleanup_stale_resuming(
+        created.pending_turn_id, expected_updated_at=a_record.updated_at
+    )
+
+    snapshot_before = store.get_pending_turn(created.pending_turn_id)
+    assert snapshot_before is not None
+    assert snapshot_before.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+    assert snapshot_before.last_resume_error_message is None
+
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(
+            created.pending_turn_id, lease_id=a_record.resume_lease_id or ""
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.rebind_source_run_id_for_resume(
+            created.pending_turn_id,
+            new_source_run_id="run_a_late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.record_resume_failure(
+            created.pending_turn_id,
+            error_message="late failure",
+            lease_id=a_record.resume_lease_id or "",
+        )
+
+    snapshot_after = store.get_pending_turn(created.pending_turn_id)
+    assert snapshot_after is not None
+    # last_resume_error_message 不得被旧 holder 误写。
+    assert snapshot_after.last_resume_error_message is None
+    assert snapshot_after.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+
+
+@pytest.mark.unit
+def test_sqlite_writes_after_cleanup_before_reacquire_raise_lease_expired(tmp_path: Path) -> None:
+    """SQLite：同结构防御：cleanup 后、B 未 acquire 时旧 holder 三类写入全 LeaseExpired。"""
+
+    host_store = HostStore(tmp_path / ".host" / "dayu_host.db")
+    host_store.initialize_schema()
+    store = SQLitePendingConversationTurnStore(host_store)
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+
+    store.cleanup_stale_resuming(
+        created.pending_turn_id, expected_updated_at=a_record.updated_at
+    )
+
+    snapshot_before = store.get_pending_turn(created.pending_turn_id)
+    assert snapshot_before is not None
+    assert snapshot_before.state is PendingConversationTurnState.ACCEPTED_BY_HOST
+    assert snapshot_before.last_resume_error_message is None
+
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(
+            created.pending_turn_id, lease_id=a_record.resume_lease_id or ""
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.rebind_source_run_id_for_resume(
+            created.pending_turn_id,
+            new_source_run_id="run_a_late",
+            lease_id=a_record.resume_lease_id or "",
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.record_resume_failure(
+            created.pending_turn_id,
+            error_message="late failure",
+            lease_id=a_record.resume_lease_id or "",
+        )
+
+    snapshot_after = store.get_pending_turn(created.pending_turn_id)
+    assert snapshot_after is not None
+    assert snapshot_after.last_resume_error_message is None
+    assert snapshot_after.state is PendingConversationTurnState.ACCEPTED_BY_HOST


### PR DESCRIPTION
## Summary

PR-2 of the cross-process consistency epic: introduces a record-level fence token (`resume_lease_id`) on `pending_conversation_turn` to root-cause "stale resumer late writes overwriting the new holder". Mirrors the lease pattern established by PR-1 (#104) on `reply_outbox`.

- Schema 新增 `resume_lease_id`；`HostStore.initialize_schema` 对旧库 fail-closed。
- `record_resume_attempt` acquire 成功时分配 lease 并随记录交给 executor 持有。
- `release_resume_lease` / `rebind_source_run_id_for_resume` / `record_resume_failure` 改为 `state='resuming' AND resume_lease_id=?` 双条件 CAS，mismatch 或非 RESUMING 一律抛 `LeaseExpiredError`，无静默 no-op。
- `cleanup_stale_resuming` 作为 Host 兜底接管入口，使用 `expected_updated_at` 做 TOCTOU 防御，回退后把 lease 显式置 NULL。
- `Host.resume_pending_turn_stream` 自吸收 `LeaseExpiredError` 与 `SessionWriteBlockedError`，不让 fence token 异常覆盖 executor 原始执行异常。
- Lease 不上翻 Service / UI：`PendingTurnSummary` 与 view 入口不暴露 lease，全程 Host 内部 round-trip。

## Test plan

- [x] `pytest tests/application/test_pending_turn_store.py tests/application/test_host_executor.py tests/application/test_chat_service.py` 109 passed
- [x] `pyright dayu/host/...` 0 errors
- [x] threading 双连接交叉并发：A acquire → cleanup 抢占改 lease → B 重新 acquire → A 迟到 release/rebind/failure 全抛 `LeaseExpiredError`
- [x] executor 抛业务异常 + 并发 cleanup 抢占场景下，原始执行异常穿透到上层（不被 `LeaseExpiredError` 掩盖）
- [ ] PR-5 落地后补"两个独立 dayu 进程同 workspace 同 pending turn"真实跨进程冒烟（计划已在 plan 中备注）

🤖 Generated with [Claude Code](https://claude.com/claude-code)