### PR TITLE
feat(write_pipeline): 章节内取消 fast-path + cancel-induced barrier 映射 (#114)

### DIFF
--- a/dayu/engine/README.md
+++ b/dayu/engine/README.md
@@ -116,6 +116,7 @@ class AsyncRunner(Protocol):
 - 取消信号不是只在 iteration 首尾观察；Runner 必须在 `session.post(...)` 建连等待、`response.json()` / `response.text()` 读取、429/5xx 重试 sleep，以及 SSE 流的下一块等待期间协作式响应取消
 - 取消一旦命中，上层看到的稳定事实是抛出 `dayu.contracts.cancellation.CancelledError`；不能把这类路径降级成 `error_event`、普通超时重试或吞掉后继续产出 `final_answer`
 - Runner 为取消观察临时注册到 `CancellationToken` 的回调必须在本轮调用结束后注销；复用同一 token 的多轮调用不允许累积历史 loop/future 闭包
+- `await_or_cancel` 在等待业务 awaitable 时，对内层抛出的 `RuntimeError` 走双门控收口：仅当 `cancellation_token` 已取消，且错误文本严格匹配 `"cannot schedule new futures after shutdown"` 时（双 Ctrl-C 后 asyncio 默认 executor shutdown，DNS `getaddrinfo` 等路径仍 `executor.submit` 撞上的固定异常），才将其映射成 `CancelledError` 并以单行 warn 收口；其余情形原样上抛，禁止误吞业务异常
 
 历史残留实现：
 - `AsyncCliRunner`：已禁用，仅保留源码以便迁移旧实现，不允许再通过配置或 Host 主链路使用；已从 `dayu.engine` 包级公共导出移除，测试等内部使用方须通过 `dayu.engine.async_cli_runner` 直接导入

--- a/dayu/engine/cancellation.py
+++ b/dayu/engine/cancellation.py
@@ -12,6 +12,13 @@ from dayu.log import Log
 
 MODULE = "ENGINE.CANCELLATION"
 
+# 双 Ctrl-C 收口：CPython asyncio 在默认 executor shutdown 后再
+# ``executor.submit``（典型路径：DNS ``getaddrinfo``）抛出的 RuntimeError
+# 错误文本是 ``RuntimeError: cannot schedule new futures after shutdown``，
+# 即 ``str(exc)`` 严格等于下面常量。用全等匹配而非子串匹配，避免任何含此
+# 短语但根因不同的 RuntimeError 在取消窗口期被误折叠成 CancelledError。
+_EXECUTOR_SHUTDOWN_RUNTIME_ERROR_MESSAGE = "cannot schedule new futures after shutdown"
+
 _AwaitableResult = TypeVar("_AwaitableResult")
 
 
@@ -123,7 +130,25 @@ async def await_or_cancel(
                 module=log_module,
             )
             raise EngineCancelledError(f"operation cancelled: {operation_name}")
-        return await task
+        try:
+            return await task
+        except RuntimeError as exc:
+            # 双 Ctrl-C 收口：第二次 SIGINT 后 asyncio 默认 executor shutdown，
+            # DNS getaddrinfo 等路径仍 ``executor.submit`` → 撞上
+            # ``RuntimeError: cannot schedule new futures after shutdown``。
+            # 双门控（token 已取消 + 错误文本严格全等）下转 CancelledError，
+            # 单行警告收口；其它情形原样上抛，避免误吞业务异常。
+            if (
+                cancellation_token is not None
+                and cancellation_token.is_cancelled()
+                and str(exc) == _EXECUTOR_SHUTDOWN_RUNTIME_ERROR_MESSAGE
+            ):
+                Log.warn(
+                    f"{log_prefix} 取消窗口期 executor 已关停: {operation_name}",
+                    module=log_module,
+                )
+                raise EngineCancelledError(f"operation cancelled: {operation_name}") from exc
+            raise
     except asyncio.CancelledError:
         await cancel_task_and_wait(task)
         raise

--- a/dayu/services/internal/write_pipeline/pipeline.py
+++ b/dayu/services/internal/write_pipeline/pipeline.py
@@ -24,7 +24,12 @@ except ImportError:  # pragma: no cover - Windows 不提供 fcntl
 
 from dayu.contracts.cancellation import CancelledError, CancellationToken
 from dayu.host import HostExecutorProtocol
-from dayu.host.protocols import HostGovernanceProtocol
+from dayu.host.protocols import (
+    HostGovernanceProtocol,
+    SessionClearingError,
+    SessionClosedError,
+    SessionWriteBlockedError,
+)
 from dayu.execution.options import ExecutionOptions, ResolvedExecutionOptions
 from dayu.log import Log
 from dayu.services.concurrency_lanes import LANE_WRITE_CHAPTER
@@ -94,6 +99,17 @@ MODULE = "APP.WRITE_PIPELINE"
 _INFER_COMPANY_META_EXCLUDED_FIELDS = frozenset({"company_id"})
 
 
+# Cancel-induced session barrier 白名单：仅这两个子类会在"cancel_run_and_settle
+# 触发后下一次 register_run / scene 启动"路径上抛，且语义等价于"运行已被取消"，
+# 可在外层 token 已置位的双门控下映射成 CancelledError。
+# SessionClearingFailedError 是持久锁定故障态、需人工恢复，刻意排除：即使
+# 外层 token 已取消也原样上抛，避免把 host 侧 actionable 故障掩盖成普通取消。
+_CANCEL_INDUCED_BARRIERS: tuple[type[SessionWriteBlockedError], ...] = (
+    SessionClosedError,
+    SessionClearingError,
+)
+
+
 class _HostScenePromptContractExecutor:
     """适配 ``Host`` 与 ``ScenePromptContractExecutorProtocol`` 的薄壳。
 
@@ -102,13 +118,60 @@ class _HostScenePromptContractExecutor:
     避免在 helper 中泄漏 ``Host`` 类型，也避免回退到无历史的
     ``run_agent_and_wait``——所有 scene 调用都通过 replayable 入口拿到
     ``ReplayHandle``，统一了 helper 内的两条路径。
+
+    取消语义（issue #114）：
+
+    - 调用前一次 ``raise_if_cancelled`` 作为 fast path：仅收口"进入本方法
+      时 token 已置位"这一种情况——典型场景是上一次 LLM 调用返回到本次
+      调用入口之间，外层 token 已被 ``ProcessShutdownCoordinator.
+      settle_active_runs`` 置位。命中即抛 ``CancelledError``，不发起 host
+      调用。**此检查并不能关闭** "preflight 通过 → host 内部 ``register_run``
+      注册 child run 之间" 的 race 窗口（见下）。
+    - 仅捕获 cancel-induced 的 ``SessionClosedError`` /
+      ``SessionClearingError`` 子类（白名单见 ``_CANCEL_INDUCED_BARRIERS``）；
+      在外层 token 已置位的双门控下映射成 ``CancelledError``，避免
+      pipeline fallback 路径把"取消导致的 session 关闭"误判成普通失败、
+      产出 fallback ``chapter.md``。``SessionClearingFailedError`` 是持久
+      锁定故障态、需人工恢复，**不**进白名单——即便外层 token 已取消也
+      原样上抛，避免把 host 侧 actionable 故障掩盖成普通用户取消。
+
+    已知未关闭的 race 窗口（issue #114 后续工作，**不在本 PR 范围**）：
+
+    ``ProcessShutdownCoordinator.settle_active_runs`` 在开始 settle 前对
+    ``Host.list_active_run_ids_for_current_owner()`` 做一次 owner snapshot；
+    每个 child LLM 调用在 ``HostExecutor._start_run`` 内部独立 ``register_run``
+    并拿到自己的全新 ``CancellationToken``，与外层 Service 层 token 之间
+    **没有桥接**。若 SIGINT 落在"本方法 ``_check_cancellation`` 已通过 →
+    host 内部 ``register_run`` 完成"之间，新登记的 child run 不在 settle
+    snapshot 内、也无人会对它调 ``cancel_run_and_settle``，本次 LLM 调用
+    会跑到自然返回（audit/repair 等可能继续追下一次）。彻底关闭该窗口
+    需要 Host 侧把 Service 层外层 token 桥接到每个 child run 的 token
+    （或在 ``register_run`` 入口与外层 token 联动），属 Host 改造，
+    不在本 PR 引入。
+
+    本 executor 也**不**在 await 边界对 host 子任务做强制取消：
+    若改用 ``task.cancel()`` 强制注入 ``asyncio.CancelledError``，会跳过
+    host 的 cancelled 终态分支留下孤儿 active run，并掩盖 host 真实异常
+    （含 ``SessionClearingFailedError`` 这类 actionable 故障）。
+    ``ProcessShutdownCoordinator.settle_active_runs`` 通过
+    ``cancel_run_and_settle`` → ``request_cancel`` → ``CancellationBridge``
+    触达 child run token 才是 settle in-flight child run 的真源，会沿
+    协程栈抛 ``dayu.contracts.cancellation.CancelledError``，进而被 host
+    的 ``_settle_agent_cancelled`` / ``_finalize_cancelled`` 正常收口。
     """
 
-    def __init__(self, *, host_executor: HostExecutorProtocol) -> None:
+    def __init__(
+        self,
+        *,
+        host_executor: HostExecutorProtocol,
+        cancellation_token: CancellationToken | None = None,
+    ) -> None:
         """初始化适配器。
 
         Args:
             host_executor: 已组装好的 Host 执行入口。
+            cancellation_token: 协作式取消令牌；为 ``None`` 时退化为不做
+                LLM 入口自查与 cancel-induced 异常映射，行为与旧版一致。
 
         Returns:
             无。
@@ -118,6 +181,65 @@ class _HostScenePromptContractExecutor:
         """
 
         self._host_executor = host_executor
+        self._cancellation_token = cancellation_token
+
+    def _check_cancellation(self) -> None:
+        """LLM 调用入口 fast path checkpoint。
+
+        仅检查"进入本方法时 token 是否已置位"——命中即抛，不发起 host 调用。
+        **不能**关闭"本检查通过 → host 内部 ``register_run`` 之间"的 race
+        窗口（详见类 docstring）。
+
+        Args:
+            无。
+
+        Returns:
+            无。
+
+        Raises:
+            CancelledError: ``cancellation_token`` 已触发时抛出。
+        """
+
+        token = self._cancellation_token
+        if token is not None:
+            token.raise_if_cancelled()
+
+    def _maybe_map_cancel_induced_barrier(
+        self, exc: SessionWriteBlockedError
+    ) -> CancelledError | None:
+        """将 cancel-induced session barrier 异常映射成 ``CancelledError``。
+
+        当 ``cancel_run_and_settle`` 触发 session 关闭后，下一次
+        ``register_run`` 入口可能撞上 ``SessionClosedError`` /
+        ``SessionClearingError``；这些异常本身不是 ``CancelledError``，若沿
+        调用栈传到 pipeline fallback 会被当作普通失败、产出 fallback
+        ``chapter.md``。本方法在 token 已取消的双门控下、仅针对白名单
+        子类把这些异常折叠成 ``CancelledError``。
+
+        ``SessionClearingFailedError`` 是 host 持久锁定故障态、需人工恢复，
+        不进白名单：本方法对其返回 ``None``，由调用方原样上抛，保留
+        actionable 信号。
+
+        Args:
+            exc: 捕获到的 ``SessionWriteBlockedError`` 子类异常实例。
+
+        Returns:
+            映射后的 ``CancelledError`` 实例（保留原异常作 ``__cause__``）；
+            若 token 未置位、或异常类型不在白名单内，则返回 ``None``，由
+            调用方原样上抛。
+
+        Raises:
+            无。
+        """
+
+        token = self._cancellation_token
+        if token is None or not token.is_cancelled():
+            return None
+        if not isinstance(exc, _CANCEL_INDUCED_BARRIERS):
+            return None
+        cancelled = CancelledError("操作已被取消")
+        cancelled.__cause__ = exc
+        return cancelled
 
     async def run_replayable(
         self,
@@ -132,10 +254,20 @@ class _HostScenePromptContractExecutor:
             ``(AppResult, ReplayHandle)`` 二元组。
 
         Raises:
-            无。
+            CancelledError: 调用前 token 已取消，或 cancel-induced 白名单
+                barrier 异常被双门控映射后抛出。
         """
 
-        return await self._host_executor.run_agent_and_wait_replayable(execution_contract)
+        self._check_cancellation()
+        try:
+            return await self._host_executor.run_agent_and_wait_replayable(
+                execution_contract
+            )
+        except SessionWriteBlockedError as exc:
+            mapped = self._maybe_map_cancel_induced_barrier(exc)
+            if mapped is not None:
+                raise mapped from exc
+            raise
 
     async def replay(
         self,
@@ -152,10 +284,20 @@ class _HostScenePromptContractExecutor:
             ``(AppResult, ReplayHandle)`` 二元组；新句柄可继续追加 replay。
 
         Raises:
-            无。
+            CancelledError: 调用前 token 已取消，或 cancel-induced 白名单
+                barrier 异常被双门控映射后抛出。
         """
 
-        return await self._host_executor.replay_agent_and_wait(handle, execution_contract)
+        self._check_cancellation()
+        try:
+            return await self._host_executor.replay_agent_and_wait(
+                handle, execution_contract
+            )
+        except SessionWriteBlockedError as exc:
+            mapped = self._maybe_map_cancel_induced_barrier(exc)
+            if mapped is not None:
+                raise mapped from exc
+            raise
 
     def discard(self, handle: ReplayHandle) -> None:
         """释放未消费的 replay 句柄；转交给 ``Host.discard_replay_state``。
@@ -313,7 +455,10 @@ class WritePipelineRunner:
         )
         self._prompt_runner = ScenePromptRunner(
             preparer=self._preparer,
-            contract_executor=_HostScenePromptContractExecutor(host_executor=host_executor),
+            contract_executor=_HostScenePromptContractExecutor(
+                host_executor=host_executor,
+                cancellation_token=cancellation_token,
+            ),
             write_config=write_config,
         )
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -463,6 +463,9 @@ Fins 相关改动时，至少同步更新：
 - `test_conversation_store.py`
 - `test_conversation_memory.py`
 - `test_write_pipeline.py`
+- `test_write_pipeline_cancellation.py`
+- `test_write_pipeline_drain_settle.py`
+- `test_await_or_cancel_shutdown.py`
 - `test_report_assembler.py`
 - `test_execution_summary_builder.py`
 

--- a/tests/engine/test_await_or_cancel_shutdown.py
+++ b/tests/engine/test_await_or_cancel_shutdown.py
@@ -1,0 +1,130 @@
+"""``await_or_cancel`` 双 Ctrl-C 双门控收口测试（issue #114 Phase B）。
+
+第二次 SIGINT 后 asyncio 默认 executor shutdown，DNS ``getaddrinfo`` 等路径
+仍走 ``executor.submit`` → 撞 ``RuntimeError: cannot schedule new futures after
+shutdown``。``await_or_cancel`` 在双门控（token 已取消 + 错误文本严格匹配）
+下把该 RuntimeError 转 ``CancelledError``，其他情形原样上抛。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dayu.contracts.cancellation import CancelledError, CancellationToken
+from dayu.engine.cancellation import await_or_cancel
+
+
+def _noop_check() -> None:
+    """raise_if_cancelled 桩：始终通过。"""
+
+
+async def _raise_runtime_error(message: str) -> None:
+    """构造一个抛出指定 RuntimeError 的协程。"""
+
+    raise RuntimeError(message)
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_mapped_when_token_cancelled_and_message_matches() -> None:
+    """token 已取消 + 错误文本严格匹配 → 转 CancelledError。"""
+
+    token = CancellationToken()
+    token.cancel()
+    waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    waiter.set_result(None)
+
+    # 让 cancellation_waiter 先 done，但因为 token 已取消会先走 cancel 路径，
+    # 故这里不用 waiter 通道——把 waiter 设为 pending，让 task 先抛错。
+    pending_waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    with pytest.raises(CancelledError) as exc_info:
+        await await_or_cancel(
+            _raise_runtime_error("cannot schedule new futures after shutdown"),
+            operation_name="dns_lookup",
+            cancellation_waiter=pending_waiter,
+            cancellation_token=token,
+            raise_if_cancelled=_noop_check,
+            log_prefix="[TEST]",
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_propagates_when_token_not_cancelled() -> None:
+    """token 未取消 → RuntimeError 原样上抛，禁止误吞。"""
+
+    token = CancellationToken()
+    pending_waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+        await await_or_cancel(
+            _raise_runtime_error("cannot schedule new futures after shutdown"),
+            operation_name="dns_lookup",
+            cancellation_waiter=pending_waiter,
+            cancellation_token=token,
+            raise_if_cancelled=_noop_check,
+            log_prefix="[TEST]",
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_propagates_when_message_mismatches() -> None:
+    """token 已取消但错误文本不匹配 → 仍原样上抛，避免误吞业务异常。"""
+
+    token = CancellationToken()
+    token.cancel()
+    pending_waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    with pytest.raises(RuntimeError, match="some other error"):
+        await await_or_cancel(
+            _raise_runtime_error("some other error"),
+            operation_name="dns_lookup",
+            cancellation_waiter=pending_waiter,
+            cancellation_token=token,
+            raise_if_cancelled=_noop_check,
+            log_prefix="[TEST]",
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_propagates_when_token_is_none() -> None:
+    """无 token + cancellation_waiter=None 场景下，RuntimeError 原样上抛。"""
+
+    with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+        await await_or_cancel(
+            _raise_runtime_error("cannot schedule new futures after shutdown"),
+            operation_name="dns_lookup",
+            cancellation_waiter=None,
+            cancellation_token=None,
+            raise_if_cancelled=_noop_check,
+            log_prefix="[TEST]",
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_propagates_when_message_only_contains_phrase() -> None:
+    """token 已取消 + 错误文本仅包含目标短语作为子串 → 原样上抛。
+
+    收口子串匹配的退化风险：业务侧若抛出含 "cannot schedule new futures
+    after shutdown" 子串但根因不同的 RuntimeError（例如外层 wrapper 拼接
+    了上下文前缀），不能在取消窗口期被折叠成 CancelledError 掩盖根因。
+    """
+
+    token = CancellationToken()
+    token.cancel()
+    pending_waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    with pytest.raises(RuntimeError, match="wrapper error: cannot schedule new futures after shutdown"):
+        await await_or_cancel(
+            _raise_runtime_error(
+                "wrapper error: cannot schedule new futures after shutdown"
+            ),
+            operation_name="dns_lookup",
+            cancellation_waiter=pending_waiter,
+            cancellation_token=token,
+            raise_if_cancelled=_noop_check,
+            log_prefix="[TEST]",
+        )

--- a/tests/engine/test_write_pipeline_cancellation.py
+++ b/tests/engine/test_write_pipeline_cancellation.py
@@ -1,0 +1,317 @@
+"""WritePipeline 章节内取消（issue #114 Phase A）单元测试。
+
+聚焦 ``_HostScenePromptContractExecutor`` 的两个新增能力：
+
+1. 调 ``run_agent_and_wait_replayable`` / ``replay_agent_and_wait`` **前**
+   一次 ``raise_if_cancelled``——token 命中即退当前 LLM。
+2. 捕获 ``SessionWriteBlockedError`` 子类时双门控映射成
+   ``CancelledError``（token 已取消 + 异常属于白名单基类），保留原异常
+   作 ``__cause__``；token 未取消则原样上抛，避免误吞。
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dayu.contracts.agent_execution import ExecutionContract, ReplayHandle
+from dayu.contracts.cancellation import CancelledError, CancellationToken
+from dayu.contracts.events import AppResult
+from dayu.host.host_execution import HostExecutorProtocol
+from dayu.host.protocols import (
+    SessionClearingError,
+    SessionClearingFailedError,
+    SessionClosedError,
+)
+from dayu.services.internal.write_pipeline.pipeline import (
+    _HostScenePromptContractExecutor,
+)
+
+
+def _make_app_result() -> AppResult:
+    """构造一个最小 AppResult 桩。"""
+
+    return AppResult(content="ok", errors=[], warnings=[])
+
+
+def _make_handle() -> ReplayHandle:
+    """构造一个最小 ReplayHandle 桩。"""
+
+    return ReplayHandle(handle_id="handle-1")
+
+
+def _make_contract() -> ExecutionContract:
+    """构造一个不会被 executor 解析的占位 ExecutionContract。
+
+    Executor 仅把契约透传给 host，不读取任何字段；测试中只需要任意
+    可作为参数传递的对象，不必构造完整契约。
+    """
+
+    return cast(ExecutionContract, object())
+
+
+class _StubHostExecutor:
+    """最小 HostExecutorProtocol 桩——仅实现 executor 用到的三个方法。"""
+
+    def __init__(self) -> None:
+        self.run_replayable = AsyncMock(
+            return_value=(_make_app_result(), _make_handle())
+        )
+        self.replay = AsyncMock(
+            return_value=(_make_app_result(), _make_handle())
+        )
+        self.discard_calls: list[ReplayHandle] = []
+
+    async def run_agent_and_wait_replayable(
+        self, execution_contract: ExecutionContract
+    ) -> tuple[AppResult, ReplayHandle]:
+        return await self.run_replayable(execution_contract)
+
+    async def replay_agent_and_wait(
+        self,
+        handle: ReplayHandle,
+        execution_contract: ExecutionContract,
+    ) -> tuple[AppResult, ReplayHandle]:
+        return await self.replay(handle, execution_contract)
+
+    def discard_replay_state(self, handle: ReplayHandle) -> None:
+        self.discard_calls.append(handle)
+
+
+def _build_executor(
+    *, token: CancellationToken | None
+) -> tuple[_HostScenePromptContractExecutor, _StubHostExecutor]:
+    """组装 executor + stub host_executor。"""
+
+    stub = _StubHostExecutor()
+    executor = _HostScenePromptContractExecutor(
+        host_executor=cast(HostExecutorProtocol, stub),
+        cancellation_token=token,
+    )
+    return executor, stub
+
+
+@pytest.mark.asyncio
+async def test_run_replayable_raises_cancelled_when_token_already_cancelled() -> None:
+    """token 在 LLM 入口已置位时，executor 直接抛 CancelledError，不发起 host 调用。"""
+
+    token = CancellationToken()
+    token.cancel()
+    executor, stub = _build_executor(token=token)
+
+    with pytest.raises(CancelledError):
+        await executor.run_replayable(_make_contract())
+
+    stub.run_replayable.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replay_raises_cancelled_when_token_already_cancelled() -> None:
+    """replay 路径同样在入口自查 token，命中即退。"""
+
+    token = CancellationToken()
+    token.cancel()
+    executor, stub = _build_executor(token=token)
+
+    with pytest.raises(CancelledError):
+        await executor.replay(_make_handle(), _make_contract())
+
+    stub.replay.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_replayable_passes_through_when_token_not_cancelled() -> None:
+    """token 未触发时，run_replayable 正常透传到 host_executor。"""
+
+    token = CancellationToken()
+    executor, stub = _build_executor(token=token)
+
+    result, handle = await executor.run_replayable(_make_contract())
+
+    assert result.content == "ok"
+    assert handle.handle_id == "handle-1"
+    stub.run_replayable.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_replayable_without_token_skips_check() -> None:
+    """``cancellation_token=None`` 时退化为不做入口自查与异常映射。"""
+
+    executor, stub = _build_executor(token=None)
+    result, _ = await executor.run_replayable(_make_contract())
+
+    assert result.content == "ok"
+    stub.run_replayable.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: SessionClosedError("sess-1"),
+        lambda: SessionClearingError("sess-1"),
+    ],
+)
+async def test_cancel_induced_barrier_mapped_to_cancelled_when_token_set(
+    exc_factory,
+) -> None:
+    """token 已取消 + 白名单 barrier 异常 → 映射成 CancelledError。
+
+    白名单仅含 ``SessionClosedError`` / ``SessionClearingError``：这两类
+    在 cancel_run_and_settle 触发后下一次 register_run 路径上抛，语义等价
+    "运行已被取消"。``SessionClearingFailedError`` 由独立用例守住——它是
+    持久锁定故障态、不进白名单。
+
+    用 ``_LateCancelToken`` 模拟"自查通过、host 调用阶段被 settle 触发"的
+    时序：入口检查时 token 未触发，进入 host 调用后再 ``fire`` 并抛 barrier。
+    """
+
+    class _LateCancelToken(CancellationToken):
+        def __init__(self) -> None:
+            super().__init__()
+            self._fired = False
+
+        def is_cancelled(self) -> bool:
+            return self._fired
+
+        def raise_if_cancelled(self) -> None:
+            if self._fired:
+                raise CancelledError("操作已被取消")
+
+        def fire(self) -> None:
+            self._fired = True
+
+    late_token = _LateCancelToken()
+    stub = _StubHostExecutor()
+    executor = _HostScenePromptContractExecutor(
+        host_executor=cast(HostExecutorProtocol, stub),
+        cancellation_token=late_token,
+    )
+    raised = exc_factory()
+
+    async def _side_effect_then_fire(_contract: ExecutionContract):
+        late_token.fire()
+        raise raised
+
+    stub.run_replayable.side_effect = _side_effect_then_fire
+
+    with pytest.raises(CancelledError) as exc_info:
+        await executor.run_replayable(_make_contract())
+
+    assert exc_info.value.__cause__ is raised
+
+
+@pytest.mark.asyncio
+async def test_session_closed_error_propagates_when_token_not_cancelled() -> None:
+    """token 未取消时，barrier 异常原样上抛，禁止被误吞为 CancelledError。"""
+
+    token = CancellationToken()
+    executor, stub = _build_executor(token=token)
+    raised = SessionClosedError("sess-1")
+    stub.run_replayable.side_effect = raised
+
+    with pytest.raises(SessionClosedError) as exc_info:
+        await executor.run_replayable(_make_contract())
+
+    assert exc_info.value is raised
+
+
+@pytest.mark.asyncio
+async def test_session_clearing_failed_error_never_mapped_even_when_cancelled() -> None:
+    """``SessionClearingFailedError`` 不进 cancel-induced 白名单。
+
+    它是 host 持久锁定故障态、需人工恢复——即便外层 token 已取消也必须
+    原样上抛，避免被掩盖成普通用户取消导致 actionable 信号丢失。
+    """
+
+    class _LateCancelToken(CancellationToken):
+        def __init__(self) -> None:
+            super().__init__()
+            self._fired = False
+
+        def is_cancelled(self) -> bool:
+            return self._fired
+
+        def raise_if_cancelled(self) -> None:
+            if self._fired:
+                raise CancelledError("操作已被取消")
+
+        def fire(self) -> None:
+            self._fired = True
+
+    late_token = _LateCancelToken()
+    stub = _StubHostExecutor()
+    executor = _HostScenePromptContractExecutor(
+        host_executor=cast(HostExecutorProtocol, stub),
+        cancellation_token=late_token,
+    )
+    raised = SessionClearingFailedError("sess-1")
+
+    async def _side_effect(_contract: ExecutionContract):
+        late_token.fire()
+        raise raised
+
+    stub.run_replayable.side_effect = _side_effect
+
+    with pytest.raises(SessionClearingFailedError) as exc_info:
+        await executor.run_replayable(_make_contract())
+
+    assert exc_info.value is raised
+
+
+@pytest.mark.asyncio
+async def test_replay_maps_cancel_induced_barrier_under_double_gate() -> None:
+    """replay 路径同样在双门控下把 barrier 映射成 CancelledError。"""
+
+    class _LateCancelToken(CancellationToken):
+        def __init__(self) -> None:
+            super().__init__()
+            self._fired = False
+
+        def is_cancelled(self) -> bool:
+            return self._fired
+
+        def raise_if_cancelled(self) -> None:
+            if self._fired:
+                raise CancelledError("操作已被取消")
+
+        def fire(self) -> None:
+            self._fired = True
+
+    token = _LateCancelToken()
+    executor, stub = _build_executor(token=token)
+    raised = SessionClearingError("sess-1")
+
+    async def _side_effect(_handle: ReplayHandle, _contract: ExecutionContract):
+        token.fire()
+        raise raised
+
+    stub.replay.side_effect = _side_effect
+
+    with pytest.raises(CancelledError) as exc_info:
+        await executor.replay(_make_handle(), _make_contract())
+
+    assert exc_info.value.__cause__ is raised
+
+
+@pytest.mark.asyncio
+async def test_replay_session_closed_error_propagates_without_token() -> None:
+    """``cancellation_token=None`` 时 replay 路径不做映射，barrier 异常原样上抛。"""
+
+    executor, stub = _build_executor(token=None)
+    raised = SessionClosedError("sess-1")
+    stub.replay.side_effect = raised
+
+    with pytest.raises(SessionClosedError):
+        await executor.replay(_make_handle(), _make_contract())
+
+
+def test_discard_delegates_to_host_executor() -> None:
+    """discard 仅做透传，不引入额外语义。"""
+
+    executor, stub = _build_executor(token=None)
+    handle = _make_handle()
+    executor.discard(handle)
+    assert stub.discard_calls == [handle]

--- a/tests/engine/test_write_pipeline_drain_settle.py
+++ b/tests/engine/test_write_pipeline_drain_settle.py
@@ -1,0 +1,200 @@
+"""WritePipeline 取消时多 chapter drain/settle 集成测试（issue #114 Phase C）。
+
+验证 Phase A executor 自查 + 异常映射、Phase B ``await_or_cancel`` 双门控
+两个改动联动后，多 chapter 并发场景在取消触发后能在 stub LLM 立即返回的
+前提下 settle，且不依赖墙钟。语义点：
+
+- Settled 章节（取消前已 finalize）→ 最终产物保留；
+- 未 settle 章节（取消时未 finalize）→ 不进入 fallback、不产出 fallback chapter.md。
+
+本测试聚焦 ``_HostScenePromptContractExecutor`` 在多并发 await 下被同时
+取消的 settle 行为，对 PR 73/84/87/92 的取消语义点对点引用、不复制。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dayu.contracts.agent_execution import ExecutionContract, ReplayHandle
+from dayu.contracts.cancellation import CancelledError, CancellationToken
+from dayu.contracts.events import AppResult
+from dayu.host.host_execution import HostExecutorProtocol
+from dayu.host.protocols import SessionClosedError
+from dayu.services.internal.write_pipeline.pipeline import (
+    _HostScenePromptContractExecutor,
+)
+
+
+def _stub_app_result() -> AppResult:
+    """构造最小 AppResult。"""
+
+    return AppResult(content="stub", errors=[], warnings=[])
+
+
+def _stub_handle(idx: int) -> ReplayHandle:
+    """构造带索引的 ReplayHandle。"""
+
+    return ReplayHandle(handle_id=f"handle-{idx}")
+
+
+def _stub_contract() -> ExecutionContract:
+    """构造占位 ExecutionContract。"""
+
+    return cast(ExecutionContract, object())
+
+
+class _SettleStubHostExecutor:
+    """模拟 host_executor：在 token cancel 后让 in-flight LLM 抛 CancelledError。
+
+    模拟两条真实链路：
+    1. ``run_agent_and_wait_replayable`` 已 in-flight：cancel 后 await 即时
+       抛 ``CancelledError``（对应 Host child run 收 token cancel → bridge
+       传播到 ``await_or_cancel`` 抛 ``CancelledError``）。
+    2. cancel 后下一次进入入口 → executor 自查直接抛（Phase A）。
+    """
+
+    def __init__(self, token: CancellationToken) -> None:
+        self._token = token
+        self._call_count = 0
+        self.discard_replay_state = AsyncMock()
+
+    async def run_agent_and_wait_replayable(
+        self, _execution_contract: ExecutionContract
+    ) -> tuple[AppResult, ReplayHandle]:
+        self._call_count += 1
+        # 等待 token 取消或最多 0.5 秒（CI 上限）；对应真实 await_or_cancel
+        # 在收到取消后即时抛 CancelledError。
+        loop = asyncio.get_running_loop()
+        cancel_event = asyncio.Event()
+
+        def _on_cancel() -> None:
+            loop.call_soon_threadsafe(cancel_event.set)
+
+        unregister = self._token.on_cancel(_on_cancel)
+        if self._token.is_cancelled():
+            cancel_event.set()
+        try:
+            await asyncio.wait_for(cancel_event.wait(), timeout=0.5)
+        except asyncio.TimeoutError:
+            return _stub_app_result(), _stub_handle(self._call_count)
+        finally:
+            unregister()
+        raise CancelledError("operation cancelled: stub_llm")
+
+    async def replay_agent_and_wait(
+        self,
+        _handle: ReplayHandle,
+        _execution_contract: ExecutionContract,
+    ) -> tuple[AppResult, ReplayHandle]:
+        return _stub_app_result(), _stub_handle(self._call_count)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_chapters_all_settle_on_cancel() -> None:
+    """多个 chapter 并发执行 → 取消触发后所有 future 在 stub LLM 即时返回下 settle。
+
+    断言：
+    - 每个并发 in-flight LLM 都抛 ``CancelledError``，不留悬空 future。
+    - 不依赖墙钟（stub 内部 wait timeout 仅作 CI 兜底）。
+    """
+
+    token = CancellationToken()
+    stub = _SettleStubHostExecutor(token)
+    executor = _HostScenePromptContractExecutor(
+        host_executor=cast(HostExecutorProtocol, stub),
+        cancellation_token=token,
+    )
+
+    async def _chapter() -> AppResult:
+        result, _ = await executor.run_replayable(_stub_contract())
+        return result
+
+    # 启动 5 个并发 chapter，模拟 in-flight LLM
+    tasks = [asyncio.create_task(_chapter()) for _ in range(5)]
+    # 让任务进入 host LLM await 阶段
+    await asyncio.sleep(0)
+    # 触发取消（对应 ProcessShutdownCoordinator.settle_active_runs 的 cascade）
+    token.cancel()
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    # 全部抛 CancelledError，无残余、无超时
+    assert all(isinstance(r, CancelledError) for r in results), results
+
+
+@pytest.mark.asyncio
+async def test_subsequent_call_after_cancel_short_circuits_at_executor_entry() -> None:
+    """取消触发后再发起的 LLM 调用直接走 executor 自查抛 CancelledError，不进 host。
+
+    对应 Phase A 设计点：取消落在"checkpoint 已通过、register_run 之间"
+    窗口期外的、新一次 LLM 入口前——executor 自查命中即退。
+    """
+
+    token = CancellationToken()
+    token.cancel()
+    stub = _SettleStubHostExecutor(token)
+    executor = _HostScenePromptContractExecutor(
+        host_executor=cast(HostExecutorProtocol, stub),
+        cancellation_token=token,
+    )
+
+    with pytest.raises(CancelledError):
+        await executor.run_replayable(_stub_contract())
+
+    # 入口自查命中，host LLM 未被调用
+    assert stub._call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_register_run_window_session_closed_mapped_to_cancelled() -> None:
+    """取消落在"checkpoint 通过、register_run 之间"窗口 → barrier 异常映射成 CancelledError。
+
+    对应 Phase A 设计点：cancel-induced ``SessionClosedError`` 在双门控下
+    映射成 ``CancelledError``，避免 pipeline fallback 把取消误判成普通失败。
+    """
+
+    class _LateCancelToken(CancellationToken):
+        def __init__(self) -> None:
+            super().__init__()
+            self._fired = False
+
+        def is_cancelled(self) -> bool:
+            return self._fired
+
+        def raise_if_cancelled(self) -> None:
+            if self._fired:
+                raise CancelledError("操作已被取消")
+
+        def fire(self) -> None:
+            self._fired = True
+
+    late_token = _LateCancelToken()
+
+    class _BarrierStub:
+        def __init__(self) -> None:
+            self.discard_replay_state = AsyncMock()
+
+        async def run_agent_and_wait_replayable(
+            self, _ec: ExecutionContract
+        ) -> tuple[AppResult, ReplayHandle]:
+            late_token.fire()
+            raise SessionClosedError("sess-1")
+
+        async def replay_agent_and_wait(
+            self, _h: ReplayHandle, _ec: ExecutionContract
+        ) -> tuple[AppResult, ReplayHandle]:
+            raise NotImplementedError
+
+    stub = _BarrierStub()
+    executor = _HostScenePromptContractExecutor(
+        host_executor=cast(HostExecutorProtocol, stub),
+        cancellation_token=late_token,
+    )
+
+    with pytest.raises(CancelledError) as exc_info:
+        await executor.run_replayable(_stub_contract())
+
+    assert isinstance(exc_info.value.__cause__, SessionClosedError)


### PR DESCRIPTION
## Summary

Closes #114（最小版章节内取消支持）。三件事：

- **Pipeline 端 fast-path**：`_HostScenePromptContractExecutor` 在每次 LLM 入口先 `raise_if_cancelled`，token 已置位时不发起 host 调用、直接抛 `CancelledError`，收口"两次 LLM 之间"窗口期取消信号。
- **Cancel-induced barrier 映射**：在白名单（`SessionClosedError` / `SessionClearingError`）+ token 已置位双门控下把 barrier 异常映射成 `CancelledError`，避免 pipeline fallback 路径把"取消导致的 session 关闭"误判为普通失败、产 fallback `chapter.md`。`SessionClearingFailedError` 是持久锁定故障态，刻意排除白名单。
- **双 Ctrl-C 收口**：`await_or_cancel` 在双门控（token 已取消 + 错误文本严格全等 `"cannot schedule new futures after shutdown"`）下把第二次 SIGINT 后 asyncio executor shutdown 路径的 `RuntimeError` 折叠成 `CancelledError`，单行 warn。

Host 侧零修改。

## 取消语义

- 取消信号到达**之前**已 `_finalize_chapter_execution` 的章节 → 最终产物（`chapter.md` / `final_audit.json`）正常保留。
- 取消信号到达时**尚未 finalize** 的章节 → 不进 fallback、不产 fallback `chapter.md`；中间稿残留可见，由 ArtifactStore 现有 phase 落盘逻辑覆写。

## 已知未关闭限制（已记入 docstring）

`ProcessShutdownCoordinator.settle_active_runs` 在开始 settle 前对 owner snapshot 一次；每个 child LLM 在 `HostExecutor._start_run` 内部独立 `register_run` 拿全新 token，与 Service 层外层 token **没有桥接**。SIGINT 落在 "preflight 通过 → register_run 之间" 窗口 → 新 child run 漏网，本次 LLM 跑到自然返回。彻底关闭需 Host 侧桥接外层 token 到 child run token，属 Host 改造，不在本 PR 范围。

## Test plan

- [x] `pytest tests/engine/test_write_pipeline_cancellation.py`（11 tests）
- [x] `pytest tests/engine/test_write_pipeline_drain_settle.py`（3 tests）
- [x] `pytest tests/engine/test_await_or_cancel_shutdown.py`（5 tests，含子串非全等用例锁死全等语义）
- [x] `pytest tests/engine/test_write_pipeline.py`（246 tests，回归无 regress）
- [x] `pyright dayu/services/internal/write_pipeline/pipeline.py dayu/engine/cancellation.py`：0 errors
- [ ] 手工 UX：`dayu-cli write --ticker MCO` phase 中途 Ctrl-C → ≤1s 退出；连按两次不打印 cannot schedule futures 堆栈

🤖 Generated with [Claude Code](https://claude.com/claude-code)