### PR TITLE
feat: dayu-cli init workspace advisory lock + 迁移 fail-fast (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ API Key 申请地址：
 - 如需接入 OpenRouter 等聚合服务，可在 `init` 中选择”自定义 OpenAI 兼容 API”，填写 `CUSTOM_OPENAI_API_KEY`、Base URL、模型 ID 与最大上下文 tokens。
 - 本地 Ollama 模型和自定义 OpenAI 兼容 API 在 `init` 时会根据最大上下文 tokens 自动配置 `conversation_memory`（>= 100 万 tokens 扩大工作记忆上限，< 100 万收紧情景记忆预算）；Ollama 的 `write_chapter` 并发 lane 默认设为 2。
 - `--reset` 确认后会删除 `workspace/.dayu/`、`workspace/config/`、`workspace/assets/`，再按首次初始化流程重建；它比 `--overwrite` 更彻底，会一并清空运行时状态。
+- 升级 dayu 后若运行命令时看到 `HostStore 检测到旧版 SQLite schema 与当前实现不兼容` 报错，按提示处理：优先删除报错信息里 `db_path` 指向的数据库文件后重启（仅丢失 host 运行状态，保留 conversation 历史与 `run.json`）；如果不方便定位也可以直接跑 `dayu-cli init --reset` 完整重建工作区。
 - 联网搜索默认可走 `auto`，若配置了 Tavily / Serper，会优先使用对应 provider。
 - 若运行环境需要访问 `localhost`、私网 IP 或内网域名，可在 `workspace/config/run.json` 的 `web_tools_config.allow_private_network_url` 中显式打开内网访问开关。
 - 修改默认模型请参考 [8. 模型配置](#model-config)。

--- a/dayu/cli/commands/init.py
+++ b/dayu/cli/commands/init.py
@@ -24,6 +24,7 @@ import urllib.error
 import urllib.request
 from dayu.cli.workspace_migrations import apply_all_workspace_migrations
 from dayu.startup.config_file_resolver import resolve_package_assets_path, resolve_package_config_path
+from dayu.state_dir_lock import StateDirSingleInstanceLock
 from dayu.contracts.env_keys import (
     FMP_API_KEY_ENV,
     SEC_USER_AGENT_ENV,
@@ -228,6 +229,12 @@ _ROLE_THINKING = "thinking"
 # API Key 的方案（DeepSeek Flash/Pro、Mimo Plan/Plan-SG/Pro）在 re-init 按 Enter
 # 时静默降级到声明顺序靠前的另一档。
 _INIT_PROVIDER_OPTION_ENV = "DAYU_INIT_PROVIDER_OPTION"
+
+# Workspace 级 advisory lock 文件名。dayu-cli init 在执行 _copy_config /
+# _copy_assets / apply_all_workspace_migrations 三段临界区时必须独占持有该锁，
+# 避免双 init 进程并发改动同一 workspace 时迁移脚本互相踩踏。
+_INIT_WORKSPACE_LOCK_FILE_NAME = ".dayu_init.lock"
+_INIT_WORKSPACE_LOCK_NAME = "dayu workspace init"
 
 _THIRD_PARTY_OUTPUT_QUIET_ENV: tuple[tuple[str, str], ...] = (
     ("TRANSFORMERS_VERBOSITY", "error"),
@@ -1479,30 +1486,59 @@ def run_init_command(args: Namespace) -> int:
     base_dir = Path(args.base).resolve()
     overwrite: bool = bool(getattr(args, "overwrite", False))
     reset: bool = bool(getattr(args, "reset", False))
+    # --reset 删除的 .dayu/ / config/ / assets/ 与下面 _copy_config /
+    # _copy_assets / apply_all_workspace_migrations 操作的是同一批 workspace
+    # 产物；如果 reset 在锁外执行，另一个 dayu-cli init 进程仍可能在我们
+    # 删除 → 复制的中间窗口进入临界区，导致"我刚写进去你又删掉"或
+    # "迁移跑到一半目录被 reset 清空"的竞态。所以 reset 也必须在 advisory
+    # lock 之内。但 reset 之前的交互确认（input/y/N）应当在锁外完成，
+    # 避免长时间持锁阻塞其他 init 进程。
     if reset:
         if not _confirm_workspace_reset(base_dir):
             print("已取消工作区重置。")
             return 1
-        removed_targets = _reset_workspace_init_targets(base_dir)
-        if removed_targets:
-            removed_names = "、".join(path.name for path in removed_targets)
-            print(f"✓ 已重置工作区初始化目录: {removed_names}")
-        else:
-            target_names = "、".join(path.name for path in _build_workspace_reset_targets(base_dir))
-            print(f"✓ 已执行工作区重置：未发现需要删除的 {target_names}")
 
     is_first_workspace_init = reset or not (base_dir / "config").exists()
-    # 1. 复制配置
-    config_dir = _copy_config(base_dir, overwrite=overwrite)
-    print(f"✓ 配置已复制到: {config_dir}")
+    # 1. 复制配置 / assets 与跑工作区迁移属于 workspace 级临界区：双 init
+    # 并发会互相踩踏 SQLite 写事务、run.json 原子替换以及 config 目录复制。
+    # 用 advisory lock 排他独占。base_dir 在 `_resolve_workspace_root` 中
+    # 已确保存在，可直接落锁文件 `.dayu_init.lock`。
+    base_dir.mkdir(parents=True, exist_ok=True)
+    workspace_init_lock = StateDirSingleInstanceLock(
+        state_dir=base_dir,
+        lock_file_name=_INIT_WORKSPACE_LOCK_FILE_NAME,
+        lock_name=_INIT_WORKSPACE_LOCK_NAME,
+    )
+    try:
+        workspace_init_lock.acquire()
+    except RuntimeError as exc:
+        print(f"\n❌ {exc}")
+        print("   同一 workspace 已有另一个 dayu-cli init 进程在运行，请等待其完成后重试。")
+        return 1
+    try:
+        if reset:
+            removed_targets = _reset_workspace_init_targets(base_dir)
+            if removed_targets:
+                removed_names = "、".join(path.name for path in removed_targets)
+                print(f"✓ 已重置工作区初始化目录: {removed_names}")
+            else:
+                target_names = "、".join(
+                    path.name for path in _build_workspace_reset_targets(base_dir)
+                )
+                print(f"✓ 已执行工作区重置：未发现需要删除的 {target_names}")
 
-    # 1b. 复制 assets（定性分析模板等）
-    assets_dir = _copy_assets(base_dir, overwrite=overwrite)
-    print(f"✓ assets 已复制到: {assets_dir}")
+        config_dir = _copy_config(base_dir, overwrite=overwrite)
+        print(f"✓ 配置已复制到: {config_dir}")
 
-    # 1c. 对旧工作区应用一次性迁移（run.json、Host SQLite）。
-    # 具体规则集中在 dayu.cli.workspace_migrations，避免混入 init 常规流程。
-    apply_all_workspace_migrations(base_dir=base_dir, config_dir=config_dir)
+        # 1b. 复制 assets（定性分析模板等）
+        assets_dir = _copy_assets(base_dir, overwrite=overwrite)
+        print(f"✓ assets 已复制到: {assets_dir}")
+
+        # 1c. 对旧工作区应用一次性迁移（run.json、Host SQLite）。
+        # 具体规则集中在 dayu.cli.workspace_migrations，避免混入 init 常规流程。
+        apply_all_workspace_migrations(base_dir=base_dir, config_dir=config_dir)
+    finally:
+        workspace_init_lock.release()
 
     # 2. 选择初始化模型方案 + 输入 API Key（已有则跳过）
     chosen_option_key = _prompt_provider_selection()

--- a/dayu/cli/workspace_migrations/conversation_archive_init.py
+++ b/dayu/cli/workspace_migrations/conversation_archive_init.py
@@ -16,13 +16,14 @@
 - **原地** 覆盖旧文件路径（``CONVERSATION_STORE_RELATIVE_DIR``），
   不换目录、不双写、不留兼容读取路径。
 - **幂等**：识别到顶层已有 ``runtime_transcript`` 的新 schema 直接跳过。
-- 单文件失败仅 stderr warning 跳过，不阻塞整体迁移。
+- **fail-fast**：任一文件 ``OSError`` / ``json.JSONDecodeError`` /
+  旧 schema 反序列化异常都向上传播，由 runner 显式上抛到
+  ``dayu-cli init``，避免"半迁移"被静默吞掉。
 """
 
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 from dayu.host.conversation_session_archive import (
@@ -48,7 +49,11 @@ def migrate_conversation_archive_init(workspace_root: Path) -> int:
         实际被改写的文件数量。
 
     Raises:
-        无：单文件失败仅 stderr warning 跳过；目录不存在则返回 0。
+        OSError: 单文件读取或回写失败时上抛。
+        json.JSONDecodeError: 单文件 JSON 解析失败时上抛。
+        ValueError: 旧 transcript 反序列化失败、或顶层非对象时上抛。
+        TypeError: 旧 transcript 字段类型异常时上抛。
+        KeyError: 旧 transcript 必需字段缺失时上抛。
     """
 
     target_dir = workspace_root / CONVERSATION_STORE_RELATIVE_DIR
@@ -69,49 +74,30 @@ def _migrate_single_file(json_path: Path) -> bool:
         json_path: 目标文件绝对路径。
 
     Returns:
-        True 表示实际重写了文件；False 表示已是新 schema 或异常跳过。
+        True 表示实际重写了文件；False 表示已是新 schema 或本就不是旧
+        schema（无 ``turns`` key），无需动文件。
 
     Raises:
-        无：所有异常都被吞掉并 stderr warning。
+        OSError: 读取或写回文件失败。
+        json.JSONDecodeError: 文件内容不是合法 JSON。
+        ValueError: 顶层不是 JSON 对象，或旧 transcript 反序列化失败。
+        TypeError: 旧 transcript 字段类型异常。
+        KeyError: 旧 transcript 必需字段缺失。
     """
 
-    try:
-        raw_text = json_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        print(
-            f"⚠ 工作区迁移: 跳过 {json_path.name}（读取失败：{exc}）",
-            file=sys.stderr,
-        )
-        return False
-
-    try:
-        payload: object = json.loads(raw_text)
-    except json.JSONDecodeError as exc:
-        print(
-            f"⚠ 工作区迁移: 跳过 {json_path.name}（JSON 解析失败：{exc}）",
-            file=sys.stderr,
-        )
-        return False
+    raw_text = json_path.read_text(encoding="utf-8")
+    payload: object = json.loads(raw_text)
     if not isinstance(payload, dict):
-        print(
-            f"⚠ 工作区迁移: 跳过 {json_path.name}（顶层不是对象）",
-            file=sys.stderr,
+        raise ValueError(
+            f"工作区迁移: {json_path.name} 顶层不是 JSON 对象，无法识别为旧 transcript schema"
         )
-        return False
 
     if _NEW_SCHEMA_KEY in payload:
         return False
     if _LEGACY_TURNS_KEY not in payload:
         return False
 
-    try:
-        runtime_transcript = ConversationTranscript.from_dict(payload)
-    except (ValueError, KeyError, TypeError) as exc:
-        print(
-            f"⚠ 工作区迁移: 跳过 {json_path.name}（旧 transcript 反序列化失败：{exc}）",
-            file=sys.stderr,
-        )
-        return False
+    runtime_transcript = ConversationTranscript.from_dict(payload)
 
     history_records = tuple(
         ConversationHistoryTurnRecord(
@@ -139,14 +125,7 @@ def _migrate_single_file(json_path: Path) -> bool:
     )
 
     new_text = json.dumps(archive.to_dict(), ensure_ascii=False, indent=2) + "\n"
-    try:
-        json_path.write_text(new_text, encoding="utf-8")
-    except OSError as exc:
-        print(
-            f"⚠ 工作区迁移: 跳过 {json_path.name}（写回失败：{exc}）",
-            file=sys.stderr,
-        )
-        return False
+    json_path.write_text(new_text, encoding="utf-8")
     return True
 
 

--- a/dayu/cli/workspace_migrations/host_store_rename_concurrency_lane.py
+++ b/dayu/cli/workspace_migrations/host_store_rename_concurrency_lane.py
@@ -18,6 +18,8 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
+from dayu.host.host_store import create_host_store_connection, write_transaction
+
 
 _OLD_KEY = "concurrency_lane"
 _NEW_KEY = "business_concurrency_lane"
@@ -38,29 +40,25 @@ def migrate_host_store_rename_concurrency_lane(host_db_path: Path) -> int:
             通常由 :func:`dayu.workspace_paths.build_host_store_default_path` 解析。
 
     Returns:
-        实际被改写的行数；数据库不存在、表不存在或没有旧 key 时返回 0。
+        实际被改写的行数；数据库不存在或表不存在时返回 0。
 
     Raises:
-        无：打开失败、SQL 异常由本函数吞掉并返回 0，避免阻塞 init 流程。
+        sqlite3.Error: 底层 SQLite 操作失败时由调用方决定如何处理；
+            不再吞错，由 ``apply_all_workspace_migrations`` 上抛 init 命令。
     """
 
     if not host_db_path.exists():
         return 0
 
+    conn = create_host_store_connection(host_db_path)
     try:
-        conn = sqlite3.connect(str(host_db_path))
-    except sqlite3.Error:
-        return 0
-
-    try:
-        conn.row_factory = sqlite3.Row
         if not _table_exists(conn, _TABLE_NAME):
             return 0
 
-        rewritten = 0
         rows = conn.execute(
             f"SELECT {_ID_COLUMN}, {_JSON_COLUMN} FROM {_TABLE_NAME}"  # noqa: S608
         ).fetchall()
+        pending_updates: list[tuple[str, str]] = []
         for row in rows:
             raw = row[_JSON_COLUMN]
             if not isinstance(raw, str) or not raw:
@@ -74,20 +72,15 @@ def migrate_host_store_rename_concurrency_lane(host_db_path: Path) -> int:
             if not _rename_key_in_place(payload):
                 continue
             new_text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
-            conn.execute(
+            pending_updates.append((new_text, row[_ID_COLUMN]))
+        if not pending_updates:
+            return 0
+        with write_transaction(conn):
+            conn.executemany(
                 f"UPDATE {_TABLE_NAME} SET {_JSON_COLUMN} = ? WHERE {_ID_COLUMN} = ?",  # noqa: S608
-                (new_text, row[_ID_COLUMN]),
+                pending_updates,
             )
-            rewritten += 1
-        if rewritten:
-            conn.commit()
-        return rewritten
-    except sqlite3.Error:
-        try:
-            conn.rollback()
-        except sqlite3.Error:
-            pass
-        return 0
+        return len(pending_updates)
     finally:
         conn.close()
 

--- a/dayu/cli/workspace_migrations/host_store_strip_max_output_tokens.py
+++ b/dayu/cli/workspace_migrations/host_store_strip_max_output_tokens.py
@@ -19,6 +19,8 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
+from dayu.host.host_store import create_host_store_connection, write_transaction
+
 
 _STRIP_KEY = "max_output_tokens"
 # 作为 JSON 文本里的"键"出现时必然带双引号；加引号短路才能避免误匹配。
@@ -36,29 +38,25 @@ def migrate_host_store_strip_max_output_tokens(host_db_path: Path) -> int:
             通常由 :func:`dayu.workspace_paths.build_host_store_default_path` 解析。
 
     Returns:
-        实际被改写的行数；数据库不存在、表不存在或没有该 key 时返回 0。
+        实际被改写的行数；数据库不存在或表不存在时返回 0。
 
     Raises:
-        无：打开失败、SQL 异常由本函数吞掉并返回 0，避免阻塞 init 流程。
+        sqlite3.Error: 底层 SQLite 操作失败时由调用方决定如何处理；
+            不再吞错，由 ``apply_all_workspace_migrations`` 上抛 init 命令。
     """
 
     if not host_db_path.exists():
         return 0
 
+    conn = create_host_store_connection(host_db_path)
     try:
-        conn = sqlite3.connect(str(host_db_path))
-    except sqlite3.Error:
-        return 0
-
-    try:
-        conn.row_factory = sqlite3.Row
         if not _table_exists(conn, _TABLE_NAME):
             return 0
 
-        rewritten = 0
         rows = conn.execute(
             f"SELECT {_ID_COLUMN}, {_JSON_COLUMN} FROM {_TABLE_NAME}"  # noqa: S608
         ).fetchall()
+        pending_updates: list[tuple[str, str]] = []
         for row in rows:
             raw = row[_JSON_COLUMN]
             if not isinstance(raw, str) or not raw:
@@ -72,20 +70,15 @@ def migrate_host_store_strip_max_output_tokens(host_db_path: Path) -> int:
             if not _strip_key_in_place(payload):
                 continue
             new_text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
-            conn.execute(
+            pending_updates.append((new_text, row[_ID_COLUMN]))
+        if not pending_updates:
+            return 0
+        with write_transaction(conn):
+            conn.executemany(
                 f"UPDATE {_TABLE_NAME} SET {_JSON_COLUMN} = ? WHERE {_ID_COLUMN} = ?",  # noqa: S608
-                (new_text, row[_ID_COLUMN]),
+                pending_updates,
             )
-            rewritten += 1
-        if rewritten:
-            conn.commit()
-        return rewritten
-    except sqlite3.Error:
-        try:
-            conn.rollback()
-        except sqlite3.Error:
-            pass
-        return 0
+        return len(pending_updates)
     finally:
         conn.close()
 

--- a/dayu/cli/workspace_migrations/run_json_write_chapter_lane.py
+++ b/dayu/cli/workspace_migrations/run_json_write_chapter_lane.py
@@ -7,11 +7,15 @@
 
 本迁移只做一件事：在 ``host_config.lane`` 缺少 ``write_chapter`` 时补 5；
 存在则一律尊重用户取值，绝不覆写。
+
+写入采用「写临时文件 + ``os.replace`` 原子替换」：在 init 持有 workspace
+advisory lock 的前提下额外抵御进程被强制终止时残留半截写入的边界情况。
 """
 
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -33,22 +37,17 @@ def migrate_run_json_add_write_chapter_lane(config_dir: Path) -> bool:
         True 表示实际改写了文件；False 表示无需变更或文件不存在。
 
     Raises:
-        无：文件缺失、解析失败或结构不符预期均安静跳过，由上层决定是否告警。
+        OSError: 读取或写入 ``run.json`` 失败时抛出，由 init 命令显式失败。
+        json.JSONDecodeError: ``run.json`` 既存但 JSON 解析失败；不再吞错，
+            由上层决定是否继续。
     """
 
     run_json_path = config_dir / _RUN_JSON_FILENAME
     if not run_json_path.exists():
         return False
 
-    try:
-        raw_text = run_json_path.read_text(encoding="utf-8")
-    except OSError:
-        return False
-
-    try:
-        payload: Any = json.loads(raw_text)
-    except json.JSONDecodeError:
-        return False
+    raw_text = run_json_path.read_text(encoding="utf-8")
+    payload: Any = json.loads(raw_text)
     if not isinstance(payload, dict):
         return False
 
@@ -65,5 +64,34 @@ def migrate_run_json_add_write_chapter_lane(config_dir: Path) -> bool:
 
     lane_section[_WRITE_CHAPTER_LANE] = _DEFAULT_WRITE_CHAPTER_CONCURRENCY
     new_text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-    run_json_path.write_text(new_text, encoding="utf-8")
+    _atomic_write_text(run_json_path, new_text)
     return True
+
+
+def _atomic_write_text(target_path: Path, content: str) -> None:
+    """使用临时文件 + ``os.replace`` 原子替换 ``target_path``。
+
+    Args:
+        target_path: 目标文件绝对路径。
+        content: 待写入文本。
+
+    Returns:
+        无。
+
+    Raises:
+        OSError: 写入或重命名失败时抛出。
+    """
+
+    temp_path = target_path.with_name(f".{target_path.name}.migrate.tmp")
+    try:
+        with open(temp_path, "w", encoding="utf-8") as fp:
+            fp.write(content)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.replace(temp_path, target_path)
+    finally:
+        # 仅清理悬挂临时文件；replace 成功后该路径已不存在，unlink 会 ENOENT。
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass

--- a/dayu/cli/workspace_migrations/runner.py
+++ b/dayu/cli/workspace_migrations/runner.py
@@ -7,6 +7,10 @@
 3. 在 :func:`apply_all_workspace_migrations` 里按顺序调用并打印结果。
 
 **不要**把规则写回 ``init.py``；也不要在此文件里做除"调度 + 汇报"以外的事。
+
+失败语义：任一迁移内部抛错（``OSError`` / ``sqlite3.Error`` / ``json.JSONDecodeError``
+等）将原样向上传播，由 ``dayu-cli init`` 命令显式失败。运行 ``init`` 时调用方
+负责持有 workspace advisory lock，确保不会有第二个 init 在同一目录上并发改动。
 """
 
 from __future__ import annotations
@@ -39,7 +43,9 @@ def apply_all_workspace_migrations(*, base_dir: Path, config_dir: Path) -> None:
         无。
 
     Raises:
-        无：单条迁移失败不应阻塞 init 主流程，异常由各迁移自行吞掉。
+        OSError: 文件 I/O 失败时由迁移函数原样抛出。
+        sqlite3.Error: SQLite 操作失败时由迁移函数原样抛出。
+        json.JSONDecodeError: JSON 解析失败时由迁移函数原样抛出。
     """
 
     if migrate_run_json_add_write_chapter_lane(config_dir):

--- a/dayu/host/host_store.py
+++ b/dayu/host/host_store.py
@@ -195,7 +195,7 @@ class HostStore:
         if conn is not None:
             return conn
 
-        conn = _create_connection(self._db_path)
+        conn = create_host_store_connection(self._db_path)
         Log.debug(
             _build_connection_debug_message(db_path=self._db_path, conn=conn),
             module=MODULE,
@@ -308,7 +308,7 @@ class HostStore:
             self._local.conn = None
 
 
-def _create_connection(db_path: Path) -> sqlite3.Connection:
+def create_host_store_connection(db_path: Path) -> sqlite3.Connection:
     """创建一个配置好的 SQLite 连接。
 
     Args:
@@ -444,7 +444,7 @@ def _require_table_columns(
         return
     missing_columns_text = ", ".join(missing_columns)
     raise RuntimeError(
-        "HostStore 检测到旧版 SQLite schema 与当前实现不兼容: "
-        f"table={table_name}, missing_columns=[{missing_columns_text}], db_path={db_path}. "
-        "当前项目默认不做数据库 schema 升级兼容，请删除该数据库后重建。"
+        "HostStore 检测到旧版 SQLite schema 与当前实现不兼容（"
+        f"table={table_name}, missing_columns=[{missing_columns_text}], db_path={db_path}），"
+        f"请删除 {db_path} 后重启（或运行 `dayu-cli init --reset` 完整重建工作区）。"
     )

--- a/tests/application/test_pending_turn_store_cross_process.py
+++ b/tests/application/test_pending_turn_store_cross_process.py
@@ -1,0 +1,197 @@
+"""PR-2 (#107) 遗留：``cleanup_stale_resuming`` 跨进程冒烟。
+
+PR-2 在 store 事务层完成了 fence token 强一致改造，回归测试覆盖到了
+**线程级双连接**（同一进程内 ``threading.Thread`` 共享 SQLite 文件）。
+真正的"两个 dayu 进程同 workspace 同 pending turn"场景需要等到 PR-5
+落地 advisory lock 之后再补跨进程冒烟，本测试就是这条遗留断言。
+
+测试结构：
+  * 主进程预置一条 pending turn 并完成首次 ``record_resume_attempt``
+    （持 lease ``A``）。
+  * 启动一个 ``subprocess.Popen`` worker，在另一进程内对同一个 SQLite 文件
+    打开第二把连接并执行 ``cleanup_stale_resuming``，模拟另一台 host 进程
+    抢占 stale RESUMING。
+  * 等 worker 干净退出后，主进程持旧 lease ``A`` 调用
+    ``release_resume_lease`` / ``rebind_source_run_id_for_resume`` /
+    ``record_resume_failure``，全部必须抛 ``LeaseExpiredError``。
+  * 反向路径：主进程重新 ``record_resume_attempt`` 拿到 lease ``B``；启动
+    第二个 worker 用主进程已经"过期"的 ``A`` lease 去触发 release/cleanup
+    必须 no-op，不会抢走 ``B`` 的合法 lease。
+
+不依赖外部 fixture：通过 ``subprocess.Popen`` 起 ``python -c '<inline>'`` 子
+进程，子进程在自身 ``sys.path`` 里 import 真实 dayu 模块，对同一个
+SQLite 文件做 ``cleanup_stale_resuming``；事件同步走 stdout 行（worker
+干完写一行 ``DONE``）。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from dayu.host.host_store import HostStore
+from dayu.host.lease import LeaseExpiredError
+from dayu.host.pending_turn_store import (
+    PendingConversationTurnState,
+    SQLitePendingConversationTurnStore,
+)
+
+
+def _build_worker_script(db_path: Path, pending_turn_id: str, expected_updated_at_iso: str) -> str:
+    """构造 worker 子进程要 ``python -c`` 执行的源码字符串。
+
+    Args:
+        db_path: 主进程 HostStore 落地的 SQLite 数据库文件路径。
+        pending_turn_id: 目标 pending turn ID。
+        expected_updated_at_iso: ``cleanup_stale_resuming`` 所需的 stale
+            判定时间戳，按 ``datetime.isoformat()`` 序列化。
+
+    Returns:
+        worker 子进程的 inline Python 源码。
+    """
+
+    return (
+        "import sys\n"
+        f"sys.path.insert(0, {str(Path.cwd())!r})\n"
+        "from datetime import datetime\n"
+        "from pathlib import Path\n"
+        "from dayu.host.host_store import HostStore\n"
+        "from dayu.host.pending_turn_store import SQLitePendingConversationTurnStore\n"
+        f"host_store = HostStore(Path({str(db_path)!r}))\n"
+        "host_store.initialize_schema()\n"
+        "store = SQLitePendingConversationTurnStore(host_store)\n"
+        "store.cleanup_stale_resuming(\n"
+        f"    {pending_turn_id!r},\n"
+        f"    expected_updated_at=datetime.fromisoformat({expected_updated_at_iso!r}),\n"
+        ")\n"
+        "print('DONE', flush=True)\n"
+    )
+
+
+def _run_worker(db_path: Path, pending_turn_id: str, expected_updated_at_iso: str) -> None:
+    """启动 worker 子进程并等待其完成。
+
+    Args:
+        db_path: SQLite 数据库路径。
+        pending_turn_id: 目标 pending turn ID。
+        expected_updated_at_iso: stale 判定时间戳的 ISO 序列化形式。
+
+    Returns:
+        无。
+
+    Raises:
+        AssertionError: worker 退出码非 0 或未输出 ``DONE`` 标记。
+    """
+
+    script = _build_worker_script(db_path, pending_turn_id, expected_updated_at_iso)
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, (
+        f"worker 退出码={completed.returncode}, stderr={completed.stderr}"
+    )
+    assert "DONE" in completed.stdout
+
+
+@pytest.mark.unit
+def test_cleanup_stale_resuming_cross_process_invalidates_lease(tmp_path: Path) -> None:
+    """跨进程：主进程持旧 lease，worker 进程 cleanup 后旧 lease 操作必抛 LeaseExpiredError。"""
+
+    db_path = tmp_path / ".host" / "dayu_host.db"
+    host_store = HostStore(db_path)
+    host_store.initialize_schema()
+
+    store = SQLitePendingConversationTurnStore(host_store)
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    a_lease = a_record.resume_lease_id or ""
+    assert a_lease
+
+    # 关闭主进程持有的连接，避免 SQLite 在不同进程间因 WAL shm 状态产生干扰。
+    host_store.close()
+
+    _run_worker(
+        db_path,
+        created.pending_turn_id,
+        a_record.updated_at.isoformat(),
+    )
+
+    # 主进程重新打开 store；旧 lease 走任一 fence token CAS 写路径都必须 LeaseExpiredError。
+    host_store = HostStore(db_path)
+    store = SQLitePendingConversationTurnStore(host_store)
+
+    with pytest.raises(LeaseExpiredError):
+        store.release_resume_lease(created.pending_turn_id, lease_id=a_lease)
+    with pytest.raises(LeaseExpiredError):
+        store.rebind_source_run_id_for_resume(
+            created.pending_turn_id,
+            new_source_run_id="run_a_late",
+            lease_id=a_lease,
+        )
+    with pytest.raises(LeaseExpiredError):
+        store.record_resume_failure(
+            created.pending_turn_id,
+            error_message="late",
+            lease_id=a_lease,
+        )
+
+
+@pytest.mark.unit
+def test_cleanup_stale_resuming_cross_process_does_not_steal_fresh_lease(tmp_path: Path) -> None:
+    """反向路径：主进程已重新 acquire 拿到新 lease，worker 用旧 stale 时间戳 cleanup 必须 no-op。"""
+
+    db_path = tmp_path / ".host" / "dayu_host.db"
+    host_store = HostStore(db_path)
+    host_store.initialize_schema()
+
+    store = SQLitePendingConversationTurnStore(host_store)
+    created = store.upsert_pending_turn(
+        session_id="s1",
+        scene_name="wechat",
+        user_text="问题",
+        source_run_id="run_1",
+        resumable=True,
+        state=PendingConversationTurnState.ACCEPTED_BY_HOST,
+    )
+    a_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    a_stale_snapshot_iso = a_record.updated_at.isoformat()
+
+    # 主线程内合法 release，再次 acquire 拿到 fresh lease。
+    store.release_resume_lease(
+        created.pending_turn_id, lease_id=a_record.resume_lease_id or ""
+    )
+    b_record = store.record_resume_attempt(created.pending_turn_id, max_attempts=5)
+    b_lease = b_record.resume_lease_id or ""
+    assert b_lease and b_lease != (a_record.resume_lease_id or "")
+
+    host_store.close()
+
+    # worker 用 a_record 的 stale 时间戳触发 cleanup：expected_updated_at 与
+    # 当前 b_record.updated_at 不一致 → cleanup 应识别为非 stale，no-op。
+    _run_worker(
+        db_path,
+        created.pending_turn_id,
+        a_stale_snapshot_iso,
+    )
+
+    # 主进程重开 store，B 的 fresh lease 仍然合法可用。
+    host_store = HostStore(db_path)
+    store = SQLitePendingConversationTurnStore(host_store)
+    released = store.release_resume_lease(
+        created.pending_turn_id, lease_id=b_lease
+    )
+    assert released is not None
+    assert released.state is PendingConversationTurnState.ACCEPTED_BY_HOST

--- a/tests/application/test_pending_turn_store_cross_process.py
+++ b/tests/application/test_pending_turn_store_cross_process.py
@@ -18,7 +18,7 @@ PR-2 在 store 事务层完成了 fence token 强一致改造，回归测试覆�
     第二个 worker 用主进程已经"过期"的 ``A`` lease 去触发 release/cleanup
     必须 no-op，不会抢走 ``B`` 的合法 lease。
 
-不依赖外部 fixture：通过 ``subprocess.Popen`` 起 ``python -c '<inline>'`` 子
+不依赖外部 fixture：通过 ``subprocess.run`` 起 ``python -c '<inline>'`` 子
 进程，子进程在自身 ``sys.path`` 里 import 真实 dayu 模块，对同一个
 SQLite 文件做 ``cleanup_stale_resuming``；事件同步走 stdout 行（worker
 干完写一行 ``DONE``）。
@@ -40,6 +40,12 @@ from dayu.host.pending_turn_store import (
 )
 
 
+# 用 ``__file__`` 反推项目根而不是 ``Path.cwd()``：CI / 运维从任意目录
+# 直接跑 ``pytest /abs/path/to/tests/...`` 时 cwd 不一定是项目根，子进程
+# inline 脚本必须显式 import dayu，所以把项目根钉在编译期已知的常量上。
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
 def _build_worker_script(db_path: Path, pending_turn_id: str, expected_updated_at_iso: str) -> str:
     """构造 worker 子进程要 ``python -c`` 执行的源码字符串。
 
@@ -55,7 +61,7 @@ def _build_worker_script(db_path: Path, pending_turn_id: str, expected_updated_a
 
     return (
         "import sys\n"
-        f"sys.path.insert(0, {str(Path.cwd())!r})\n"
+        f"sys.path.insert(0, {str(_PROJECT_ROOT)!r})\n"
         "from datetime import datetime\n"
         "from pathlib import Path\n"
         "from dayu.host.host_store import HostStore\n"

--- a/tests/cli/test_init_workspace_lock.py
+++ b/tests/cli/test_init_workspace_lock.py
@@ -1,0 +1,245 @@
+"""``dayu-cli init`` workspace 临界区互斥测试。
+
+本模块覆盖 PR-5 (#108) 引入的 workspace advisory lock：
+``_copy_config + _copy_assets + apply_all_workspace_migrations`` 整段必须由
+``StateDirSingleInstanceLock`` 独占持有，以避免双 ``dayu-cli init`` 进程在同一
+workspace 上并发改动 SQLite 与 ``run.json`` 时互相踩踏。
+
+测试不真正起子进程：直接复用 ``StateDirSingleInstanceLock`` 的真实文件锁
+（POSIX ``fcntl.flock`` / Windows ``msvcrt.locking``）模拟"另一进程已经持锁"，
+然后调用 ``dayu.cli.commands.init`` 入口，断言：
+
+1. 检测到锁竞争时返回非 0 退出码；
+2. 不会进入 ``_copy_config`` / ``apply_all_workspace_migrations`` 临界区；
+3. 锁释放后再次 init 可以正常进入临界区。
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dayu.cli.commands import init as init_module
+from dayu.state_dir_lock import StateDirSingleInstanceLock
+
+
+@pytest.fixture()
+def workspace_root(tmp_path: Path) -> Path:
+    """构造一个干净的 workspace 根目录。"""
+
+    root = tmp_path / "workspace"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _build_args(workspace_root: Path) -> Namespace:
+    """构造 ``run_init_command`` 所需的 argparse Namespace。
+
+    Args:
+        workspace_root: 工作区根目录。
+
+    Returns:
+        Namespace：模拟 ``dayu-cli init -d <workspace>`` 的解析结果。
+    """
+
+    return Namespace(base=str(workspace_root), overwrite=False, reset=False)
+
+
+def _build_reset_args(workspace_root: Path) -> Namespace:
+    """构造 ``dayu-cli init --reset`` 的 Namespace。"""
+
+    return Namespace(base=str(workspace_root), overwrite=False, reset=True)
+
+
+@pytest.mark.unit
+def test_init_aborts_when_workspace_lock_already_held(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """另一进程持有 workspace lock 时 init 必须立即放弃。"""
+
+    # 临界区不可被进入。任一函数被调用即说明锁互斥失效。
+    def _critical_region_must_not_run(*_args: Any, **_kwargs: Any) -> Path:
+        raise AssertionError("锁竞争失败：critical region 在锁被占用时仍被进入")
+
+    monkeypatch.setattr(init_module, "_copy_config", _critical_region_must_not_run)
+    monkeypatch.setattr(init_module, "_copy_assets", _critical_region_must_not_run)
+    monkeypatch.setattr(
+        init_module,
+        "apply_all_workspace_migrations",
+        _critical_region_must_not_run,
+    )
+
+    holder = StateDirSingleInstanceLock(
+        state_dir=workspace_root,
+        lock_file_name=init_module._INIT_WORKSPACE_LOCK_FILE_NAME,
+        lock_name=init_module._INIT_WORKSPACE_LOCK_NAME,
+    )
+    holder.acquire()
+    try:
+        exit_code = init_module.run_init_command(_build_args(workspace_root))
+    finally:
+        holder.release()
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "dayu workspace init" in captured.out
+    assert "另一个 dayu-cli init" in captured.out
+
+
+@pytest.mark.unit
+def test_init_proceeds_after_lock_released(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """先竞争失败、再成功获得锁时，init 必须能正常进入临界区。"""
+
+    entered: dict[str, bool] = {"copy_config": False, "migrations": False}
+
+    config_dir = workspace_root / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    assets_dir = workspace_root / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    def _fake_copy_config(_base_dir: Path, *, overwrite: bool) -> Path:
+        del overwrite
+        entered["copy_config"] = True
+        return config_dir
+
+    def _fake_copy_assets(_base_dir: Path, *, overwrite: bool) -> Path:
+        del overwrite
+        return assets_dir
+
+    def _fake_migrations(*, base_dir: Path, config_dir: Path) -> None:
+        del base_dir, config_dir
+        entered["migrations"] = True
+
+    monkeypatch.setattr(init_module, "_copy_config", _fake_copy_config)
+    monkeypatch.setattr(init_module, "_copy_assets", _fake_copy_assets)
+    monkeypatch.setattr(init_module, "apply_all_workspace_migrations", _fake_migrations)
+
+    # 临界区已经被记录后，立即让 _prompt_provider_selection 抛 SystemExit
+    # 让 init 早退，避免后续 prompt 交互。
+    def _short_circuit() -> str:
+        raise SystemExit(0)
+
+    monkeypatch.setattr(init_module, "_prompt_provider_selection", _short_circuit)
+
+    with pytest.raises(SystemExit):
+        init_module.run_init_command(_build_args(workspace_root))
+
+    assert entered["copy_config"] is True
+    assert entered["migrations"] is True
+
+    # 锁文件应该已经被释放：再起一把 lock 不应抛 RuntimeError。
+    second_holder = StateDirSingleInstanceLock(
+        state_dir=workspace_root,
+        lock_file_name=init_module._INIT_WORKSPACE_LOCK_FILE_NAME,
+        lock_name=init_module._INIT_WORKSPACE_LOCK_NAME,
+    )
+    second_holder.acquire()
+    second_holder.release()
+
+
+@pytest.mark.unit
+def test_init_reset_does_not_run_when_lock_already_held(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """锁竞争失败时 ``--reset`` 删除目标的动作必须 **不** 被执行。
+
+    ``--reset`` 删除的 ``.dayu/`` / ``config/`` / ``assets/`` 与临界区操作
+    的是同一批 workspace 产物。如果 reset 在锁外发生，另一进程仍会在
+    "我们删 → 我们复制" 的中间窗口冲进来踩踏，因此 reset 必须落在锁内。
+    """
+
+    # 预置工作区里几个 reset 目标，让删除动作可观测
+    (workspace_root / "config").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "config" / "marker.txt").write_text("alive", encoding="utf-8")
+    (workspace_root / "assets").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "assets" / "marker.txt").write_text("alive", encoding="utf-8")
+
+    # 用户已确认 reset
+    monkeypatch.setattr(init_module, "_confirm_workspace_reset", lambda _base: True)
+
+    def _critical_region_must_not_run(*_args: Any, **_kwargs: Any) -> Path:
+        raise AssertionError("锁竞争失败：critical region 在锁被占用时仍被进入")
+
+    monkeypatch.setattr(init_module, "_copy_config", _critical_region_must_not_run)
+    monkeypatch.setattr(init_module, "_copy_assets", _critical_region_must_not_run)
+    monkeypatch.setattr(
+        init_module,
+        "apply_all_workspace_migrations",
+        _critical_region_must_not_run,
+    )
+
+    holder = StateDirSingleInstanceLock(
+        state_dir=workspace_root,
+        lock_file_name=init_module._INIT_WORKSPACE_LOCK_FILE_NAME,
+        lock_name=init_module._INIT_WORKSPACE_LOCK_NAME,
+    )
+    holder.acquire()
+    try:
+        exit_code = init_module.run_init_command(_build_reset_args(workspace_root))
+    finally:
+        holder.release()
+
+    assert exit_code == 1
+    # reset 目标必须仍然在原位 —— 锁外没有被偷偷删掉
+    assert (workspace_root / "config" / "marker.txt").read_text(encoding="utf-8") == "alive"
+    assert (workspace_root / "assets" / "marker.txt").read_text(encoding="utf-8") == "alive"
+    captured = capsys.readouterr()
+    assert "另一个 dayu-cli init" in captured.out
+
+
+@pytest.mark.unit
+def test_init_reset_runs_inside_lock_when_acquired(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """成功拿到锁后，``--reset`` 删除动作必须在锁内执行（critical region 之前）。"""
+
+    (workspace_root / "config").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "config" / "marker.txt").write_text("alive", encoding="utf-8")
+    (workspace_root / "assets").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "assets" / "marker.txt").write_text("alive", encoding="utf-8")
+
+    monkeypatch.setattr(init_module, "_confirm_workspace_reset", lambda _base: True)
+
+    # 临界区内：要求 reset 先发生（config / assets 已被删除），否则 _copy_config
+    # 会看到旧的 marker.txt 仍在 → 立即 fail。
+    def _fake_copy_config(base_dir: Path, *, overwrite: bool) -> Path:
+        del overwrite
+        # reset 必须已经把旧 config 清掉
+        assert not (base_dir / "config" / "marker.txt").exists(), (
+            "reset 应该在 _copy_config 之前在锁内执行，但旧 marker 仍在"
+        )
+        config_dir = base_dir / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        return config_dir
+
+    def _fake_copy_assets(base_dir: Path, *, overwrite: bool) -> Path:
+        del overwrite
+        assets_dir = base_dir / "assets"
+        assets_dir.mkdir(parents=True, exist_ok=True)
+        return assets_dir
+
+    def _fake_migrations(*, base_dir: Path, config_dir: Path) -> None:
+        del base_dir, config_dir
+
+    monkeypatch.setattr(init_module, "_copy_config", _fake_copy_config)
+    monkeypatch.setattr(init_module, "_copy_assets", _fake_copy_assets)
+    monkeypatch.setattr(init_module, "apply_all_workspace_migrations", _fake_migrations)
+
+    def _short_circuit() -> str:
+        raise SystemExit(0)
+
+    monkeypatch.setattr(init_module, "_prompt_provider_selection", _short_circuit)
+
+    with pytest.raises(SystemExit):
+        init_module.run_init_command(_build_reset_args(workspace_root))

--- a/tests/cli/workspace_migrations/test_conversation_archive_init.py
+++ b/tests/cli/workspace_migrations/test_conversation_archive_init.py
@@ -1,12 +1,13 @@
 """conversation_archive_init 迁移测试。
 
-覆盖 plan 用例 24-28：
+覆盖：
 
 - 旧 transcript 全量投影到 history_archive，原地写回原文件路径
 - 单文件每条 ``assistant_reasoning == ""``、其余字段全量保留
 - 二次执行幂等
 - 旧目录不存在 → no-op
-- 单文件 JSON 损坏 → warning 跳过、其余文件继续
+- 单文件 JSON 损坏 → 显式上抛 ``json.JSONDecodeError``（fail-fast 语义）
+- 旧 transcript 反序列化失败 → 显式上抛 ValueError/TypeError/KeyError
 """
 
 from __future__ import annotations
@@ -125,26 +126,38 @@ def test_migration_returns_zero_when_target_dir_missing(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_migration_skips_corrupted_file_and_continues(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """单文件 JSON 损坏只 warning 跳过，不阻塞同目录其他文件。"""
+def test_migration_raises_on_corrupted_file(tmp_path: Path) -> None:
+    """单文件 JSON 损坏必须显式上抛 ``json.JSONDecodeError``，不再吞错继续。
 
-    good_file = _seed_legacy_file(tmp_path, "sess_legacy_good")
-    bad_file = good_file.parent / "sess_legacy_bad.json"
+    新语义要求 ``apply_all_workspace_migrations`` fail-fast：损坏文件
+    意味着工作区状态不一致，必须显式让 ``dayu-cli init`` 退出非 0
+    暴露给运维，而不是 stderr warning 后假装成功。
+    """
+
+    _seed_legacy_file(tmp_path, "sess_legacy_good")
+    target_dir = tmp_path / CONVERSATION_STORE_RELATIVE_DIR
+    bad_file = target_dir / "sess_legacy_bad.json"
     bad_file.write_text("{ this is not valid json", encoding="utf-8")
 
-    rewritten = migrate_conversation_archive_init(tmp_path)
-    assert rewritten == 1
+    with pytest.raises(json.JSONDecodeError):
+        migrate_conversation_archive_init(tmp_path)
 
-    captured = capsys.readouterr()
-    assert "sess_legacy_bad" in captured.err
 
-    # 好文件成功升级
-    good_payload = json.loads(good_file.read_text(encoding="utf-8"))
-    assert "runtime_transcript" in good_payload
-    # 损坏文件保持原样
-    assert bad_file.read_text(encoding="utf-8") == "{ this is not valid json"
+@pytest.mark.unit
+def test_migration_raises_on_legacy_deserialize_failure(tmp_path: Path) -> None:
+    """旧 transcript 反序列化失败时必须显式上抛，不再 warning 跳过。"""
+
+    target_dir = tmp_path / CONVERSATION_STORE_RELATIVE_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    # 顶层有 ``turns`` 但字段类型不对，应当触发 ConversationTranscript.from_dict 抛错
+    bad_file = target_dir / "sess_bad_struct.json"
+    bad_file.write_text(
+        json.dumps({"turns": "not a list"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    with pytest.raises((ValueError, KeyError, TypeError)):
+        migrate_conversation_archive_init(tmp_path)
 
 
 @pytest.mark.unit

--- a/tests/cli/workspace_migrations/test_host_store_rename_concurrency_lane.py
+++ b/tests/cli/workspace_migrations/test_host_store_rename_concurrency_lane.py
@@ -188,3 +188,30 @@ def test_migration_drops_old_key_when_new_key_already_exists(tmp_path: Path) -> 
     new_payload = json.loads(_read_row(db_path, "p1"))
     assert new_payload["host_policy"].get("concurrency_lane") is None
     assert new_payload["host_policy"]["business_concurrency_lane"] == "NEW"
+
+
+@pytest.mark.unit
+def test_migration_propagates_sqlite_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """底层 SQLite 失败时显式上抛，不再吞错返回 0。
+
+    通过把 ``create_host_store_connection`` 替换成抛 ``sqlite3.OperationalError``
+    的 stub 来构造打开数据库失败的边界。新语义要求 init 命令显式失败而非
+    静默继续，避免旧版本"返回 0 装作什么都没发生"导致 host_store 卡在
+    旧 schema 还自称迁移成功。
+    """
+
+    db_path = tmp_path / "dayu_host.db"
+    _build_pending_turns_db(
+        db_path,
+        [("p1", json.dumps({"host_policy": {"concurrency_lane": "write_chapter"}}))],
+    )
+
+    def boom(_path: Path) -> sqlite3.Connection:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    import dayu.cli.workspace_migrations.host_store_rename_concurrency_lane as module
+
+    monkeypatch.setattr(module, "create_host_store_connection", boom)
+
+    with pytest.raises(sqlite3.OperationalError):
+        migrate_host_store_rename_concurrency_lane(db_path)

--- a/tests/cli/workspace_migrations/test_host_store_strip_max_output_tokens.py
+++ b/tests/cli/workspace_migrations/test_host_store_strip_max_output_tokens.py
@@ -149,3 +149,24 @@ def test_migration_invalid_json_is_skipped(tmp_path: Path) -> None:
     good_payload = json.loads(_read_row(db_path, "p_good"))
     assert "max_output_tokens" not in good_payload["agent_create_args"]
     assert good_payload["agent_create_args"]["model_name"] == "m"
+
+
+@pytest.mark.unit
+def test_migration_propagates_sqlite_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """底层 SQLite 失败时显式上抛，不再吞错返回 0。"""
+
+    db_path = tmp_path / "dayu_host.db"
+    _build_pending_turns_db(
+        db_path,
+        [("p1", json.dumps({"agent_create_args": {"max_output_tokens": 1024}}))],
+    )
+
+    def boom(_path: Path) -> sqlite3.Connection:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    import dayu.cli.workspace_migrations.host_store_strip_max_output_tokens as module
+
+    monkeypatch.setattr(module, "create_host_store_connection", boom)
+
+    with pytest.raises(sqlite3.OperationalError):
+        migrate_host_store_strip_max_output_tokens(db_path)

--- a/tests/cli/workspace_migrations/test_run_json_write_chapter_lane.py
+++ b/tests/cli/workspace_migrations/test_run_json_write_chapter_lane.py
@@ -61,13 +61,32 @@ def test_migrate_run_json_missing_file_returns_false(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_migrate_run_json_invalid_json_returns_false(tmp_path: Path) -> None:
-    """解析失败时返回 False 不抛异常。"""
+def test_migrate_run_json_invalid_json_raises(tmp_path: Path) -> None:
+    """解析失败时显式抛 ``json.JSONDecodeError``，不再吞错返回 False。"""
 
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     (config_dir / "run.json").write_text("{not json", encoding="utf-8")
-    assert migrate_run_json_add_write_chapter_lane(config_dir) is False
+    with pytest.raises(json.JSONDecodeError):
+        migrate_run_json_add_write_chapter_lane(config_dir)
+
+
+@pytest.mark.unit
+def test_migrate_run_json_writes_atomically(tmp_path: Path) -> None:
+    """临时文件不应残留；最终文件即为目标 run.json。"""
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    run_json = config_dir / "run.json"
+    run_json.write_text(
+        json.dumps({"host_config": {"lane": {"llm_api": 8}}}),
+        encoding="utf-8",
+    )
+
+    assert migrate_run_json_add_write_chapter_lane(config_dir) is True
+    # 原子写入完成后，目录里只有 run.json，不应残留临时文件。
+    children = sorted(p.name for p in config_dir.iterdir())
+    assert children == ["run.json"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- 给 `dayu-cli init` 临界区套上 `StateDirSingleInstanceLock(.dayu_init.lock)`，把 `--reset` 删除目标、配置/assets 复制、workspace 迁移整段串行化，杜绝双 init 并发在同一 workspace 上互相踩踏 SQLite 写事务、`run.json` 原子替换或 config 目录复制。
- workspace migrations 全面 fail-fast：三个 SQLite 迁移复用 HostStore 真源连接（WAL / `busy_timeout` / `BEGIN IMMEDIATE`），不再吞 `sqlite3.Error`；`run.json` 改原子写；`conversation_archive_init` 不再 stderr warning 跳过损坏文件，所有异常透传 runner → `dayu-cli init`。
- HostStore schema 不兼容时的 `RuntimeError` 直接携带 `table` / `missing_columns` / `db_path`，并引导用户优先删 db 文件、兜底再走 `init --reset`，把破坏面降到最小。
- PR-2 (#107) 遗留 `cleanup_stale_resuming` 跨进程冒烟在本 PR 顺手补齐（subprocess.Popen 起独立 worker，验证 fence token 在跨进程下同样阻断 stale lease）。

## Test plan

- [x] `pytest tests/`：4914 passed, 6 skipped
- [x] `pyright`：受影响文件 0 errors / 0 warnings
- [x] `pytest tests/cli/test_init_workspace_lock.py`：双 init 锁竞争 + reset 锁内执行 4 个用例全绿
- [x] `pytest tests/cli/workspace_migrations/`：含三条迁移 fail-fast 与 conversation_archive_init 损坏文件上抛新语义
- [x] `pytest tests/application/test_pending_turn_store_cross_process.py`：跨进程冒烟通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)